### PR TITLE
fix: resolve 5 bugs — broadcast exclusion, plans cleanup, launch perms, config, fetch race

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -117,19 +117,24 @@ def config_show():
 
 @config_app.command("set")
 def config_set(
-    key: str = typer.Argument(..., help="Config key: data_dir, user, default_team"),
+    key: str = typer.Argument(..., help="Config key (e.g. data_dir, user, transport, workspace, default_backend, skip_permissions)"),
     value: str = typer.Argument(..., help="Config value"),
 ):
     """Persistently set a configuration value."""
-    from clawteam.config import load_config, save_config
+    from clawteam.config import ClawTeamConfig, load_config, save_config
 
-    valid_keys = {"data_dir", "user", "default_team"}
+    valid_keys = set(ClawTeamConfig.model_fields.keys())
     if key not in valid_keys:
         console.print(f"[red]Invalid key '{key}'. Valid: {', '.join(sorted(valid_keys))}[/red]")
         raise typer.Exit(1)
 
     cfg = load_config()
-    setattr(cfg, key, value)
+    # Handle boolean fields (skip_permissions)
+    field_info = ClawTeamConfig.model_fields[key]
+    if field_info.annotation is bool:
+        setattr(cfg, key, value.lower() in ("true", "1", "yes"))
+    else:
+        setattr(cfg, key, value)
     save_config(cfg)
 
     _output(
@@ -140,12 +145,12 @@ def config_set(
 
 @config_app.command("get")
 def config_get(
-    key: str = typer.Argument(..., help="Config key: data_dir, user, default_team"),
+    key: str = typer.Argument(..., help="Config key (e.g. data_dir, user, transport, workspace, default_backend, skip_permissions)"),
 ):
     """Get the effective value of a config key."""
-    from clawteam.config import get_effective
+    from clawteam.config import ClawTeamConfig, get_effective
 
-    valid_keys = {"data_dir", "user", "default_team"}
+    valid_keys = set(ClawTeamConfig.model_fields.keys())
     if key not in valid_keys:
         console.print(f"[red]Invalid key '{key}'. Valid: {', '.join(sorted(valid_keys))}[/red]")
         raise typer.Exit(1)
@@ -2221,6 +2226,11 @@ def launch_team(
             workspace_branch=ws_branch,
         )
 
+        # Resolve skip_permissions from config
+        from clawteam.config import get_effective
+        sp_val, _ = get_effective("skip_permissions")
+        _skip = str(sp_val).lower() not in ("false", "0", "no", "")
+
         result = be.spawn(
             command=a_cmd,
             agent_name=agent.name,
@@ -2229,6 +2239,7 @@ def launch_team(
             team_name=t_name,
             prompt=prompt,
             cwd=cwd,
+            skip_permissions=_skip,
         )
         spawned.append({"name": agent.name, "id": a_id, "type": agent.type, "result": result})
 

--- a/clawteam/team/mailbox.py
+++ b/clawteam/team/mailbox.py
@@ -122,11 +122,21 @@ class MailboxManager:
         key: str | None = None,
         exclude: list[str] | None = None,
     ) -> list[TeamMessage]:
+        from clawteam.team.manager import TeamManager
+
         exclude_set = set(exclude or [])
         exclude_set.add(from_agent)
+        # Build a mapping from inbox directory name to logical agent name
+        # so we can correctly exclude the sender even when inbox names
+        # use user-prefixed format (e.g. "alice_worker").
+        exclude_inboxes = set()
+        for name in exclude_set:
+            inbox = TeamManager.resolve_inbox(self.team_name, name)
+            exclude_inboxes.add(inbox)
+            exclude_inboxes.add(name)  # also exclude by raw name
         messages = []
         for recipient in self._transport.list_recipients():
-            if recipient not in exclude_set:
+            if recipient not in exclude_inboxes:
                 msg = TeamMessage(
                     type=msg_type,
                     from_agent=from_agent,

--- a/clawteam/transport/file.py
+++ b/clawteam/transport/file.py
@@ -50,16 +50,28 @@ class FileTransport(Transport):
         messages: list[bytes] = []
         for f in files[:limit]:
             try:
-                raw = f.read_bytes()
-                messages.append(raw)
                 if consume:
-                    f.unlink()
-            except Exception:
-                if consume:
+                    # Atomically rename to a consumed marker first to prevent
+                    # duplicate reads when multiple processes fetch concurrently.
+                    consumed = f.with_suffix(".consumed")
                     try:
-                        f.unlink()
+                        f.rename(consumed)
                     except OSError:
-                        pass
+                        # Another process already consumed this message
+                        continue
+                    try:
+                        raw = consumed.read_bytes()
+                        messages.append(raw)
+                    finally:
+                        try:
+                            consumed.unlink()
+                        except OSError:
+                            pass
+                else:
+                    raw = f.read_bytes()
+                    messages.append(raw)
+            except Exception:
+                continue
         return messages
 
     def count(self, agent_name: str) -> int:


### PR DESCRIPTION
## Summary

Fixes 5 independent bugs discovered during deep testing of the project.

### 1. Broadcast exclude logic does not work (mailbox.py)
`broadcast()` compares inbox directory names (e.g. `alice_worker`) against logical agent names (e.g. `worker`) in the exclude set. Since these never match, **the sender always receives their own broadcast**. Fixed by resolving logical names to inbox names before comparison.

### 2. `cleanup` deletes ALL teams' plan files (manager.py)
`TeamManager.cleanup()` called `plans_dir.glob("*.md")` and deleted everything in the shared `plans/` directory — wiping plans from every team, not just the one being cleaned up. Fixed by loading the team config first and only deleting plan files whose agent name prefix matches a team member.

### 3. `launch` does not pass `skip_permissions` to spawned agents (commands.py)
The `spawn` command correctly reads `skip_permissions` from config and passes it to backends. The `launch` command did not, so agents spawned via templates (e.g. `clawteam launch hedge-fund`) never got `--dangerously-skip-permissions` even when configured. Fixed by reading the config value and forwarding it.

### 4. `config set` / `config get` only accept 3 of 7 valid keys (commands.py)
Both commands hardcoded `{"data_dir", "user", "default_team"}` as valid keys, making `transport`, `workspace`, `default_backend`, and `skip_permissions` impossible to set via CLI (even though `config show` displays all 7). Fixed by dynamically reading valid keys from the Pydantic model, with proper boolean field handling.

### 5. File transport `fetch()` has a race condition (file.py)
When multiple processes call `fetch(consume=True)` concurrently, both can `read_bytes()` the same message file before either calls `unlink()`, resulting in **duplicate message delivery**. Fixed by atomically renaming the file to `.consumed` before reading — only one process can win the `rename()`, and losers skip the message.

## Changes

| File | Lines | What |
|------|-------|------|
| `clawteam/team/mailbox.py` | +12 -1 | Resolve agent names to inbox names in broadcast exclude |
| `clawteam/team/manager.py` | +19 -5 | Scope plan cleanup to team members only |
| `clawteam/cli/commands.py` | +25 -7 | Add skip_permissions to launch; expand config set/get keys |
| `clawteam/transport/file.py` | +26 -7 | Atomic rename-before-read in fetch |

## Test plan

- [x] All 124 existing tests pass (`pytest tests/ -v`)
- [x] `ruff check` — no new lint errors (pre-existing `N802` on `do_GET` is unchanged)
- [x] Manually verified broadcast no longer delivers to sender
- [x] Manually verified `config set transport file` now works
- [x] Manually verified `config set skip_permissions true` handles booleans correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)