### PR TITLE
Serialize TaskStore writes

### DIFF
--- a/clawteam/team/tasks.py
+++ b/clawteam/team/tasks.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
+import os
+import tempfile
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -24,6 +28,10 @@ def _task_path(team_name: str, task_id: str) -> Path:
     return _tasks_root(team_name) / f"task-{task_id}.json"
 
 
+def _tasks_lock_path(team_name: str) -> Path:
+    return _tasks_root(team_name) / ".tasks.lock"
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -37,6 +45,17 @@ class TaskStore:
 
     def __init__(self, team_name: str):
         self.team_name = team_name
+
+    @contextmanager
+    def _write_lock(self):
+        lock_path = _tasks_lock_path(self.team_name)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+", encoding="utf-8") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
     def create(
         self,
@@ -57,10 +76,14 @@ class TaskStore:
         )
         if task.blocked_by:
             task.status = TaskStatus.blocked
-        self._save(task)
+        with self._write_lock():
+            self._save_unlocked(task)
         return task
 
     def get(self, task_id: str) -> TaskItem | None:
+        return self._get_unlocked(task_id)
+
+    def _get_unlocked(self, task_id: str) -> TaskItem | None:
         path = _task_path(self.team_name, task_id)
         if not path.exists():
             return None
@@ -83,56 +106,57 @@ class TaskStore:
         caller: str = "",
         force: bool = False,
     ) -> TaskItem | None:
-        task = self.get(task_id)
-        if not task:
-            return None
+        with self._write_lock():
+            task = self._get_unlocked(task_id)
+            if not task:
+                return None
 
-        # Lock logic when transitioning to in_progress
-        if status == TaskStatus.in_progress:
-            self._acquire_lock(task, caller, force)
-            # Record when work actually started
-            if not task.started_at:
-                task.started_at = _now_iso()
+            # Lock logic when transitioning to in_progress
+            if status == TaskStatus.in_progress:
+                self._acquire_lock(task, caller, force)
+                # Record when work actually started
+                if not task.started_at:
+                    task.started_at = _now_iso()
 
-        # Clear lock when transitioning to completed or pending
-        if status in (TaskStatus.completed, TaskStatus.pending):
-            task.locked_by = ""
-            task.locked_at = ""
+            # Clear lock when transitioning to completed or pending
+            if status in (TaskStatus.completed, TaskStatus.pending):
+                task.locked_by = ""
+                task.locked_at = ""
 
-        # Compute duration when completing a task that has a start time
-        if status == TaskStatus.completed and task.started_at:
-            try:
-                start = datetime.fromisoformat(task.started_at)
-                duration_secs = (datetime.now(timezone.utc) - start).total_seconds()
-                task.metadata["duration_seconds"] = round(duration_secs, 2)
-            except (ValueError, TypeError):
-                pass  # malformed timestamp, skip
+            # Compute duration when completing a task that has a start time
+            if status == TaskStatus.completed and task.started_at:
+                try:
+                    start = datetime.fromisoformat(task.started_at)
+                    duration_secs = (datetime.now(timezone.utc) - start).total_seconds()
+                    task.metadata["duration_seconds"] = round(duration_secs, 2)
+                except (ValueError, TypeError):
+                    pass  # malformed timestamp, skip
 
-        if status is not None:
-            task.status = status
-        if owner is not None:
-            task.owner = owner
-        if subject is not None:
-            task.subject = subject
-        if description is not None:
-            task.description = description
-        if add_blocks:
-            for b in add_blocks:
-                if b not in task.blocks:
-                    task.blocks.append(b)
-        if add_blocked_by:
-            for b in add_blocked_by:
-                if b not in task.blocked_by:
-                    task.blocked_by.append(b)
-        if metadata:
-            task.metadata.update(metadata)
-        task.updated_at = _now_iso()
+            if status is not None:
+                task.status = status
+            if owner is not None:
+                task.owner = owner
+            if subject is not None:
+                task.subject = subject
+            if description is not None:
+                task.description = description
+            if add_blocks:
+                for b in add_blocks:
+                    if b not in task.blocks:
+                        task.blocks.append(b)
+            if add_blocked_by:
+                for b in add_blocked_by:
+                    if b not in task.blocked_by:
+                        task.blocked_by.append(b)
+            if metadata:
+                task.metadata.update(metadata)
+            task.updated_at = _now_iso()
 
-        if task.status == TaskStatus.completed:
-            self._resolve_dependents(task_id)
+            if task.status == TaskStatus.completed:
+                self._resolve_dependents_unlocked(task_id)
 
-        self._save(task)
-        return task
+            self._save_unlocked(task)
+            return task
 
     def _acquire_lock(self, task: TaskItem, caller: str, force: bool) -> None:
         """Acquire lock on a task for the caller agent."""
@@ -159,19 +183,25 @@ class TaskStore:
         from clawteam.spawn.registry import is_agent_alive
 
         released = []
-        for task in self.list_tasks():
-            if not task.locked_by:
-                continue
-            alive = is_agent_alive(self.team_name, task.locked_by)
-            if alive is False:
-                task.locked_by = ""
-                task.locked_at = ""
-                task.updated_at = _now_iso()
-                self._save(task)
-                released.append(task.id)
+        with self._write_lock():
+            for task in self._list_tasks_unlocked():
+                if not task.locked_by:
+                    continue
+                alive = is_agent_alive(self.team_name, task.locked_by)
+                if alive is False:
+                    task.locked_by = ""
+                    task.locked_at = ""
+                    task.updated_at = _now_iso()
+                    self._save_unlocked(task)
+                    released.append(task.id)
         return released
 
     def list_tasks(
+        self, status: TaskStatus | None = None, owner: str | None = None
+    ) -> list[TaskItem]:
+        return self._list_tasks_unlocked(status=status, owner=owner)
+
+    def _list_tasks_unlocked(
         self, status: TaskStatus | None = None, owner: str | None = None
     ) -> list[TaskItem]:
         root = _tasks_root(self.team_name)
@@ -213,16 +243,23 @@ class TaskStore:
             "avg_duration_seconds": round(avg_duration, 2),
         }
 
-    def _save(self, task: TaskItem) -> None:
+    def _save_unlocked(self, task: TaskItem) -> None:
         path = _task_path(self.team_name, task.id)
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text(
-            task.model_dump_json(indent=2, by_alias=True), encoding="utf-8"
+        fd, tmp_name = tempfile.mkstemp(
+            dir=path.parent,
+            prefix=f"{path.stem}-",
+            suffix=".tmp",
         )
-        tmp.rename(path)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+                tmp_file.write(task.model_dump_json(indent=2, by_alias=True))
+            Path(tmp_name).replace(path)
+        except BaseException:
+            Path(tmp_name).unlink(missing_ok=True)
+            raise
 
-    def _resolve_dependents(self, completed_task_id: str) -> None:
+    def _resolve_dependents_unlocked(self, completed_task_id: str) -> None:
         root = _tasks_root(self.team_name)
         for f in root.glob("task-*.json"):
             try:
@@ -233,6 +270,6 @@ class TaskStore:
                     if not task.blocked_by and task.status == TaskStatus.blocked:
                         task.status = TaskStatus.pending
                     task.updated_at = _now_iso()
-                    self._save(task)
+                    self._save_unlocked(task)
             except Exception:
                 continue

--- a/tests/test_task_store_locking.py
+++ b/tests/test_task_store_locking.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from clawteam.team.models import TaskStatus
+from clawteam.team.tasks import TaskStore
+
+
+def _claim_task(
+    data_dir: str,
+    task_id: str,
+    agent_name: str,
+    save_delay: float,
+    result_queue,
+) -> None:
+    os.environ["CLAWTEAM_DATA_DIR"] = data_dir
+    store = TaskStore("demo")
+    original_save = TaskStore._save_unlocked
+
+    def delayed_save(self, task):
+        if save_delay:
+            time.sleep(save_delay)
+        return original_save(self, task)
+
+    TaskStore._save_unlocked = delayed_save
+    try:
+        task = store.update(task_id, status=TaskStatus.in_progress, caller=agent_name)
+        result_queue.put((agent_name, "ok", task.locked_by if task else None))
+    except Exception as exc:
+        result_queue.put((agent_name, "err", type(exc).__name__))
+    finally:
+        TaskStore._save_unlocked = original_save
+
+
+@pytest.mark.skipif("fork" not in mp.get_all_start_methods(), reason="requires fork start method")
+def test_only_one_agent_can_claim_task_concurrently(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path))
+    store = TaskStore("demo")
+    task = store.create("demo task")
+
+    ctx = mp.get_context("fork")
+    result_queue = ctx.Queue()
+
+    proc_a = ctx.Process(
+        target=_claim_task,
+        args=(str(tmp_path), task.id, "agent-a", 0.3, result_queue),
+    )
+    proc_b = ctx.Process(
+        target=_claim_task,
+        args=(str(tmp_path), task.id, "agent-b", 0.0, result_queue),
+    )
+
+    proc_a.start()
+    time.sleep(0.05)
+    proc_b.start()
+
+    results = sorted(result_queue.get(timeout=10) for _ in range(2))
+
+    proc_a.join(timeout=10)
+    proc_b.join(timeout=10)
+
+    assert [result[1] for result in results].count("ok") == 1
+    assert [result[1] for result in results].count("err") == 1
+    assert any(result[2] == "TaskLockError" for result in results if result[1] == "err")
+
+    final_task = TaskStore("demo").get(task.id)
+    assert final_task is not None
+    assert final_task.status == TaskStatus.in_progress
+    assert final_task.locked_by in {"agent-a", "agent-b"}


### PR DESCRIPTION
## Summary
- serialize `TaskStore` mutations with a team-scoped file lock
- re-read task state inside the lock before applying updates, so concurrent claim attempts cannot both succeed on stale snapshots
- use unique temp files for task saves to avoid shared `.tmp` filename collisions during contention
- add a regression test that races two worker processes against the same task and asserts only one can claim it

## Root Cause
`TaskStore.update()` previously performed an unlocked read-modify-write cycle:
- process A and process B could both read the same unlocked task
- both would pass `_acquire_lock()` against their stale in-memory copy
- both would then race while saving, so the later writer could overwrite the earlier lock state
- under contention, both writers also targeted the same `task-<id>.tmp` path, which could produce `FileNotFoundError` while still leaving the loser's state on disk

In short, the implementation had atomic file replacement but not atomic state transitions.

## What Changed
- added `tasks/<team>/.tasks.lock` and wrapped `create`, `update`, and `release_stale_locks` in an exclusive `flock`
- changed `update()` to reload the task only after the write lock is held
- kept dependent resolution inside the same mutation boundary
- replaced the shared `task-<id>.tmp` save path with unique temp files followed by atomic replace

## Validation
- `python -m pytest -q`
- `python -m compileall clawteam tests`
- `ruff check clawteam/team/tasks.py tests/test_task_store_locking.py`
- manual repro before fix: two forked worker processes racing on the same task could produce one success plus one crash on the shared `.tmp` path, while the final `locked_by` still reflected the losing writer
- manual repro after fix: one worker succeeds, the other gets `TaskLockError`, and the final task owner remains stable
