### PR TITLE
docs: add Korean README translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 Human provides the goal. The Agent Team orchestrates everything else.
 
-Full compatibility with [Claude Code](https://claude.ai/claude-code), [Codex](https://openai.com/codex), [OpenClaw](https://github.com/nicepkg/OpenClaw), [nanobot](https://github.com/AbanteAI/nanobot), [Cursor](https://cursor.com), and any CLI agent.&nbsp;&nbsp;[**中文文档**](README_CN.md)
+Full compatibility with [Claude Code](https://claude.ai/claude-code), [Codex](https://openai.com/codex), [OpenClaw](https://github.com/nicepkg/OpenClaw), [nanobot](https://github.com/AbanteAI/nanobot), [Cursor](https://cursor.com), and any CLI agent.&nbsp;&nbsp;[**中文文档**](README_CN.md) | [**한국어**](README_KR.md)
 
 <p align="center">
   <img src="assets/teaser.png" alt="ClawTeam - AI agents orchestrating themselves" width="800">

--- a/README_KR.md
+++ b/README_KR.md
@@ -1,0 +1,674 @@
+<h1 align="center"><img src="assets/icon.png" alt="" width="64" style="vertical-align: middle;">&nbsp; ClawTeam: 에이전트 스웜 인텔리전스</h1>
+
+<p align="center">
+  <strong>AI 에이전트의 진화 🚀: 솔로 🤖 → 스웜 🦞🤖🤖🤖<br>
+  ClawTeam은 AI 에이전트가 무리를 이뤄 함께 생각하고 일하며 더 빠르게 결과를 내도록 돕습니다</strong>
+</p>
+
+<p align="center">
+  <a href="#-빠른-시작"><img src="https://img.shields.io/badge/Quick_Start-3_min-blue?style=for-the-badge" alt="Quick Start"></a>
+  <a href="#-활용-사례"><img src="https://img.shields.io/badge/Use_Cases-3_Demos-green?style=for-the-badge" alt="Use Cases"></a>
+  <a href="#-기능"><img src="https://img.shields.io/badge/Features-12+-purple?style=for-the-badge" alt="Features"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge" alt="License"></a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/python-≥3.10-blue?logo=python&logoColor=white" alt="Python">
+  <img src="https://img.shields.io/badge/typer-CLI-green" alt="Typer">
+  <img src="https://img.shields.io/badge/agents-Claude_Code_%7C_Codex_%7C_Any_CLI-blueviolet" alt="Agents">
+  <img src="https://img.shields.io/badge/transport-File_%7C_ZeroMQ_P2P-orange" alt="Transport">
+  <a href="https://github.com/HKUDS/.github/blob/main/profile/README.md"><img src="https://img.shields.io/badge/Feishu-Group-E9DBFC?style=flat&logo=feishu&logoColor=white" alt="Feishu"></a>
+  <a href="https://github.com/HKUDS/.github/blob/main/profile/README.md"><img src="https://img.shields.io/badge/WeChat-Group-C5EAB4?style=flat&logo=wechat&logoColor=white" alt="WeChat"></a>
+</p>
+
+**명령 한 줄이면 끝. 완전 자동화.** 에이전트가 스스로 스웜을 만들고, 작업을 나누고, 결과를 내놓습니다.
+
+사람은 목표만 제시하면 됩니다. 나머지는 에이전트 팀이 조율합니다.
+
+[Claude Code](https://claude.ai/claude-code), [Codex](https://openai.com/codex), [OpenClaw](https://github.com/nicepkg/OpenClaw), [nanobot](https://github.com/AbanteAI/nanobot), [Cursor](https://cursor.com) 그리고 각종 CLI 에이전트와 폭넓게 호환됩니다.&nbsp;&nbsp;[**English**](README.md) | [**中文文档**](README_CN.md)
+
+<p align="center">
+  <img src="assets/teaser.png" alt="ClawTeam - AI agents orchestrating themselves" width="800">
+</p>
+
+---
+
+## ✨ ClawTeam의 핵심 기능
+
+<table align="center" width="100%">
+<tr>
+<td width="25%" align="center" style="vertical-align: top; padding: 15px;">
+
+<h3>🔬 AI 연구 자동화</h3>
+
+<div align="center">
+  <img src="https://img.shields.io/badge/AutoResearch-FF6B6B?style=for-the-badge&logo=pytorch&logoColor=white" alt="AutoResearch" />
+</div>
+
+<img src="assets/scene-autoresearch.png" width="180">
+
+<p align="center"><strong>• 대규모 ML 실험 자동화</strong></p>
+
+<p align="center"><strong>• AI 모델 학습 및 최적화</strong></p>
+
+<p align="center"><strong>• AI 기반 가설 생성 및 검증</strong></p>
+
+<p align="center"><strong>• 스스로 발전하는 모델 아키텍처</strong></p>
+
+</td>
+<td width="25%" align="center" style="vertical-align: top; padding: 15px;">
+
+<h3>🏗️ 에이전트 기반 엔지니어링</h3>
+
+<div align="center">
+  <img src="https://img.shields.io/badge/Full--Stack_Dev-4ECDC4?style=for-the-badge&logo=git&logoColor=white" alt="Engineering" />
+</div>
+
+<img src="assets/scene-engineering.png" width="180">
+
+<p align="center"><strong>• 자율적인 풀스택 개발</strong></p>
+
+<p align="center"><strong>• 스스로 진화하는 소프트웨어</strong></p>
+
+<p align="center"><strong>• 협업형 오픈소스 개발</strong></p>
+
+<p align="center"><strong>• 실시간 시스템 통합</strong></p>
+
+</td>
+<td width="25%" align="center" style="vertical-align: top; padding: 15px;">
+
+<h3>💰 AI 헤지펀드</h3>
+
+<div align="center">
+  <img src="https://img.shields.io/badge/Investment_Analysis-FFD93D?style=for-the-badge&logo=bitcoin&logoColor=black" alt="Hedge Fund" />
+</div>
+
+<img src="assets/scene-hedgefund.png" width="180">
+
+<p align="center"><strong>• 자동화된 시장 조사 및 데이터 마이닝</strong></p>
+
+<p align="center"><strong>• 다중 전략 포트폴리오 최적화</strong></p>
+
+<p align="center"><strong>• 실시간 리스크 평가</strong></p>
+
+<p align="center"><strong>• 알고리즘 트레이딩 실행 및 모니터링</strong></p>
+
+</td>
+<td width="25%" align="center" style="vertical-align: top; padding: 15px;">
+
+<h3>🎪 나만의 스웜</h3>
+
+<div align="center">
+  <img src="https://img.shields.io/badge/TOML_Templates-C77DFF?style=for-the-badge&logo=toml&logoColor=white" alt="Templates" />
+</div>
+
+<img src="assets/scene-template.png" width="180">
+
+<p align="center"><strong>• 맞춤형 과학 연구 팀</strong></p>
+
+<p align="center"><strong>• 개인화된 투자 위원회</strong></p>
+
+<p align="center"><strong>• 비즈니스 운영 팀</strong></p>
+
+<p align="center"><strong>• 콘텐츠 제작 스튜디오</strong></p>
+
+</td>
+</tr>
+</table>
+
+---
+
+https://github.com/user-attachments/assets/f6f0b220-9a5e-4d0a-a25d-f80753d3639b
+
+☝️ 지능형 리더 에이전트가 8대의 H100 GPU에 걸쳐 8개의 전문 서브에이전트를 조율하며, 실시간 성능에 맞춰 자원을 동적으로 재배치하면서 실험을 자율적으로 설계합니다.
+
+🧠 시스템은 팀 전반의 성과를 종합해 전략을 스스로 발전시키며, 사람 개입 없이 연구 자동화를 실현합니다.
+
+---
+
+## 🤔 왜 ClawTeam인가?
+
+지금의 AI 에이전트는 강력합니다. 하지만 대부분 **각자 따로 움직입니다**. 복잡한 작업을 만나면 여러 에이전트를 사람이 직접 조율하고, 컨텍스트를 붙잡고, 흩어진 결과를 다시 꿰맞춰야 하죠.
+
+**에이전트가 팀처럼 생각하고 일할 수 있다면 어떨까요?**
+
+ClawTeam은 **에이전트 스웜 인텔리전스**를 구현합니다. AI 에이전트가 스스로 협업 팀을 만들고, 복잡한 작업을 똑똑하게 쪼개고, 인사이트를 실시간으로 공유하면서 더 나은 해답으로 수렴하게 합니다.
+
+• **🚀 전문 서브에이전트 생성** 각자 전용 환경과 집중 영역을 가집니다
+
+• **📋 지능형 작업 분배 설계** 의존성까지 고려해 할당합니다
+
+• **💬 실시간 협업 지원** 에이전트끼리 자연스럽게 소통합니다
+
+• **📊 팀 성과 모니터링** 진행 상황과 병목을 파악합니다
+
+• **🔄 동적 전략 조정** 자원을 재할당하고 방향을 수정합니다
+
+#### ✨ 결과는?
+비전은 사람이 제시합니다. 실행은 스웜이 집단 지성으로 해냅니다.
+
+<p align="center">
+  <img src="assets/comic-how-it-works.png" alt="How ClawTeam works - comic" width="700">
+</p>
+
+---
+
+## 🎯 실제로 작동하는 스웜 인텔리전스
+
+<table>
+<tr>
+<td width="33%">
+
+### 🦞 에이전트가 에이전트를 만듭니다
+리더 에이전트는 `clawteam spawn`을 호출해 워커를 생성합니다. 각 워커는 자동으로 자신만의 **git worktree**, **tmux 창**, **정체성**을 부여받습니다.
+
+```bash
+# 리더 에이전트가 실행:
+clawteam spawn --team my-team \
+  --agent-name worker1 \
+  --task "인증 모듈 구현"
+```
+
+</td>
+<td width="33%">
+
+### 🤖 에이전트끼리 대화합니다
+워커는 받은 편지함을 확인하고, 작업 상태를 갱신하고, 결과를 보고합니다. 이 모든 흐름은 프롬프트에 **자동 주입되는** CLI 명령으로 이뤄집니다.
+
+```bash
+# 워커 에이전트가 작업 확인:
+clawteam task list my-team --owner me
+# 그다음 결과 보고:
+clawteam inbox send my-team leader \
+  "인증 작업 완료. 테스트도 모두 통과했습니다."
+```
+
+</td>
+<td width="33%">
+
+### 👀 사용자는 지켜보기만 하면 됩니다
+타일형 tmux 화면이나 Web UI에서 스웜을 모니터링할 수 있습니다. 조율은 리더가 맡고, 사용자는 필요할 때만 개입하면 됩니다.
+
+```bash
+# 모든 에이전트를 한 번에 보기
+clawteam board attach my-team
+# 또는 웹 대시보드 실행
+clawteam board serve --port 8080
+```
+
+</td>
+</tr>
+</table>
+
+| | ClawTeam | 다른 멀티에이전트 프레임워크 |
+|---|---------|----------------------------|
+| 🎯 **누가 사용하나** | **AI 에이전트 스스로 사용** | 사람이 오케스트레이션 코드를 작성 |
+| ⚡ **설정 난이도** | `pip install` 후 리더에게 프롬프트 한 번 | Docker, 클라우드 API, YAML 설정 |
+| 🏗️ **인프라** | 파일시스템과 tmux만 있으면 됨 | Redis, 메시지 큐, 데이터베이스 |
+| 🤖 **에이전트 지원 범위** | 어떤 CLI 에이전트든 가능 (Claude Code, Codex, OpenClaw, 커스텀) | 해당 프레임워크 전용만 지원 |
+| 🌳 **격리 방식** | Git worktree (실제 브랜치, 실제 diff) | 컨테이너 또는 가상환경 |
+| 🧠 **지능의 위치** | CLI 명령을 바탕으로 스웜이 스스로 조직됨 | 하드코딩된 오케스트레이션 로직 |
+
+---
+
+## 🎬 활용 사례
+
+### 🔬 1. 자율 ML 연구, 8 에이전트 × 8 H100 GPU
+
+[@karpathy의 autoresearch](https://github.com/karpathy/autoresearch)를 기반으로 합니다.
+
+#### 💫 명령 한 번. 완전 자동화.
+
+#### 사람의 입력: "8개의 GPU로 이 LLM 학습 설정을 최적화해줘"
+
+나머지는 에이전트 팀이 처리합니다:
+- H100 위에 8개의 전문 연구 에이전트를 띄움
+- 2000개가 넘는 자율 실험 설계
+- 획기적인 개선 달성 (`val_bpb: 1.044→0.977`)
+- 사람 개입 없이 완료
+
+#### 🎯 대규모 순수 연구
+
+몇 달 걸리던 수작업 하이퍼파라미터 튜닝을, 몇 시간짜리 지능형 자동화로 바꿉니다.
+
+<p align="center">
+  <img src="assets/autoresearch-progress.png" alt="AutoResearch Progress" width="720">
+  <br>
+  <em>🏆 val_bpb: 1.044 → 0.977 (6.4% 개선) | 2430개 이상 실험 | 약 30 GPU-시간</em>
+</p>
+
+**에이전트 팀이 자율적으로 수행한 일:**
+
+```
+사람 프롬프트: "8개의 GPU를 사용해 train.py를 최적화해. 지침은 program.md를 읽어."
+
+🦞 리더 에이전트의 행동:
+├── 📖 program.md를 읽고 실험 프로토콜 파악
+├── 🏗️ clawteam team spawn-team autoresearch
+├── 🚀 각 GPU에 연구 방향 할당:
+│   ├── GPU 0: clawteam spawn --task "모델 깊이 탐색 (DEPTH 10-16)"
+│   ├── GPU 1: clawteam spawn --task "모델 폭 탐색 (ASPECT_RATIO 80-128)"
+│   ├── GPU 2: clawteam spawn --task "학습률과 옵티마이저 튜닝"
+│   ├── GPU 3: clawteam spawn --task "배치 크기와 accumulation 탐색"
+│   ├── GPU 4-7: clawteam spawn tmux codex --task "..."  (Codex 에이전트)
+│   └── 🌳 각 에이전트: 자체 git worktree, 자체 브랜치, 격리된 실험
+├── 🔄 30분마다 결과 점검:
+│   ├── clawteam board show autoresearch
+│   ├── 각 에이전트의 results.tsv 확인
+│   ├── 🏆 최고 성과 식별 (depth=12, batch=2^17, norm-before-RoPE)
+│   └── 📡 성과 공유: 새 에이전트가 최고 설정에서 시작하도록 지시
+├── 🔧 에이전트가 끝나면 GPU 재배치:
+│   ├── 놀고 있는 에이전트 종료, worktree 정리
+│   ├── 최고 커밋 기준으로 새 worktree 생성
+│   └── 최적화 방향을 합쳐 새 에이전트 재투입
+└── ✅ 2430개 이상 실험 후: val_bpb 1.044 → 0.977
+```
+
+전체 결과: [novix-science/autoresearch](https://github.com/novix-science/autoresearch)
+
+---
+
+### 🏗️ 2. 에이전트형 소프트웨어 엔지니어링
+
+Claude Code에게 이렇게 말합니다. *"인증, 데이터베이스, React 프런트엔드가 있는 풀스택 할 일 앱을 만들어줘."* 그러면 Claude는 이 작업이 여러 모듈로 나뉜다는 걸 이해하고 **스스로 팀을 조직합니다**.
+
+```
+사람 프롬프트: "auth, database, React frontend가 있는 full-stack todo app을 만들어줘."
+
+🦞 리더 에이전트의 행동:
+├── 🏗️ clawteam team spawn-team webapp -d "풀스택 할 일 앱"
+├── 📋 의존성 체인이 있는 작업 생성:
+│   ├── T1: "REST API 스키마 설계"                → architect
+│   ├── T2: "JWT 인증 구현" --blocked-by T1       → backend1
+│   ├── T3: "데이터베이스 레이어 구축" --blocked-by T1 → backend2
+│   ├── T4: "React 프런트엔드 구축"               → frontend
+│   └── T5: "통합 테스트" --blocked-by T2,T3,T4   → tester
+├── 🚀 5개 서브에이전트 생성 (각자 독립 git worktree 사용):
+│   ├── clawteam spawn --agent-name architect --task "API 스키마 설계"
+│   ├── clawteam spawn --agent-name backend1  --task "JWT 인증 구현"
+│   ├── clawteam spawn --agent-name backend2  --task "PostgreSQL 모델 작성"
+│   ├── clawteam spawn --agent-name frontend  --task "React UI 구현"
+│   └── clawteam spawn --agent-name tester    --task "pytest 테스트 작성"
+├── 🔗 의존성 자동 해제:
+│   ├── architect 완료 → backend1, backend2 자동 시작 가능
+│   ├── 백엔드 작업 완료 → tester 자동 시작 가능
+│   └── 각 에이전트 호출: clawteam task update <id> --status completed
+├── 💬 받은 편지함으로 서브에이전트 간 조율:
+│   ├── architect → backend1: "OpenAPI 스펙은 다음과 같아: ..."
+│   ├── backend1 → tester: "인증 엔드포인트는 /api/auth/* 에 준비됨"
+│   └── tester → leader: "총 47개 테스트 모두 통과 ✅"
+└── 🌳 리더가 모든 worktree를 main 브랜치로 병합
+```
+
+---
+
+### 💰 3. AI 헤지펀드, 명령 한 번으로 팀 실행
+
+미리 만들어 둔 TOML 템플릿 하나로 **7개 에이전트** 투자 분석 팀을 바로 띄울 수 있습니다.
+
+```bash
+# 이 한 줄로 전체 팀이 실행됩니다:
+clawteam launch hedge-fund --team fund1 --goal "AAPL, MSFT, NVDA를 2026년 2분기 기준으로 분석"
+```
+
+```
+🦞 자동으로 일어나는 일:
+├── 📊 포트폴리오 매니저(리더)가 생성되고 목표를 전달받음
+├── 🤖 5명의 애널리스트 에이전트 생성, 각자 다른 전략 담당:
+│   ├── 🎩 버핏 애널리스트     → 가치 투자 (moat, ROE, DCF)
+│   ├── 🚀 성장 애널리스트     → 파괴적 성장 (TAM, 네트워크 효과)
+│   ├── 📈 기술적 분석가       → 지표 분석 (EMA, RSI, Bollinger)
+│   ├── 📋 펀더멘털 분석가     → 재무 비율 (P/E, D/E, FCF)
+│   └── 📰 센티먼트 분석가     → 뉴스 + 내부자 거래 신호
+├── 🛡️ 리스크 매니저 생성, 모든 애널리스트 신호 대기:
+│   ├── clawteam inbox receive fund1 (5개 신호 수집)
+│   ├── 종합 분석 후 포지션 한도 계산
+│   └── clawteam inbox send fund1 portfolio-manager "RISK REPORT: ..."
+└── 💼 포트폴리오 매니저가 최종 매수/매도/보유 결정
+```
+
+템플릿은 TOML 파일입니다. 어떤 도메인이든 **나만의 팀 원형을 만들 수 있습니다**.
+
+---
+
+## 📦 설치
+
+```bash
+pip install clawteam
+
+# 또는 소스에서 설치
+git clone https://github.com/HKUDS/ClawTeam.git
+cd ClawTeam
+pip install -e .
+
+# 선택 사항: P2P transport (ZeroMQ)
+pip install -e ".[p2p]"
+```
+
+**Python 3.10+**가 필요합니다. 의존성은 `typer`, `pydantic`, `rich`입니다.
+
+---
+
+## 🚀 빠른 시작
+
+### ⚡ 옵션 1: 에이전트에게 맡기기 (권장)
+
+ClawTeam에는 **Claude Code 스킬**이 포함되어 있어 자동으로 활성화됩니다. 설치한 뒤 이렇게 프롬프트를 주면 됩니다.
+
+```
+"웹 앱을 만들어줘. 작업은 clawteam으로 여러 에이전트에게 나눠서 진행해."
+```
+
+그러면 에이전트가 내부적으로 `clawteam` CLI 명령을 사용해 팀을 만들고, 워커를 띄우고, 작업을 나누고, 전체 흐름을 조율합니다.
+
+### 🔧 옵션 2: 직접 조작하기
+
+```bash
+# 1. 팀 생성 (당신이 리더가 됩니다)
+clawteam team spawn-team my-team -d "인증 모듈 만들기" -n leader
+
+# 2. 워커 에이전트 생성. 각 에이전트는 git worktree, tmux 창, 정체성을 받습니다
+clawteam spawn --team my-team --agent-name alice --task "OAuth2 플로우 구현"
+clawteam spawn --team my-team --agent-name bob   --task "인증 유닛 테스트 작성"
+
+# 3. 워커는 자동으로 조율용 프롬프트를 받아 다음 동작을 배웁니다:
+#    ✅ 작업 확인:    clawteam task list my-team --owner alice
+#    ✅ 상태 갱신:    clawteam task update my-team <id> --status completed
+#    ✅ 리더에게 알림: clawteam inbox send my-team leader "완료!"
+#    ✅ 유휴 상태 보고: clawteam lifecycle idle my-team
+
+# 4. 나란히 일하는 모습을 확인
+clawteam board attach my-team
+```
+
+### 🤖 지원하는 에이전트
+
+ClawTeam은 셸 명령을 실행할 수 있는 **어떤 CLI 에이전트**와도 함께 쓸 수 있습니다.
+
+| Agent | Spawn Command | Status |
+|-------|--------------|--------|
+| [Claude Code](https://claude.ai/claude-code) | `clawteam spawn tmux claude --team ...` | ✅ 완전 지원 |
+| [Codex](https://openai.com/codex) | `clawteam spawn tmux codex --team ...` | ✅ 완전 지원 |
+| [OpenClaw](https://github.com/nicepkg/OpenClaw) | `clawteam spawn tmux openclaw --team ...` | ✅ 완전 지원 |
+| [nanobot](https://github.com/AbanteAI/nanobot) | `clawteam spawn tmux nanobot --team ...` | ✅ 완전 지원 |
+| [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | 🔮 실험적 |
+| Custom scripts | `clawteam spawn subprocess python --team ...` | ✅ 완전 지원 |
+
+---
+
+## ✨ 기능
+
+<table>
+<tr>
+<td width="50%">
+
+### 🦞 에이전트 자가 조직화
+- 리더 에이전트가 워커 에이전트를 생성하고 관리
+- **조율 프롬프트 자동 주입** 수동 설정이 필요 없음
+- 워커가 상태, 결과, 유휴 상태를 스스로 보고
+- Claude Code, Codex, OpenClaw, 커스텀 등 어떤 CLI 에이전트와도 작동
+
+### 🌳 워크스페이스 격리
+- 각 에이전트는 자신만의 **git worktree**(별도 브랜치)를 가짐
+- 병렬 작업 중에도 merge conflict 최소화
+- 체크포인트, 병합, 정리 명령 제공
+- 브랜치 이름 규칙: `clawteam/{team}/{agent}`
+
+### 📋 의존성 있는 작업 추적
+- 공유 칸반 흐름: `pending` → `in_progress` → `completed` / `blocked`
+- `--blocked-by` 의존성 체인, **완료 시 자동 해제**
+- `task wait`로 모든 작업 완료까지 대기 가능
+- 상태, 담당자별 필터링 및 스크립팅용 JSON 출력 지원
+
+</td>
+<td width="50%">
+
+### 💬 에이전트 간 메시징
+- 일대일 **받은 편지함**(send, receive, peek)
+- 모든 팀원에게 **브로드캐스트** 가능
+- 기본은 파일 기반, 필요 시 ZeroMQ P2P transport와 오프라인 fallback 지원
+- 에이전트는 `inbox receive`로 메시지를 확인
+
+### 📊 모니터링 및 대시보드
+- `board show` 터미널 칸반 보드
+- `board live` 자동 새로고침 대시보드
+- `board attach` **타일형 tmux 뷰**로 전체 에이전트 관찰
+- `board serve` **실시간 Web UI** 제공
+
+### 🎪 팀 템플릿
+- **TOML 파일**로 팀 원형(역할, 작업, 프롬프트) 정의
+- 명령 한 줄로 팀 전체 실행: `clawteam launch <template>`
+- 기본 포함: AI Hedge Fund (7개 에이전트). 직접 확장 가능
+- 변수 치환: `{goal}`, `{team_name}`, `{agent_name}`
+
+</td>
+</tr>
+</table>
+
+### 🔧 추가 기능
+
+| Feature | Description |
+|---------|-------------|
+| 📝 **계획 승인** | 에이전트가 실행 전에 계획을 제출하고 리더가 검토 |
+| 🔄 **라이프사이클 프로토콜** | 정상 종료 요청/승인/거절, 유휴 알림 지원 |
+| 📊 **JSON 출력** | 모든 명령에 `--json` 플래그 제공, 에이전트가 구조화된 출력 파싱 가능 |
+| 🌐 **멀티머신 지원** | 공유 파일시스템(NFS/SSHFS) 또는 P2P transport로 분산 팀 운영 |
+| 👥 **멀티유저 지원** | 사용자별 네임스페이스로 여러 사람이 한 팀을 공유 가능 |
+| ⚙️ **설정 관리** | 영속 설정 우선순위: 환경 변수 > 설정 파일 > 기본값 |
+| 🔌 **Claude Code 스킬** | 사용자가 멀티에이전트 협업을 요청하면 자동 트리거 |
+
+---
+
+## 🤖 에이전트는 ClawTeam을 어떻게 쓰나
+
+에이전트가 `clawteam spawn`으로 생성되면 **조율 프롬프트가 자동 주입**됩니다.
+
+```
+## Coordination Protocol (생성된 모든 에이전트에 자동 주입)
+
+- 📋 작업 확인:          clawteam task list <team> --owner <your-name>
+- ▶️ 작업 시작:         clawteam task update <team> <id> --status in_progress
+- ✅ 작업 완료:         clawteam task update <team> <id> --status completed
+- 💬 리더에게 메시지:    clawteam inbox send <team> leader "status update..."
+- 💬 팀원에게 메시지:    clawteam inbox send <team> <name> "info..."
+- 📨 받은 편지함 확인:   clawteam inbox receive <team>
+- 😴 유휴 상태 보고:    clawteam lifecycle idle <team>
+```
+
+즉 **어떤 CLI 에이전트든** ClawTeam 팀에 참여할 수 있습니다. 셸 명령만 실행할 수 있으면 됩니다. 별도 SDK도, API 통합도, 프레임워크 종속도 필요 없습니다.
+
+---
+
+## 📖 명령어 레퍼런스
+
+<details open>
+<summary><h3>🔧 핵심 명령어</h3></summary>
+
+```bash
+# 🏗️ 팀 라이프사이클
+clawteam team spawn-team <team> -d "description" -n <leader>
+clawteam team discover                    # 전체 팀 목록
+clawteam team status <team>               # 멤버 상태 보기
+clawteam team cleanup <team> --force      # 팀 삭제
+
+# 🚀 에이전트 생성
+clawteam spawn --team <team> --agent-name <name> --task "do this"
+clawteam spawn tmux codex --team <team> --agent-name <name> --task "do this"
+
+# 📋 작업 관리
+clawteam task create <team> "subject" -o <owner> --blocked-by <id1>,<id2>
+clawteam task update <team> <id> --status completed   # 완료 시 의존성 자동 해제
+clawteam task list <team> --status blocked --owner worker1
+clawteam task wait <team> --timeout 300
+
+# 💬 메시징
+clawteam inbox send <team> <to> "message"
+clawteam inbox broadcast <team> "message"
+clawteam inbox receive <team>             # 메시지 소비
+clawteam inbox peek <team>                # 소비 없이 읽기
+
+# 📊 모니터링
+clawteam board show <team>                # 터미널 칸반
+clawteam board live <team> --interval 3   # 자동 새로고침
+clawteam board attach <team>              # 타일형 tmux 뷰
+clawteam board serve --port 8080          # Web UI
+```
+
+</details>
+
+<details>
+<summary><h3>🌳 워크스페이스, 📝 계획, 🔄 라이프사이클, ⚙️ 설정</h3></summary>
+
+```bash
+# 🌳 Workspace (git worktree 관리)
+clawteam workspace list <team>
+clawteam workspace checkpoint <team> <agent>    # 자동 커밋
+clawteam workspace merge <team> <agent>         # main에 병합
+clawteam workspace cleanup <team> <agent>       # worktree 제거
+
+# 📝 계획 승인
+clawteam plan submit <team> <agent> "plan" --summary "TL;DR"
+clawteam plan approve <team> <plan-id> <agent> --feedback "LGTM"
+clawteam plan reject <team> <plan-id> <agent> --feedback "Revise X"
+
+# 🔄 라이프사이클
+clawteam lifecycle request-shutdown <team> <agent> --reason "done"
+clawteam lifecycle approve-shutdown <team> <request-id> <agent>
+clawteam lifecycle idle <team>
+
+# 🎪 템플릿
+clawteam launch <template> --team <name> --goal "Build X"
+clawteam template list
+
+# ⚙️ 설정
+clawteam config show
+clawteam config set transport p2p
+clawteam config health
+```
+
+| Setting | Env Var | Default | Description |
+|---------|---------|---------|-------------|
+| `data_dir` | `CLAWTEAM_DATA_DIR` | `~/.clawteam` | 데이터 디렉터리 |
+| `transport` | `CLAWTEAM_TRANSPORT` | `file` | `file` 또는 `p2p` |
+| `workspace` | `CLAWTEAM_WORKSPACE` | `auto` | `auto` / `always` / `never` |
+| `default_backend` | `CLAWTEAM_DEFAULT_BACKEND` | `tmux` | `tmux` 또는 `subprocess` |
+| `skip_permissions` | `CLAWTEAM_SKIP_PERMISSIONS` | `true` | 에이전트 도구 자동 승인 |
+
+</details>
+
+---
+
+## 🏗️ 아키텍처
+
+```
+  사람: "이 LLM을 최적화해줘"
+         │
+         ▼
+  ┌──────────────┐     clawteam spawn     ┌──────────────┐
+  │ 🦞 Leader    │ ──────────────────────► │ 🤖 Worker    │
+  │ (Claude Code)│ ──────┐                │ (Claude Code)│
+  │              │       │                │ git worktree │
+  │ Uses:        │       │                │ tmux window  │
+  │ • spawn      │       │ clawteam spawn └──────────────┘
+  │ • task create│       │
+  │ • inbox send │       ▼                ┌──────────────┐
+  │ • board show │ ──────────────────────► │ 🤖 Worker    │
+  │ • task wait  │       │                │ (Codex)      │
+  └──────────────┘       │                │ git worktree │
+                         │                │ tmux window  │
+                         │ clawteam spawn └──────────────┘
+                         ▼
+                   ┌──────────────┐
+                   │ 🤖 Worker    │    각 워커가 사용하는 명령:
+                   │ (any CLI)    │    • task list (작업 확인)
+                   │ git worktree │    • task update (완료 보고)
+                   │ tmux window  │    • inbox send (리더에게 메시지)
+                   └──────────────┘    • inbox receive (지시 받기)
+                         │
+                         ▼
+              ┌─────────────────────┐
+              │    ~/.clawteam/     │
+              │ ├── teams/   (누가) │
+              │ ├── tasks/   (무엇) │
+              │ ├── inboxes/ (대화) │
+              │ └── workspaces/     │
+              │     (격리된 코드)   │
+              └─────────────────────┘
+```
+
+모든 상태는 `~/.clawteam/` 아래 JSON 파일로 저장됩니다. 데이터베이스도, 서버도, 클라우드도 필요 없습니다. `tmp + rename` 방식의 원자적 쓰기로 충돌과 크래시에도 안전합니다.
+
+| Spawn Default | Value | Override |
+|---------------|-------|----------|
+| Backend | `tmux` | `clawteam spawn subprocess ...` |
+| Command | `claude` | `clawteam spawn tmux codex ...` |
+| Workspace | `auto` (git worktree) | `--no-workspace` |
+| Permissions | skip | `--no-skip-permissions` |
+
+| Transport | 동작 방식 | 사용 시점 |
+|-----------|-------------|-------------|
+| **file** (기본값) | inbox 디렉터리의 JSON 파일 | 단일 머신, 공유 파일시스템 |
+| **p2p** | ZeroMQ PUSH/PULL + 파일 fallback | 낮은 지연 시간, 자동 fallback |
+
+---
+
+## 🗺️ 로드맵
+
+| Phase | Version | 내용 | Status |
+|-------|---------|------|--------|
+| **현재** | v0.3 | File + P2P (ZeroMQ) transport, Web UI, multi-user, team templates | ✅ 출시됨 |
+| **Phase 1** | v0.4 | Redis Transport, 머신 간 메시징 | 🔜 예정 |
+| **Phase 2** | v0.5 | Shared State Layer, 머신 간 팀 설정 및 작업 공유 | 🔜 예정 |
+| **Phase 3** | v0.6 | Agent Marketplace, 커뮤니티 템플릿 탐색 및 재사용 | 💡 검토 중 |
+| **Phase 4** | v0.7 | Adaptive Scheduling, 에이전트 성능에 따른 동적 작업 재배치 | 💡 검토 중 |
+| **Phase 5** | v1.0 | 프로덕션급 기능, auth, permissions, audit logs | 💡 검토 중 |
+
+---
+
+## 🤝 기여하기
+
+기여를 환영합니다. ClawTeam은 확장 가능성을 염두에 두고 설계되었습니다.
+
+- 🤖 **새 에이전트 연동** 더 많은 AI 코딩 에이전트 지원 추가
+- 🎪 **팀 템플릿** 새로운 도메인용 TOML 템플릿 제작 (DevOps, 데이터 과학 등)
+- 🔌 **Transport 백엔드** Redis, NATS, 기타 메시지 전송 계층 추가
+- 📊 **대시보드 개선** 향상된 Web UI, Grafana 연동
+- 📖 **문서화** 튜토리얼, 모범 사례, 에이전트 프롬프트 엔지니어링 가이드
+
+---
+
+## 📖 감사의 말
+
+- [@karpathy/autoresearch](https://github.com/karpathy/autoresearch): 8에이전트 스웜 데모에 사용한 자율 ML 연구 프레임워크
+- [Claude Code](https://claude.ai/claude-code)와 [Codex](https://openai.com/codex): ClawTeam의 팀원으로 동작하는 AI 코딩 에이전트
+- [ai-hedge-fund](https://github.com/virattt/ai-hedge-fund): 멀티 애널리스트 헤지펀드 템플릿에 영감을 준 프로젝트
+- [CLI-Anything](https://github.com/HKUDS/CLI-Anything): 모든 소프트웨어를 agent-native로 만드는 자매 프로젝트
+
+---
+
+## ⭐ Star History
+
+ClawTeam이 도움이 되었다면 스타를 눌러 주세요. ⭐
+
+## 📄 라이선스
+
+MIT License. 자유롭게 사용하고, 수정하고, 배포할 수 있습니다.
+
+---
+
+<div align="center">
+
+**ClawTeam** — *에이전트 스웜 인텔리전스* 🦞
+
+<sub>8 agents × 8 H100s × 2430 experiments × one CLI × one swarm</sub>
+
+<br>
+
+<img src="assets/icon.png" alt="ClawTeam" width="80">
+
+</div>
+
+<p align="center">
+  <em>방문해 주셔서 감사합니다 ✨ ClawTeam!</em><br><br>
+  <img src="https://visitor-badge.laobi.icu/badge?page_id=HKUDS.ClawTeam&style=for-the-badge&color=00d4ff" alt="Views">
+</p>


### PR DESCRIPTION
## Summary

- Add `README_KR.md` as a Korean translation of the main README
- Add a Korean documentation link to `README.md` alongside the existing Chinese documentation link
- Preserve the original structure, examples, tables, and commands while translating the descriptive content into natural Korean

## Changes

- Add `README_KR.md`
- Update `README.md` to include a `Korean` link in the language section

## Notes

- Documentation-only change
- No code, behavior, or dependency changes
- No tests were run because this PR only updates documentation