### PR TITLE
fix: improve error handling for config loading, task parsing and file transport

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -747,8 +747,8 @@ def task_create(
     from clawteam.team.tasks import TaskStore
 
     store = TaskStore(team)
-    blocks_list = [b.strip() for b in blocks.split(",")] if blocks else []
-    blocked_by_list = [b.strip() for b in blocked_by.split(",")] if blocked_by else []
+    blocks_list = [b.strip() for b in blocks.split(",") if b.strip()] if blocks else []
+    blocked_by_list = [b.strip() for b in blocked_by.split(",") if b.strip()] if blocked_by else []
 
     task = store.create(
         subject=subject,
@@ -820,8 +820,8 @@ def task_update(
 
     store = TaskStore(team)
     ts = TaskStatus(status) if status else None
-    blocks_list = [b.strip() for b in add_blocks.split(",")] if add_blocks else None
-    blocked_by_list = [b.strip() for b in add_blocked_by.split(",")] if add_blocked_by else None
+    blocks_list = [b.strip() for b in add_blocks.split(",") if b.strip()] if add_blocks else None
+    blocked_by_list = [b.strip() for b in add_blocked_by.split(",") if b.strip()] if add_blocked_by else None
 
     caller = AgentIdentity.from_env().agent_name
 

--- a/clawteam/team/manager.py
+++ b/clawteam/team/manager.py
@@ -27,8 +27,11 @@ def _load_config(team_name: str) -> TeamConfig | None:
     path = _config_path(team_name)
     if not path.exists():
         return None
-    data = json.loads(path.read_text(encoding="utf-8"))
-    return TeamConfig.model_validate(data)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return TeamConfig.model_validate(data)
+    except (json.JSONDecodeError, Exception):
+        return None
 
 
 def _save_config(config: TeamConfig) -> None:

--- a/clawteam/transport/file.py
+++ b/clawteam/transport/file.py
@@ -37,8 +37,12 @@ class FileTransport(Transport):
         filename = f"msg-{ts}-{uid}.json"
         tmp = inbox / f".tmp-{uid}.json"
         target = inbox / filename
-        tmp.write_bytes(data)
-        tmp.rename(target)
+        try:
+            tmp.write_bytes(data)
+            tmp.replace(target)
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
 
     def fetch(self, agent_name: str, limit: int = 10, consume: bool = True) -> list[bytes]:
         inbox = _inbox_dir(self.team_name, agent_name)


### PR DESCRIPTION
## Summary

- **Fix `_load_config()` crashing on corrupted JSON**: When `config.json` contains invalid JSON or fails Pydantic validation, all callers expect `None` to be returned. Previously this raised an unhandled exception, potentially crashing discover, status, and other team commands.
- **Fix empty strings in `--blocks` / `--blocked-by` flags**: Input like `--blocked-by ",,task1"` produced `["", "", "task1"]`, causing tasks to be permanently blocked since no task has an empty-string ID. Empty entries are now filtered out during parsing in both `task create` and `task update`.
- **Fix `FileTransport.deliver()` leaving orphan tmp files on failure**: If `rename` failed (e.g. cross-filesystem), the `.tmp-*.json` file was left behind with no cleanup. Now uses `Path.replace()` for atomic move and cleans up the tmp file in an except block.

## Test plan

- [x] All 124 existing tests pass
- [x] Ruff lint clean
- [ ] Manually corrupt a team's `config.json` and verify `team discover` doesn't crash
- [ ] Test `task create --blocked-by ",,task1"` and verify only `task1` is in blockedBy
- [ ] Verify no `.tmp-*.json` files accumulate in inbox directories

Made with [Cursor](https://cursor.com)