### PR TITLE
fix: board API validation and signal handler restoration

### DIFF
--- a/clawteam/board/server.py
+++ b/clawteam/board/server.py
@@ -27,10 +27,16 @@ class BoardHandler(BaseHTTPRequestHandler):
         elif path == "/api/overview":
             self._serve_json(self.collector.collect_overview())
         elif path.startswith("/api/team/"):
-            team_name = path[len("/api/team/"):]
+            team_name = path[len("/api/team/"):].strip("/")
+            if not team_name:
+                self.send_error(400, "Team name required")
+                return
             self._serve_team(team_name)
         elif path.startswith("/api/events/"):
-            team_name = path[len("/api/events/"):]
+            team_name = path[len("/api/events/"):].strip("/")
+            if not team_name:
+                self.send_error(400, "Team name required")
+                return
             self._serve_sse(team_name)
         else:
             self.send_error(404)

--- a/clawteam/team/watcher.py
+++ b/clawteam/team/watcher.py
@@ -41,16 +41,22 @@ class InboxWatcher:
         def _handle_signal(signum, frame):
             self._running = False
 
+        prev_int = signal.getsignal(signal.SIGINT)
+        prev_term = signal.getsignal(signal.SIGTERM)
         signal.signal(signal.SIGINT, _handle_signal)
         signal.signal(signal.SIGTERM, _handle_signal)
 
-        while self._running:
-            messages = self.mailbox.receive(self.agent_name, limit=10)
-            for msg in messages:
-                self._output(msg)
-                if self.exec_cmd:
-                    self._run_callback(msg)
-            time.sleep(self.poll_interval)
+        try:
+            while self._running:
+                messages = self.mailbox.receive(self.agent_name, limit=10)
+                for msg in messages:
+                    self._output(msg)
+                    if self.exec_cmd:
+                        self._run_callback(msg)
+                time.sleep(self.poll_interval)
+        finally:
+            signal.signal(signal.SIGINT, prev_int)
+            signal.signal(signal.SIGTERM, prev_term)
 
     def _output(self, msg: TeamMessage) -> None:
         if self.json_output:


### PR DESCRIPTION
## Summary

- **Fix Board API accepting empty team_name**: Requests to `/api/team/` or `/api/events/` (with no team name) caused an internal `ValueError`. Both endpoints now validate the team_name and return HTTP 400 with a clear error message. Also strips trailing slashes for robustness.
- **Fix InboxWatcher not restoring signal handlers**: `InboxWatcher.watch()` replaced `SIGINT` and `SIGTERM` handlers but never restored them after exit. The custom handlers remained installed for the rest of the process. Now saves and restores original handlers in a `try/finally` block, matching `TaskWaiter`'s pattern.

## Test plan

- [x] All 124 existing tests pass
- [x] Ruff lint clean
- [ ] Manually test `board serve` and request `/api/team/` with empty team name
- [ ] Verify `inbox watch` properly restores signal handling after Ctrl+C

Made with [Cursor](https://cursor.com)