### PR TITLE
fix: approve-join validation and mailbox corrupted message handling

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -395,7 +395,14 @@ def team_approve_join(
             join_req = msg
             break
 
-    proposed_name = join_req.proposed_name if join_req else f"agent-{request_id[:6]}"
+    if join_req is None:
+        _output(
+            {"error": f"No join request found with id '{request_id}'"},
+            lambda d: console.print(f"[red]Error: {d['error']}[/red]"),
+        )
+        raise typer.Exit(1)
+
+    proposed_name = join_req.proposed_name
     final_name = assigned_name or proposed_name
     new_agent_id = uuid.uuid4().hex[:12]
 

--- a/clawteam/team/mailbox.py
+++ b/clawteam/team/mailbox.py
@@ -145,12 +145,22 @@ class MailboxManager:
     def receive(self, agent_name: str, limit: int = 10) -> list[TeamMessage]:
         """Receive and delete messages from an agent's inbox (FIFO)."""
         raw = self._transport.fetch(agent_name, limit=limit, consume=True)
-        return [TeamMessage.model_validate(json.loads(r)) for r in raw]
+        return self._parse_messages(raw)
 
     def peek(self, agent_name: str) -> list[TeamMessage]:
         """Return pending messages without consuming them."""
         raw = self._transport.fetch(agent_name, consume=False)
-        return [TeamMessage.model_validate(json.loads(r)) for r in raw]
+        return self._parse_messages(raw)
+
+    @staticmethod
+    def _parse_messages(raw: list[bytes]) -> list[TeamMessage]:
+        result: list[TeamMessage] = []
+        for r in raw:
+            try:
+                result.append(TeamMessage.model_validate(json.loads(r)))
+            except (json.JSONDecodeError, Exception):
+                pass
+        return result
 
     def peek_count(self, agent_name: str) -> int:
         return self._transport.count(agent_name)


### PR DESCRIPTION
## Summary

- **Fix approve-join proceeding without a valid join request**: `team approve-join` would silently add a member with a fabricated name (`agent-{id[:6]}`) when no matching join request was found. It now returns an error and exits.
- **Fix receive()/peek() crashing on corrupted messages**: A single invalid message in an inbox caused the entire `receive()` or `peek()` call to fail. With `consume=True`, already-deleted valid messages were lost. Invalid messages are now skipped gracefully via per-message try/except.

Note: the plans cleanup fix was dropped from this PR as it was already resolved upstream via PR #6.

## Test plan

- [x] All 135 existing tests pass (rebased on latest main)
- [x] Ruff lint clean
- [ ] Manually test `team approve-join` with an invalid request ID
- [ ] Manually test mailbox with a corrupted message file in inbox