### PR TITLE
docs: add Codex skill entry for ClawTeam

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,10 +380,22 @@ If the agent CLI does not run correctly by itself, `clawteam spawn` will not fix
 
 ### ⚡ Option 1: Let the Agent Drive (Recommended)
 
-ClawTeam ships with a **Claude Code skill** that auto-activates. Just install and prompt:
+ClawTeam ships with a reusable skill in `skills/clawteam/`.
+
+**Claude Code**
+
+Install the skill into `~/.claude/skills/clawteam`, then prompt:
 
 ```
 "Build a web app. Use clawteam to split the work across multiple agents."
+```
+
+**Codex**
+
+Install the same skill into `$CODEX_HOME/skills/clawteam` (typically `~/.codex/skills/clawteam`), then prompt:
+
+```
+Use $clawteam to split this task across multiple agents and coordinate the team to completion.
 ```
 
 The agent will automatically create a team, spawn workers, assign tasks, and coordinate — using `clawteam` CLI commands under the hood.
@@ -525,7 +537,7 @@ All examples below assume the corresponding CLI already runs standalone on your 
 | 🌐 **Cross-Machine** | Shared filesystem (NFS/SSHFS) or P2P transport for distributed teams |
 | 👥 **Multi-User** | Namespace agents by user — multiple humans can share a team |
 | ⚙️ **Configuration** | Persistent config: env var > config file > default priority |
-| 🔌 **Claude Code Skill** | Auto-triggers when users ask about multi-agent coordination |
+| 🔌 **Agent Skill** | Reusable skill entry for Claude Code and Codex workflows |
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -326,10 +326,22 @@ nanobot --help
 
 ### ⚡ 方式一：让 Agent 驱动（推荐）
 
-ClawTeam 内置 **Claude Code 技能**，安装后自动激活。直接告诉你的 Agent：
+ClawTeam 自带一个可复用的 skill，位于 `skills/clawteam/`。
+
+**Claude Code**
+
+把这个 skill 安装到 `~/.claude/skills/clawteam`，然后直接告诉你的 Agent：
 
 ```
 "帮我做一个 Web 应用。用 clawteam 把工作拆分给多个 Agent。"
+```
+
+**Codex**
+
+把同一个 skill 安装到 `$CODEX_HOME/skills/clawteam`（通常是 `~/.codex/skills/clawteam`），然后提示：
+
+```
+用 $clawteam 把这个任务拆成多 Agent 团队，协调执行直到完成。
 ```
 
 Agent 会自动使用 `clawteam` 命令创建团队、启动 Worker、分配任务、协调工作。

--- a/README_KR.md
+++ b/README_KR.md
@@ -353,10 +353,22 @@ pip install -e ".[p2p]"
 
 ### ⚡ 옵션 1: 에이전트에게 맡기기 (권장)
 
-ClawTeam에는 **Claude Code 스킬**이 포함되어 있어 자동으로 활성화됩니다. 설치한 뒤 이렇게 프롬프트를 주면 됩니다.
+ClawTeam에는 `skills/clawteam/`에 재사용 가능한 skill이 들어 있습니다.
+
+**Claude Code**
+
+이 skill을 `~/.claude/skills/clawteam`에 설치한 뒤, 이렇게 프롬프트를 주면 됩니다.
 
 ```
 "웹 앱을 만들어줘. 작업은 clawteam으로 여러 에이전트에게 나눠서 진행해."
+```
+
+**Codex**
+
+같은 skill을 `$CODEX_HOME/skills/clawteam`(보통 `~/.codex/skills/clawteam`)에 설치한 뒤, 이렇게 요청하면 됩니다.
+
+```
+이 작업을 여러 에이전트 팀으로 나누고 끝까지 조율하도록 $clawteam을 사용해줘.
 ```
 
 그러면 에이전트가 내부적으로 `clawteam` CLI 명령을 사용해 팀을 만들고, 워커를 띄우고, 작업을 나누고, 전체 흐름을 조율합니다.
@@ -455,7 +467,7 @@ ClawTeam은 셸 명령을 실행할 수 있는 **어떤 CLI 에이전트**와도
 | 🌐 **멀티머신 지원** | 공유 파일시스템(NFS/SSHFS) 또는 P2P transport로 분산 팀 운영 |
 | 👥 **멀티유저 지원** | 사용자별 네임스페이스로 여러 사람이 한 팀을 공유 가능 |
 | ⚙️ **설정 관리** | 영속 설정 우선순위: 환경 변수 > 설정 파일 > 기본값 |
-| 🔌 **Claude Code 스킬** | 사용자가 멀티에이전트 협업을 요청하면 자동 트리거 |
+| 🔌 **에이전트 스킬** | Claude Code와 Codex에서 재사용 가능한 skill 진입점 |
 
 ---
 

--- a/skills/clawteam/agents/openai.yaml
+++ b/skills/clawteam/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "ClawTeam"
+  short_description: "Create and coordinate multi-agent teams from Codex."
+  default_prompt: "Use $clawteam to create a team, split this task into tracked work items, spawn workers, coordinate them, and deliver the result."
+
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
## Summary
This adds a Codex entrypoint for the existing `skills/clawteam/` skill instead of introducing a second copy of the skill.

It does two things:
- adds `skills/clawteam/agents/openai.yaml` for Codex/OpenAI skill metadata
- documents how to install and trigger the same skill from Codex

It also aligns the wording across the English, Chinese, and Korean READMEs so the skill is no longer presented as Claude-only.

## What changed
- added `skills/clawteam/agents/openai.yaml`
- updated `README.md` with Codex skill install and prompt examples
- updated `README_CN.md` with the same Codex skill guidance
- updated `README_KR.md` to keep the skill wording and examples aligned across locales

## Why this approach
ClawTeam already ships a reusable skill at `skills/clawteam/SKILL.md`.

Rather than duplicating it for Codex, this keeps one shared skill body and adds the Codex entrypoint plus install docs.

## Test plan
- [x] Ran `python -m pytest -q`
- [x] Verified `skills/clawteam/agents/openai.yaml` is included in this PR
- [x] Verified `README`, `README_CN`, and `README_KR` all describe the same reusable skill setup for Claude Code and Codex
- [x] Verified each README includes the install path and a sample Codex prompt
