### PR TITLE
Fix team cleanup deleting plans from other teams

### DIFF
--- a/clawteam/team/manager.py
+++ b/clawteam/team/manager.py
@@ -7,6 +7,7 @@ import shutil
 from pathlib import Path
 
 from clawteam.team.models import TeamConfig, TeamMember, get_data_dir
+from clawteam.team.plan import referenced_legacy_plan_paths, team_plans_path
 
 
 def _teams_root() -> Path:
@@ -178,22 +179,24 @@ class TeamManager:
         except Exception:
             pass
 
+        legacy_plan_paths = referenced_legacy_plan_paths(team_name)
         team_dir = _team_dir(team_name)
         tasks_dir = get_data_dir() / "tasks" / team_name
         costs_dir = get_data_dir() / "costs" / team_name
         sessions_dir = get_data_dir() / "sessions" / team_name
-        plans_dir = get_data_dir() / "plans"
+        plans_dir = team_plans_path(team_name)
         cleaned = False
-        for d in (team_dir, tasks_dir, costs_dir, sessions_dir):
+        for d in (team_dir, tasks_dir, costs_dir, sessions_dir, plans_dir):
             if d.exists():
                 shutil.rmtree(d)
                 cleaned = True
-        if plans_dir.exists():
-            for f in plans_dir.glob("*.md"):
-                try:
-                    f.unlink()
-                except OSError:
-                    pass
+        for path in legacy_plan_paths:
+            try:
+                if path.exists():
+                    path.unlink()
+                    cleaned = True
+            except OSError:
+                pass
         return cleaned
 
     @staticmethod

--- a/clawteam/team/plan.py
+++ b/clawteam/team/plan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import uuid
 from pathlib import Path
 
@@ -10,9 +11,84 @@ from clawteam.team.models import MessageType, get_data_dir
 
 
 def _plans_root() -> Path:
-    d = get_data_dir() / "plans"
+    d = _plans_root_path()
     d.mkdir(parents=True, exist_ok=True)
     return d
+
+
+def _plans_root_path() -> Path:
+    return get_data_dir() / "plans"
+
+
+def _team_plans_root(team_name: str) -> Path:
+    d = team_plans_path(team_name)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _plan_filename(agent_name: str, plan_id: str) -> str:
+    return f"{agent_name}-{plan_id}.md"
+
+
+def _team_plan_path(team_name: str, agent_name: str, plan_id: str) -> Path:
+    return _team_plans_root(team_name) / _plan_filename(agent_name, plan_id)
+
+
+def _legacy_plan_path(agent_name: str, plan_id: str) -> Path:
+    return _plans_root_path() / _plan_filename(agent_name, plan_id)
+
+
+def _iter_plan_paths(team_name: str, agent_name: str, plan_id: str) -> list[Path]:
+    paths = []
+    if team_name:
+        paths.append(_team_plan_path(team_name, agent_name, plan_id))
+    else:
+        filename = _plan_filename(agent_name, plan_id)
+        plans_root = _plans_root_path()
+        if plans_root.exists():
+            for team_dir in sorted(plans_root.iterdir()):
+                if team_dir.is_dir():
+                    paths.append(team_dir / filename)
+    paths.append(_legacy_plan_path(agent_name, plan_id))
+    return paths
+
+
+def team_plans_path(team_name: str) -> Path:
+    """Return the team-scoped plan directory path without creating it."""
+    return _plans_root_path() / team_name
+
+
+def referenced_legacy_plan_paths(team_name: str) -> set[Path]:
+    """Return legacy flat plan files referenced by this team's event log."""
+    team_events_dir = get_data_dir() / "teams" / team_name / "events"
+    plans_root = _plans_root_path()
+    paths: set[Path] = set()
+    if not team_events_dir.exists():
+        return paths
+
+    for event_file in team_events_dir.glob("evt-*.json"):
+        try:
+            data = json.loads(event_file.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+
+        if data.get("type") != MessageType.plan_approval_request.value:
+            continue
+
+        from_agent = data.get("from")
+        request_id = data.get("requestId")
+        if from_agent and request_id:
+            paths.add(_legacy_plan_path(from_agent, request_id))
+
+        plan_file = data.get("planFile")
+        if not plan_file:
+            continue
+
+        plan_path = Path(plan_file).expanduser()
+        if plan_path.parent == plans_root:
+            paths.add(plan_path)
+
+    return paths
 
 
 class PlanManager:
@@ -30,7 +106,7 @@ class PlanManager:
         summary: str = "",
     ) -> str:
         plan_id = uuid.uuid4().hex[:12]
-        plan_path = _plans_root() / f"{agent_name}-{plan_id}.md"
+        plan_path = _team_plan_path(self.team_name, agent_name, plan_id)
         plan_path.write_text(plan_content, encoding="utf-8")
 
         self.mailbox.send(
@@ -75,8 +151,8 @@ class PlanManager:
         )
 
     @staticmethod
-    def get_plan(plan_id: str, agent_name: str) -> str | None:
-        plan_path = _plans_root() / f"{agent_name}-{plan_id}.md"
-        if plan_path.exists():
-            return plan_path.read_text(encoding="utf-8")
+    def get_plan(plan_id: str, agent_name: str, team_name: str = "") -> str | None:
+        for plan_path in _iter_plan_paths(team_name, agent_name, plan_id):
+            if plan_path.exists():
+                return plan_path.read_text(encoding="utf-8")
         return None

--- a/tests/test_plan_storage.py
+++ b/tests/test_plan_storage.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from clawteam.team.mailbox import MailboxManager
+from clawteam.team.manager import TeamManager
+from clawteam.team.models import MessageType
+from clawteam.team.plan import PlanManager
+
+
+def _create_team(tmp_path: Path, monkeypatch, team_name: str) -> None:
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path))
+    TeamManager.create_team(
+        name=team_name,
+        leader_name="leader",
+        leader_id=f"{team_name}-leader-001",
+    )
+
+
+def test_submit_plan_stores_under_team_directory(
+    monkeypatch,
+    tmp_path: Path,
+):
+    _create_team(tmp_path, monkeypatch, "alpha")
+
+    mailbox = MailboxManager("alpha")
+    plan_id = PlanManager("alpha", mailbox).submit_plan(
+        agent_name="worker",
+        leader_name="leader",
+        plan_content="team-scoped plan",
+    )
+
+    team_plan_path = tmp_path / "plans" / "alpha" / f"worker-{plan_id}.md"
+    legacy_plan_path = tmp_path / "plans" / f"worker-{plan_id}.md"
+
+    assert team_plan_path.read_text(encoding="utf-8") == "team-scoped plan"
+    assert not legacy_plan_path.exists()
+    assert PlanManager.get_plan(plan_id, "worker", team_name="alpha") == "team-scoped plan"
+
+
+def test_get_plan_falls_back_to_legacy_flat_layout(
+    monkeypatch,
+    tmp_path: Path,
+):
+    _create_team(tmp_path, monkeypatch, "alpha")
+
+    legacy_plan_path = tmp_path / "plans" / "worker-legacy123.md"
+    legacy_plan_path.parent.mkdir(parents=True, exist_ok=True)
+    legacy_plan_path.write_text("legacy plan", encoding="utf-8")
+
+    assert PlanManager.get_plan("legacy123", "worker", team_name="alpha") == "legacy plan"
+
+
+def test_get_plan_supports_team_scoped_storage_without_team_name(
+    monkeypatch,
+    tmp_path: Path,
+):
+    _create_team(tmp_path, monkeypatch, "alpha")
+
+    mailbox = MailboxManager("alpha")
+    plan_id = PlanManager("alpha", mailbox).submit_plan(
+        agent_name="worker",
+        leader_name="leader",
+        plan_content="team-scoped plan",
+    )
+
+    assert PlanManager.get_plan(plan_id, "worker") == "team-scoped plan"
+
+
+def test_cleanup_only_removes_team_plans_and_referenced_legacy_files(
+    monkeypatch,
+    tmp_path: Path,
+):
+    _create_team(tmp_path, monkeypatch, "alpha")
+    _create_team(tmp_path, monkeypatch, "beta")
+
+    alpha_mailbox = MailboxManager("alpha")
+    beta_mailbox = MailboxManager("beta")
+
+    alpha_plan_id = PlanManager("alpha", alpha_mailbox).submit_plan(
+        agent_name="worker",
+        leader_name="leader",
+        plan_content="alpha current plan",
+    )
+    beta_plan_id = PlanManager("beta", beta_mailbox).submit_plan(
+        agent_name="worker",
+        leader_name="leader",
+        plan_content="beta current plan",
+    )
+
+    legacy_alpha = tmp_path / "plans" / "worker-legacy-alpha.md"
+    legacy_beta = tmp_path / "plans" / "worker-legacy-beta.md"
+    legacy_alpha.write_text("alpha legacy plan", encoding="utf-8")
+    legacy_beta.write_text("beta legacy plan", encoding="utf-8")
+
+    alpha_mailbox.send(
+        from_agent="worker",
+        to="leader",
+        msg_type=MessageType.plan_approval_request,
+        request_id="legacy-alpha",
+        plan_file=str(legacy_alpha),
+        summary="alpha legacy",
+        plan="alpha legacy plan",
+    )
+    beta_mailbox.send(
+        from_agent="worker",
+        to="leader",
+        msg_type=MessageType.plan_approval_request,
+        request_id="legacy-beta",
+        plan_file=str(legacy_beta),
+        summary="beta legacy",
+        plan="beta legacy plan",
+    )
+
+    assert TeamManager.cleanup("alpha") is True
+
+    assert not (tmp_path / "teams" / "alpha").exists()
+    assert not (tmp_path / "plans" / "alpha" / f"worker-{alpha_plan_id}.md").exists()
+    assert not legacy_alpha.exists()
+
+    assert (tmp_path / "teams" / "beta").exists()
+    assert (tmp_path / "plans" / "beta" / f"worker-{beta_plan_id}.md").exists()
+    assert legacy_beta.exists()
+
+
+def test_cleanup_nonexistent_team_preserves_other_team_plans(
+    monkeypatch,
+    tmp_path: Path,
+):
+    _create_team(tmp_path, monkeypatch, "alpha")
+    _create_team(tmp_path, monkeypatch, "beta")
+
+    beta_mailbox = MailboxManager("beta")
+    beta_plan_id = PlanManager("beta", beta_mailbox).submit_plan(
+        agent_name="worker",
+        leader_name="leader",
+        plan_content="beta current plan",
+    )
+
+    legacy_beta = tmp_path / "plans" / "worker-legacy-beta.md"
+    legacy_beta.write_text("beta legacy plan", encoding="utf-8")
+    beta_mailbox.send(
+        from_agent="worker",
+        to="leader",
+        msg_type=MessageType.plan_approval_request,
+        request_id="legacy-beta",
+        plan_file=str(legacy_beta),
+        summary="beta legacy",
+        plan="beta legacy plan",
+    )
+
+    assert TeamManager.cleanup("ghost-team") is False
+
+    assert (tmp_path / "teams" / "beta").exists()
+    assert (tmp_path / "plans" / "beta" / f"worker-{beta_plan_id}.md").exists()
+    assert legacy_beta.exists()


### PR DESCRIPTION
## Summary
- store plan markdown under `plans/<team>/...` instead of a global flat `plans/` namespace
- scope `team cleanup` to the current team's plan directory and only remove legacy flat plan files that the team actually referenced
- add regression coverage for team-scoped plan storage, legacy fallback, cross-team cleanup isolation, and nonexistent-team cleanup

## Root cause
`PlanManager` wrote plans into a global `plans/<agent>-<id>.md` layout, while `TeamManager.cleanup(team)` deleted every `plans/*.md` file. That meant cleaning one team could delete another team's plans, and even cleaning a nonexistent team could wipe global plan files.

## Testing
- `ClawTeam/.venv/bin/python -m pytest -q tests/test_plan_storage.py tests/test_inbox_routing.py`
- `ClawTeam/.venv/bin/python -m ruff check clawteam/team/plan.py clawteam/team/manager.py tests/test_plan_storage.py tests/test_inbox_routing.py`
- `/ClawTeam/.venv/bin/python -m compileall clawteam`