### PR TITLE
fix: add --from option to inbox broadcast

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -575,17 +575,18 @@ def inbox_broadcast(
     content: str = typer.Argument(..., help="Message content"),
     key: Optional[str] = typer.Option(None, "--key", "-k", help="Optional routing key"),
     msg_type: str = typer.Option("broadcast", "--type", help="Message type"),
+    from_agent: Optional[str] = typer.Option(None, "--from", "-f", help="Override sender name (default: from env identity)"),
 ):
     """Broadcast a message to all team members (broadcast)."""
     from clawteam.identity import AgentIdentity
     from clawteam.team.mailbox import MailboxManager
     from clawteam.team.models import MessageType
 
-    identity = AgentIdentity.from_env()
+    sender = from_agent or AgentIdentity.from_env().agent_name
     mailbox = MailboxManager(team)
     mt = MessageType(msg_type)
     messages = mailbox.broadcast(
-        from_agent=identity.agent_name,
+        from_agent=sender,
         content=content,
         msg_type=mt,
         key=key,


### PR DESCRIPTION
## Summary

- `inbox broadcast` always used the default agent identity (`"agent"`) as sender, unlike `inbox send` which supports `--from / -f`
- This caused broadcast messages to show incorrect sender names (e.g., `from=agent` instead of `from=leader`) when called outside a spawned agent context
- Added `--from / -f` option to `inbox_broadcast`, consistent with `inbox_send`, falling back to env identity when not specified

## Changes

- `clawteam/cli/commands.py`: Add `from_agent` parameter to `inbox_broadcast()` (+3 lines, -2 lines)

## Before / After

```bash
# Before: sender always shows "agent"
clawteam inbox broadcast my-team "Hello everyone"
# Message log: from=agent → bob (broadcast): Hello everyone

# After: sender can be overridden
clawteam inbox broadcast my-team "Hello everyone" --from leader
# Message log: from=leader → bob (broadcast): Hello everyone
```

## Test plan

- [x] Verified `clawteam inbox broadcast --help` shows the new `--from / -f` option
- [x] Verified broadcast with `--from leader` correctly records sender as "leader" in message log
- [x] Verified broadcast without `--from` falls back to env identity (backward compatible)
- [x] Verified `inbox peek` and `inbox log` display correct sender name

🤖 Generated with [Claude Code](https://claude.com/claude-code)