### PR TITLE
fix: consolidate bug fixes from PR #9 and PR #15

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -117,19 +117,23 @@ def config_show():
 
 @config_app.command("set")
 def config_set(
-    key: str = typer.Argument(..., help="Config key: data_dir, user, default_team"),
+    key: str = typer.Argument(..., help="Config key (e.g. data_dir, user, transport, workspace, default_backend, skip_permissions)"),
     value: str = typer.Argument(..., help="Config value"),
 ):
     """Persistently set a configuration value."""
-    from clawteam.config import load_config, save_config
+    from clawteam.config import ClawTeamConfig, load_config, save_config
 
-    valid_keys = {"data_dir", "user", "default_team"}
+    valid_keys = set(ClawTeamConfig.model_fields.keys())
     if key not in valid_keys:
         console.print(f"[red]Invalid key '{key}'. Valid: {', '.join(sorted(valid_keys))}[/red]")
         raise typer.Exit(1)
 
     cfg = load_config()
-    setattr(cfg, key, value)
+    field_info = ClawTeamConfig.model_fields[key]
+    if field_info.annotation is bool:
+        setattr(cfg, key, value.lower() in ("true", "1", "yes"))
+    else:
+        setattr(cfg, key, value)
     save_config(cfg)
 
     _output(
@@ -140,12 +144,12 @@ def config_set(
 
 @config_app.command("get")
 def config_get(
-    key: str = typer.Argument(..., help="Config key: data_dir, user, default_team"),
+    key: str = typer.Argument(..., help="Config key (e.g. data_dir, user, transport, workspace, default_backend, skip_permissions)"),
 ):
     """Get the effective value of a config key."""
-    from clawteam.config import get_effective
+    from clawteam.config import ClawTeamConfig, get_effective
 
-    valid_keys = {"data_dir", "user", "default_team"}
+    valid_keys = set(ClawTeamConfig.model_fields.keys())
     if key not in valid_keys:
         console.print(f"[red]Invalid key '{key}'. Valid: {', '.join(sorted(valid_keys))}[/red]")
         raise typer.Exit(1)
@@ -395,7 +399,14 @@ def team_approve_join(
             join_req = msg
             break
 
-    proposed_name = join_req.proposed_name if join_req else f"agent-{request_id[:6]}"
+    if join_req is None:
+        _output(
+            {"error": f"No join request found with id '{request_id}'"},
+            lambda d: console.print(f"[red]Error: {d['error']}[/red]"),
+        )
+        raise typer.Exit(1)
+
+    proposed_name = join_req.proposed_name
     final_name = assigned_name or proposed_name
     new_agent_id = uuid.uuid4().hex[:12]
 
@@ -2221,6 +2232,10 @@ def launch_team(
             workspace_branch=ws_branch,
         )
 
+        from clawteam.config import get_effective
+        sp_val, _ = get_effective("skip_permissions")
+        _skip = str(sp_val).lower() not in ("false", "0", "no", "")
+
         result = be.spawn(
             command=a_cmd,
             agent_name=agent.name,
@@ -2229,6 +2244,7 @@ def launch_team(
             team_name=t_name,
             prompt=prompt,
             cwd=cwd,
+            skip_permissions=_skip,
         )
         spawned.append({"name": agent.name, "id": a_id, "type": agent.type, "result": result})
 

--- a/clawteam/team/mailbox.py
+++ b/clawteam/team/mailbox.py
@@ -122,11 +122,20 @@ class MailboxManager:
         key: str | None = None,
         exclude: list[str] | None = None,
     ) -> list[TeamMessage]:
+        from clawteam.team.manager import TeamManager
+
         exclude_set = set(exclude or [])
         exclude_set.add(from_agent)
+        # Resolve logical agent names to inbox directory names so the sender
+        # is correctly excluded even when inboxes use a user-prefixed format
+        # (e.g. "alice_worker" for logical name "worker").
+        exclude_inboxes: set[str] = set()
+        for name in exclude_set:
+            exclude_inboxes.add(name)
+            exclude_inboxes.add(TeamManager.resolve_inbox(self.team_name, name))
         messages = []
         for recipient in self._transport.list_recipients():
-            if recipient not in exclude_set:
+            if recipient not in exclude_inboxes:
                 msg = TeamMessage(
                     type=msg_type,
                     from_agent=from_agent,
@@ -142,15 +151,26 @@ class MailboxManager:
                 messages.append(msg)
         return messages
 
+    @staticmethod
+    def _parse_messages(raw: list[bytes]) -> list[TeamMessage]:
+        """Parse raw message bytes, silently skipping any corrupted entries."""
+        result: list[TeamMessage] = []
+        for r in raw:
+            try:
+                result.append(TeamMessage.model_validate(json.loads(r)))
+            except Exception:
+                pass
+        return result
+
     def receive(self, agent_name: str, limit: int = 10) -> list[TeamMessage]:
         """Receive and delete messages from an agent's inbox (FIFO)."""
         raw = self._transport.fetch(agent_name, limit=limit, consume=True)
-        return [TeamMessage.model_validate(json.loads(r)) for r in raw]
+        return self._parse_messages(raw)
 
     def peek(self, agent_name: str) -> list[TeamMessage]:
         """Return pending messages without consuming them."""
         raw = self._transport.fetch(agent_name, consume=False)
-        return [TeamMessage.model_validate(json.loads(r)) for r in raw]
+        return self._parse_messages(raw)
 
     def peek_count(self, agent_name: str) -> int:
         return self._transport.count(agent_name)

--- a/clawteam/transport/file.py
+++ b/clawteam/transport/file.py
@@ -50,16 +50,25 @@ class FileTransport(Transport):
         messages: list[bytes] = []
         for f in files[:limit]:
             try:
-                raw = f.read_bytes()
-                messages.append(raw)
                 if consume:
-                    f.unlink()
-            except Exception:
-                if consume:
+                    # Atomically rename to a `.consumed` marker before reading so
+                    # that concurrent fetchers cannot both process the same message.
+                    consumed = f.with_suffix(".consumed")
                     try:
-                        f.unlink()
+                        f.rename(consumed)
                     except OSError:
-                        pass
+                        # Another process already claimed this message; skip it.
+                        continue
+                    try:
+                        raw = consumed.read_bytes()
+                        messages.append(raw)
+                    finally:
+                        consumed.unlink(missing_ok=True)
+                else:
+                    raw = f.read_bytes()
+                    messages.append(raw)
+            except Exception:
+                continue
         return messages
 
     def count(self, agent_name: str) -> int:


### PR DESCRIPTION
## Context

Two open PRs (#9 and #15) fix overlapping bugs with different approaches. This PR consolidates the best of both, resolves their conflicts, and applies all 6 fixes not yet in \`main\`.

The one area of overlap — **plans cleanup** — was already merged via PR #6 using the subdirectory strategy (PR #9's cleaner approach). It is intentionally excluded here.

---

## Changes

### \`clawteam/team/mailbox.py\`

**Bug 1 — broadcast sender exclusion broken** *(from PR #15)*

\`broadcast()\` compared inbox *directory names* (e.g. \`alice_worker\`) against *logical agent names* (e.g. \`worker\`) in the exclude set. These never matched, so the sender always received their own broadcast.

Fix: resolve each logical name to its inbox directory name via \`TeamManager.resolve_inbox()\` before building the exclusion set.

**Bug 2 — receive() / peek() crash on corrupted messages** *(from PR #9)*

A single invalid JSON file in an inbox raised an exception that aborted the entire fetch, losing all subsequent valid messages (with \`consume=True\`, already-deleted messages were gone too).

Fix: extract a \`_parse_messages()\` helper that wraps each message in \`try/except\`, silently skipping corrupted entries.

---

### \`clawteam/transport/file.py\`

**Bug 3 — fetch(consume=True) has a race condition** *(from PR #15)*

When two processes call \`fetch(consume=True)\` concurrently, both could \`read_bytes()\` the same file before either called \`unlink()\`, resulting in duplicate message delivery.

Fix: atomically \`rename()\` the file to \`.consumed\` before reading. Only one process can win the rename; others get \`OSError\` and skip the message.

---

### \`clawteam/cli/commands.py\`

**Bug 4 — config set/get only accept 3 of 7 valid keys** *(from PR #15)*

Both commands hardcoded \`{"data_dir", "user", "default_team"}\`, making \`transport\`, \`workspace\`, \`default_backend\`, and \`skip_permissions\` impossible to set or get via CLI (even though \`config show\` displays all 7).

Fix: derive \`valid_keys\` dynamically from \`ClawTeamConfig.model_fields\`. Handle boolean fields (\`skip_permissions\`) with an explicit string→bool conversion.

**Bug 5 — approve-join silently fabricates an agent name** *(from PR #9)*

When no matching join request is found, \`team approve-join\` fabricated a name (\`agent-{id[:6]}\`) and proceeded to add a spurious team member.

Fix: return an error message and \`exit(1)\` when the join request cannot be found.

**Bug 6 — launch does not pass skip_permissions to spawned agents** *(from PR #15)*

\`clawteam spawn\` correctly reads \`skip_permissions\` from config and passes \`--dangerously-skip-permissions\` to Claude. \`clawteam launch\` did not, so agents spawned via templates always ran without the flag regardless of config.

Fix: read \`skip_permissions\` from config via \`get_effective()\` and forward it to \`be.spawn()\`.

---

## Relationship to PR #9 and PR #15

| Fix | This PR | PR #9 | PR #15 |
|-----|---------|-------|--------|
| broadcast exclusion | ✅ | ❌ | ✅ |
| receive/peek crash | ✅ | ✅ | ❌ |
| file transport race | ✅ | ❌ | ✅ |
| config set/get keys | ✅ | ❌ | ✅ |
| approve-join fabrication | ✅ | ✅ | ❌ |
| launch skip_permissions | ✅ | ❌ | ✅ |
| plans cleanup | already merged (PR #6) | ✅ subdirectory | ✅ member-filter |

If this PR is merged, both #9 and #15 can be closed as superseded (or cherry-picked for anything missed).

## Test plan

- [x] All 135 existing tests pass (`pytest tests/ -q`)
- [ ] Manually verify broadcast does not deliver to sender
- [ ] Manually verify `config set transport file` and `config set skip_permissions true` work
- [ ] Manually verify `team approve-join` with an invalid request ID returns an error
- [ ] Manually verify `clawteam launch hedge-fund` respects `skip_permissions` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)