### PR TITLE
Fix multi-user inbox routing

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -599,9 +599,10 @@ def inbox_receive(
     """Receive and consume messages from inbox."""
     from clawteam.identity import AgentIdentity
     from clawteam.team.mailbox import MailboxManager
+    from clawteam.team.manager import TeamManager
 
     identity = AgentIdentity.from_env()
-    agent_name = agent or identity.agent_name
+    agent_name = TeamManager.resolve_inbox(team, agent or identity.agent_name, identity.user)
     mailbox = MailboxManager(team)
     messages = mailbox.receive(agent_name, limit=limit)
 
@@ -629,9 +630,10 @@ def inbox_peek(
     """Peek at messages without consuming them."""
     from clawteam.identity import AgentIdentity
     from clawteam.team.mailbox import MailboxManager
+    from clawteam.team.manager import TeamManager
 
     identity = AgentIdentity.from_env()
-    agent_name = agent or identity.agent_name
+    agent_name = TeamManager.resolve_inbox(team, agent or identity.agent_name, identity.user)
     mailbox = MailboxManager(team)
     messages = mailbox.peek(agent_name)
 
@@ -697,10 +699,11 @@ def inbox_watch(
     """
     from clawteam.identity import AgentIdentity
     from clawteam.team.mailbox import MailboxManager
+    from clawteam.team.manager import TeamManager
     from clawteam.team.watcher import InboxWatcher
 
     identity = AgentIdentity.from_env()
-    agent_name = agent or identity.agent_name
+    agent_name = TeamManager.resolve_inbox(team, agent or identity.agent_name, identity.user)
     mailbox = MailboxManager(team)
 
     if not _json_output:
@@ -1043,10 +1046,15 @@ def task_wait(
     # Resolve agent name for inbox monitoring
     agent_name = agent
     if not agent_name:
-        agent_name = TeamManager.get_leader_name(team)
+        agent_name = TeamManager.get_leader_inbox(team)
     if not agent_name:
         from clawteam.identity import AgentIdentity
-        agent_name = AgentIdentity.from_env().agent_name
+        identity = AgentIdentity.from_env()
+        agent_name = TeamManager.resolve_inbox(team, identity.agent_name, identity.user)
+    elif agent:
+        from clawteam.identity import AgentIdentity
+        identity = AgentIdentity.from_env()
+        agent_name = TeamManager.resolve_inbox(team, agent_name, identity.user)
 
     mailbox = MailboxManager(team)
     store = TaskStore(team)

--- a/clawteam/team/mailbox.py
+++ b/clawteam/team/mailbox.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import time
 import uuid
-from pathlib import Path
 
 from clawteam.team.models import MessageType, TeamMessage, get_data_dir
 from clawteam.transport.base import Transport
@@ -87,6 +86,9 @@ class MailboxManager:
         last_task: str | None = None,
         status: str | None = None,
     ) -> TeamMessage:
+        from clawteam.team.manager import TeamManager
+
+        delivery_target = TeamManager.resolve_inbox(self.team_name, to)
         msg = TeamMessage(
             type=msg_type,
             from_agent=from_agent,
@@ -108,7 +110,7 @@ class MailboxManager:
             status=status,
         )
         data = msg.model_dump_json(indent=2, by_alias=True, exclude_none=True).encode("utf-8")
-        self._transport.deliver(to, data)
+        self._transport.deliver(delivery_target, data)
         self._log_event(msg)
         return msg
 

--- a/clawteam/team/manager.py
+++ b/clawteam/team/manager.py
@@ -45,6 +45,25 @@ class TeamManager:
     """Manages team lifecycle operations."""
 
     @staticmethod
+    def get_member(
+        team_name: str,
+        member_name: str,
+        user: str = "",
+    ) -> TeamMember | None:
+        """Return a member by logical name, optionally scoped by user."""
+        config = _load_config(team_name)
+        if not config:
+            return None
+        if user:
+            for member in config.members:
+                if member.name == member_name and member.user == user:
+                    return member
+        matches = [member for member in config.members if member.name == member_name]
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
+    @staticmethod
     def create_team(
         name: str,
         leader_name: str,
@@ -186,6 +205,14 @@ class TeamManager:
     def inbox_name_for(member: TeamMember) -> str:
         """Return the inbox directory name for a member."""
         return f"{member.user}_{member.name}" if member.user else member.name
+
+    @staticmethod
+    def resolve_inbox(team_name: str, recipient: str, user: str = "") -> str:
+        """Resolve a logical agent name to its on-disk inbox directory."""
+        member = TeamManager.get_member(team_name, recipient, user=user)
+        if member:
+            return TeamManager.inbox_name_for(member)
+        return recipient
 
     @staticmethod
     def get_leader_inbox(team_name: str) -> str | None:

--- a/tests/test_inbox_routing.py
+++ b/tests/test_inbox_routing.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from clawteam.board.collector import BoardCollector
+from clawteam.cli.commands import app
+from clawteam.team.lifecycle import LifecycleManager
+from clawteam.team.mailbox import MailboxManager
+from clawteam.team.manager import TeamManager
+
+
+def test_lifecycle_idle_routes_to_prefixed_leader_inbox(
+    monkeypatch,
+    tmp_path: Path,
+):
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path))
+    TeamManager.create_team(
+        name="demo",
+        leader_name="leader",
+        leader_id="leader001",
+        user="alice",
+    )
+
+    mailbox = MailboxManager("demo")
+    LifecycleManager("demo", mailbox).send_idle(
+        agent_name="worker",
+        agent_id="worker001",
+        leader_name="leader",
+        last_task="task-1",
+        task_status="blocked",
+    )
+
+    leader_inbox = tmp_path / "teams" / "demo" / "inboxes" / "alice_leader"
+    assert len(list(leader_inbox.glob("msg-*.json"))) == 1
+    assert not (tmp_path / "teams" / "demo" / "inboxes" / "leader").exists()
+
+    board = BoardCollector().collect_team("demo")
+    assert board["members"][0]["inboxCount"] == 1
+
+
+def test_inbox_peek_defaults_to_resolved_member_inbox(
+    monkeypatch,
+    tmp_path: Path,
+):
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path))
+    TeamManager.create_team(
+        name="demo",
+        leader_name="leader",
+        leader_id="leader001",
+        user="alice",
+    )
+    MailboxManager("demo").send(
+        from_agent="worker",
+        to="leader",
+        content="hello",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["inbox", "peek", "demo"],
+        env={
+            "CLAWTEAM_DATA_DIR": str(tmp_path),
+            "CLAWTEAM_USER": "alice",
+            "CLAWTEAM_AGENT_ID": "leader001",
+            "CLAWTEAM_AGENT_NAME": "leader",
+        },
+    )
+
+    assert result.exit_code == 0
+    assert "Pending messages: 1" in result.output
+    assert "from=worker" in result.output


### PR DESCRIPTION
## Summary
- fix multi-user inbox delivery by resolving logical agent names to the real on-disk inbox directory before transport delivery
- make CLI inbox receive/peek/watch and `task wait` default to the resolved member inbox instead of the bare agent name
- add regression tests covering lifecycle idle delivery and default inbox peek behavior under `CLAWTEAM_USER`

## Root Cause
Team members are stored with user-scoped inbox names like `alice_leader`, but several workflows still sent to or listened on the bare logical name `leader`. That split the control plane in two: the board counted one inbox, while lifecycle and inbox-related commands used another.

## What Changed
- introduced inbox resolution in `TeamManager`
- applied inbox resolution to transport delivery plus CLI inbox defaults
- switched `task wait` to monitor the leader's real inbox by default
- added regression coverage for inbox routing under multi-user mode

## Validation
- `python -m pytest -q`
- `python -m compileall clawteam tests`
- `ruff check clawteam/team/mailbox.py clawteam/team/manager.py tests/test_inbox_routing.py`
- manual repro before/after fix with:
  - `CLAWTEAM_USER=alice clawteam team spawn-team demo`
  - `CLAWTEAM_USER=bob clawteam lifecycle idle demo --last-task task-1 --task-status blocked`
  - before fix: board showed leader `inboxCount=0` while a stray `teams/demo/inboxes/leader` directory was created
  - after fix: board shows `inboxCount=1`, default `clawteam inbox peek demo` reads the leader inbox correctly, and only `teams/demo/inboxes/alice_leader` exists

## Notes
- full-repo `ruff check clawteam tests` still reports pre-existing baseline issues outside this change set
