### PR TITLE
feat: add task priority support and refactor spawn utilities

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -575,18 +575,17 @@ def inbox_broadcast(
     content: str = typer.Argument(..., help="Message content"),
     key: Optional[str] = typer.Option(None, "--key", "-k", help="Optional routing key"),
     msg_type: str = typer.Option("broadcast", "--type", help="Message type"),
-    from_agent: Optional[str] = typer.Option(None, "--from", "-f", help="Override sender name (default: from env identity)"),
 ):
     """Broadcast a message to all team members (broadcast)."""
     from clawteam.identity import AgentIdentity
     from clawteam.team.mailbox import MailboxManager
     from clawteam.team.models import MessageType
 
-    sender = from_agent or AgentIdentity.from_env().agent_name
+    identity = AgentIdentity.from_env()
     mailbox = MailboxManager(team)
     mt = MessageType(msg_type)
     messages = mailbox.broadcast(
-        from_agent=sender,
+        from_agent=identity.agent_name,
         content=content,
         msg_type=mt,
         key=key,
@@ -741,20 +740,24 @@ def task_create(
     subject: str = typer.Argument(..., help="Task subject"),
     description: str = typer.Option("", "--description", "-d", help="Task description"),
     owner: Optional[str] = typer.Option(None, "--owner", "-o", help="Owner agent name"),
+    priority: Optional[str] = typer.Option("medium", "--priority", "-p", help="Task priority: low, medium, high, urgent"),
     blocks: Optional[str] = typer.Option(None, "--blocks", help="Comma-separated task IDs this blocks"),
     blocked_by: Optional[str] = typer.Option(None, "--blocked-by", help="Comma-separated task IDs this is blocked by"),
 ):
     """Create a new task (TaskCreate)."""
+    from clawteam.team.models import TaskPriority
     from clawteam.team.tasks import TaskStore
 
     store = TaskStore(team)
-    blocks_list = [b.strip() for b in blocks.split(",") if b.strip()] if blocks else []
-    blocked_by_list = [b.strip() for b in blocked_by.split(",") if b.strip()] if blocked_by else []
+    blocks_list = [b.strip() for b in blocks.split(",")] if blocks else []
+    blocked_by_list = [b.strip() for b in blocked_by.split(",")] if blocked_by else []
+    task_priority = TaskPriority(priority) if priority else TaskPriority.medium
 
     task = store.create(
         subject=subject,
         description=description,
         owner=owner or "",
+        priority=task_priority,
         blocks=blocks_list,
         blocked_by=blocked_by_list,
     )
@@ -764,6 +767,7 @@ def task_create(
         console.print(f"[green]OK[/green] Task created: {d['id']}"),
         console.print(f"  Subject: {d['subject']}"),
         console.print(f"  Status: {d['status']}"),
+        console.print(f"  Priority: {d.get('priority', 'medium')}"),
         console.print(f"  Owner: {d.get('owner', '')}") if d.get('owner') else None,
     ))
 
@@ -788,6 +792,7 @@ def task_get(
         console.print(f"Task: [cyan]{d['id']}[/cyan]")
         console.print(f"  Subject: {d['subject']}")
         console.print(f"  Status: {d['status']}")
+        console.print(f"  Priority: {d.get('priority', 'medium')}")
         if d.get('owner'):
             console.print(f"  Owner: {d['owner']}")
         if d.get('lockedBy'):
@@ -810,19 +815,21 @@ def task_update(
     owner: Optional[str] = typer.Option(None, "--owner", "-o", help="New owner"),
     subject: Optional[str] = typer.Option(None, "--subject", help="New subject"),
     description: Optional[str] = typer.Option(None, "--description", "-d", help="New description"),
+    priority: Optional[str] = typer.Option(None, "--priority", "-p", help="New priority: low, medium, high, urgent"),
     add_blocks: Optional[str] = typer.Option(None, "--add-blocks", help="Comma-separated task IDs this blocks"),
     add_blocked_by: Optional[str] = typer.Option(None, "--add-blocked-by", help="Comma-separated task IDs blocking this"),
     force: bool = typer.Option(False, "--force", "-f", help="Force override task lock"),
 ):
     """Update a task (TaskUpdate)."""
     from clawteam.identity import AgentIdentity
-    from clawteam.team.models import TaskStatus
+    from clawteam.team.models import TaskPriority, TaskStatus
     from clawteam.team.tasks import TaskLockError, TaskStore
 
     store = TaskStore(team)
     ts = TaskStatus(status) if status else None
-    blocks_list = [b.strip() for b in add_blocks.split(",") if b.strip()] if add_blocks else None
-    blocked_by_list = [b.strip() for b in add_blocked_by.split(",") if b.strip()] if add_blocked_by else None
+    tp = TaskPriority(priority) if priority else None
+    blocks_list = [b.strip() for b in add_blocks.split(",")] if add_blocks else None
+    blocked_by_list = [b.strip() for b in add_blocked_by.split(",")] if add_blocked_by else None
 
     caller = AgentIdentity.from_env().agent_name
 
@@ -833,6 +840,7 @@ def task_update(
             owner=owner,
             subject=subject,
             description=description,
+            priority=tp,
             add_blocks=blocks_list,
             add_blocked_by=blocked_by_list,
             caller=caller,
@@ -855,14 +863,17 @@ def task_list(
     team: str = typer.Argument(..., help="Team name"),
     status: Optional[str] = typer.Option(None, "--status", "-s", help="Filter by status"),
     owner: Optional[str] = typer.Option(None, "--owner", "-o", help="Filter by owner"),
+    priority: Optional[str] = typer.Option(None, "--priority", "-p", help="Filter by priority: low, medium, high, urgent"),
+    sort_priority: bool = typer.Option(False, "--sort-priority", help="Sort by priority (urgent first)"),
 ):
     """List tasks for a team (TaskList)."""
-    from clawteam.team.models import TaskStatus
+    from clawteam.team.models import TaskPriority, TaskStatus
     from clawteam.team.tasks import TaskStore
 
     store = TaskStore(team)
     ts = TaskStatus(status) if status else None
-    tasks = store.list_tasks(status=ts, owner=owner)
+    tp = TaskPriority(priority) if priority else None
+    tasks = store.list_tasks(status=ts, owner=owner, priority=tp, sort_by_priority=sort_priority)
 
     data = [_dump(t) for t in tasks]
 
@@ -874,16 +885,20 @@ def task_list(
         table.add_column("ID", style="dim")
         table.add_column("Subject", style="cyan")
         table.add_column("Status")
+        table.add_column("Priority")
         table.add_column("Owner")
         table.add_column("Lock", style="yellow")
         table.add_column("Blocked By", style="dim")
         for t in items:
             st = t.get("status", "")
             style = {"pending": "white", "in_progress": "yellow", "completed": "green", "blocked": "red"}.get(st, "")
+            pr = t.get("priority", "medium")
+            pr_style = {"urgent": "red bold", "high": "yellow", "medium": "white", "low": "dim"}.get(pr, "")
             table.add_row(
                 t["id"],
                 t["subject"],
                 f"[{style}]{st}[/{style}]" if style else st,
+                f"[{pr_style}]{pr}[/{pr_style}]" if pr_style else pr,
                 t.get("owner") or "",
                 t.get("lockedBy") or "",
                 ", ".join(t.get("blockedBy", [])),

--- a/clawteam/spawn/subprocess_backend.py
+++ b/clawteam/spawn/subprocess_backend.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import os
-import shlex
 import subprocess
 
 from clawteam.spawn.base import SpawnBackend
 from clawteam.spawn.cli_env import build_spawn_path, resolve_clawteam_executable
 from clawteam.spawn.command_validation import normalize_spawn_command, validate_spawn_command
+from clawteam.spawn.utils import is_claude_command, is_codex_command
 
 
 class SubprocessBackend(SpawnBackend):
@@ -30,7 +30,6 @@ class SubprocessBackend(SpawnBackend):
         skip_permissions: bool = False,
     ) -> str:
         spawn_env = os.environ.copy()
-        clawteam_bin = resolve_clawteam_executable()
         spawn_env.update({
             "CLAWTEAM_AGENT_ID": agent_id,
             "CLAWTEAM_AGENT_NAME": agent_name,
@@ -50,9 +49,6 @@ class SubprocessBackend(SpawnBackend):
             spawn_env["CLAWTEAM_WORKSPACE_DIR"] = cwd
         if env:
             spawn_env.update(env)
-        spawn_env["PATH"] = build_spawn_path(spawn_env.get("PATH"))
-        if os.path.isabs(clawteam_bin):
-            spawn_env.setdefault("CLAWTEAM_BIN", clawteam_bin)
 
         normalized_command = normalize_spawn_command(command)
 
@@ -62,9 +58,9 @@ class SubprocessBackend(SpawnBackend):
 
         final_command = list(normalized_command)
         if skip_permissions:
-            if _is_claude_command(normalized_command):
+            if is_claude_command(normalized_command):
                 final_command.append("--dangerously-skip-permissions")
-            elif _is_codex_command(normalized_command):
+            elif is_codex_command(normalized_command):
                 final_command.append("--dangerously-bypass-approvals-and-sandbox")
         if _is_nanobot_command(normalized_command):
             if cwd and not _command_has_workspace_arg(normalized_command):
@@ -72,17 +68,17 @@ class SubprocessBackend(SpawnBackend):
             if prompt:
                 final_command.extend(["-m", prompt])
         elif prompt:
-            if _is_codex_command(normalized_command):
+            if is_codex_command(normalized_command):
                 # Codex accepts prompt as positional argument
                 final_command.append(prompt)
             else:
                 final_command.extend(["-p", prompt])
 
         # Wrap with on-exit hook so task status updates immediately on exit
+        import shlex
         cmd_str = " ".join(shlex.quote(c) for c in final_command)
-        exit_cmd = shlex.quote(clawteam_bin) if os.path.isabs(clawteam_bin) else "clawteam"
         exit_hook = (
-            f"{exit_cmd} lifecycle on-exit --team {shlex.quote(team_name)} "
+            f"clawteam lifecycle on-exit --team {shlex.quote(team_name)} "
             f"--agent {shlex.quote(agent_name)}"
         )
         shell_cmd = f"{cmd_str}; {exit_hook}"
@@ -117,22 +113,6 @@ class SubprocessBackend(SpawnBackend):
             else:
                 self._processes.pop(name, None)
         return result
-
-
-def _is_claude_command(command: list[str]) -> bool:
-    """Check if the command is a claude CLI invocation."""
-    if not command:
-        return False
-    cmd = command[0].rsplit("/", 1)[-1]
-    return cmd in ("claude", "claude-code")
-
-
-def _is_codex_command(command: list[str]) -> bool:
-    """Check if the command is a codex CLI invocation."""
-    if not command:
-        return False
-    cmd = command[0].rsplit("/", 1)[-1]
-    return cmd in ("codex", "codex-cli")
 
 
 def _is_nanobot_command(command: list[str]) -> bool:

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -12,6 +12,7 @@ import time
 from clawteam.spawn.base import SpawnBackend
 from clawteam.spawn.cli_env import build_spawn_path, resolve_clawteam_executable
 from clawteam.spawn.command_validation import normalize_spawn_command, validate_spawn_command
+from clawteam.spawn.utils import is_claude_command, is_codex_command
 
 
 class TmuxBackend(SpawnBackend):
@@ -40,7 +41,6 @@ class TmuxBackend(SpawnBackend):
             return "Error: tmux not installed"
 
         session_name = f"clawteam-{team_name}"
-        clawteam_bin = resolve_clawteam_executable()
         env_vars = {
             "CLAWTEAM_AGENT_ID": agent_id,
             "CLAWTEAM_AGENT_NAME": agent_name,
@@ -60,9 +60,6 @@ class TmuxBackend(SpawnBackend):
             env_vars["CLAWTEAM_WORKSPACE_DIR"] = cwd
         if env:
             env_vars.update(env)
-        env_vars["PATH"] = build_spawn_path(env_vars.get("PATH", os.environ.get("PATH")))
-        if os.path.isabs(clawteam_bin):
-            env_vars.setdefault("CLAWTEAM_BIN", clawteam_bin)
 
         normalized_command = normalize_spawn_command(command)
 
@@ -75,9 +72,9 @@ class TmuxBackend(SpawnBackend):
         # Build the command (without prompt — we'll send it via send-keys)
         final_command = list(normalized_command)
         if skip_permissions:
-            if _is_claude_command(normalized_command):
+            if is_claude_command(normalized_command):
                 final_command.append("--dangerously-skip-permissions")
-            elif _is_codex_command(normalized_command):
+            elif is_codex_command(normalized_command):
                 final_command.append("--dangerously-bypass-approvals-and-sandbox")
 
         if _is_nanobot_command(normalized_command):
@@ -85,21 +82,20 @@ class TmuxBackend(SpawnBackend):
                 final_command.extend(["-w", cwd])
             if prompt:
                 final_command.extend(["-m", prompt])
-        elif prompt and _is_codex_command(normalized_command):
+        elif prompt and is_codex_command(normalized_command):
             final_command.append(prompt)
 
         cmd_str = " ".join(shlex.quote(c) for c in final_command)
         # Append on-exit hook: runs immediately when agent process exits
-        exit_cmd = shlex.quote(clawteam_bin) if os.path.isabs(clawteam_bin) else "clawteam"
         exit_hook = (
-            f"{exit_cmd} lifecycle on-exit --team {shlex.quote(team_name)} "
+            f"clawteam lifecycle on-exit --team {shlex.quote(team_name)} "
             f"--agent {shlex.quote(agent_name)}"
         )
         # Unset Claude nesting-detection env vars so spawned claude agents
         # don't refuse to start when the leader is itself a claude session.
         unset_clause = "unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION 2>/dev/null; "
         if cwd:
-            full_cmd = f"{unset_clause}{export_str}; cd {shlex.quote(cwd)} && {cmd_str}; {exit_hook}"
+            full_cmd = f"{unset_clause}cd {shlex.quote(cwd)} && {export_str}; {cmd_str}; {exit_hook}"
         else:
             full_cmd = f"{unset_clause}{export_str}; {cmd_str}; {exit_hook}"
 
@@ -146,7 +142,7 @@ class TmuxBackend(SpawnBackend):
 
         # Send the prompt as input to the interactive claude session
         # (codex prompt is passed as positional arg above, so skip here)
-        if prompt and _is_claude_command(normalized_command):
+        if prompt and is_claude_command(normalized_command):
             # Wait briefly for claude to start up
             time.sleep(2)
             # Write prompt to a temp file and use load-buffer + paste-buffer
@@ -186,7 +182,7 @@ class TmuxBackend(SpawnBackend):
                 stderr=subprocess.PIPE,
             )
             os.unlink(tmp_path)
-        elif prompt and not _is_codex_command(normalized_command) and not _is_nanobot_command(normalized_command):
+        elif prompt and not is_codex_command(normalized_command) and not _is_nanobot_command(normalized_command):
             time.sleep(1)
             subprocess.run(
                 ["tmux", "send-keys", "-t", target, prompt, "Enter"],
@@ -300,22 +296,6 @@ class TmuxBackend(SpawnBackend):
         return result
 
 
-def _is_claude_command(command: list[str]) -> bool:
-    """Check if the command is a claude CLI invocation."""
-    if not command:
-        return False
-    cmd = command[0].rsplit("/", 1)[-1]  # basename
-    return cmd in ("claude", "claude-code")
-
-
-def _is_codex_command(command: list[str]) -> bool:
-    """Check if the command is a codex CLI invocation."""
-    if not command:
-        return False
-    cmd = command[0].rsplit("/", 1)[-1]  # basename
-    return cmd in ("codex", "codex-cli")
-
-
 def _is_nanobot_command(command: list[str]) -> bool:
     """Check if the command is a nanobot CLI invocation."""
     if not command:
@@ -342,7 +322,7 @@ def _confirm_workspace_trust_if_prompted(
     injection and accept it with a single Enter so the interactive TUI remains
     intact.
     """
-    if not (_is_claude_command(command) or _is_codex_command(command)):
+    if not (is_claude_command(command) or is_codex_command(command)):
         return False
 
     deadline = time.monotonic() + timeout_seconds
@@ -372,10 +352,10 @@ def _looks_like_workspace_trust_prompt(command: list[str], pane_text: str) -> bo
     if not pane_text:
         return False
 
-    if _is_claude_command(command):
+    if is_claude_command(command):
         return "trust this folder" in pane_text and "enter to confirm" in pane_text
 
-    if _is_codex_command(command):
+    if is_codex_command(command):
         return (
             "trust the contents of this directory" in pane_text
             and "press enter to continue" in pane_text
@@ -386,4 +366,4 @@ def _looks_like_workspace_trust_prompt(command: list[str], pane_text: str) -> bo
 
 def _is_interactive_cli(command: list[str]) -> bool:
     """Check if the command is an interactive AI CLI."""
-    return _is_claude_command(command) or _is_codex_command(command) or _is_nanobot_command(command)
+    return is_claude_command(command) or is_codex_command(command) or _is_nanobot_command(command)

--- a/clawteam/spawn/utils.py
+++ b/clawteam/spawn/utils.py
@@ -1,0 +1,24 @@
+"""Shared utilities for spawn backends."""
+
+from __future__ import annotations
+
+
+def is_claude_command(command: list[str]) -> bool:
+    """Check if the command is a claude CLI invocation."""
+    if not command:
+        return False
+    cmd = command[0].rsplit("/", 1)[-1]  # basename
+    return cmd in ("claude", "claude-code")
+
+
+def is_codex_command(command: list[str]) -> bool:
+    """Check if the command is a codex CLI invocation."""
+    if not command:
+        return False
+    cmd = command[0].rsplit("/", 1)[-1]  # basename
+    return cmd in ("codex", "codex-cli")
+
+
+def is_interactive_cli(command: list[str]) -> bool:
+    """Check if the command is an interactive AI CLI (claude or codex)."""
+    return is_claude_command(command) or is_codex_command(command)

--- a/clawteam/team/models.py
+++ b/clawteam/team/models.py
@@ -40,6 +40,15 @@ class TaskStatus(str, Enum):
     blocked = "blocked"
 
 
+class TaskPriority(str, Enum):
+    """Task priority levels for ordering work."""
+
+    low = "low"
+    medium = "medium"
+    high = "high"
+    urgent = "urgent"
+
+
 class MessageType(str, Enum):
     message = "message"
     join_request = "join_request"
@@ -123,6 +132,7 @@ class TaskItem(BaseModel):
     subject: str
     description: str = ""
     status: TaskStatus = TaskStatus.pending
+    priority: TaskPriority = TaskPriority.medium
     owner: str = ""
     locked_by: str = Field(default="", alias="lockedBy")
     locked_at: str = Field(default="", alias="lockedAt")

--- a/clawteam/team/tasks.py
+++ b/clawteam/team/tasks.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-import fcntl
 import json
-import os
-import tempfile
-from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from clawteam.team.models import TaskItem, TaskStatus, get_data_dir
+from clawteam.team.models import TaskItem, TaskPriority, TaskStatus, get_data_dir
 
 
 class TaskLockError(Exception):
@@ -28,10 +24,6 @@ def _task_path(team_name: str, task_id: str) -> Path:
     return _tasks_root(team_name) / f"task-{task_id}.json"
 
 
-def _tasks_lock_path(team_name: str) -> Path:
-    return _tasks_root(team_name) / ".tasks.lock"
-
-
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -46,22 +38,12 @@ class TaskStore:
     def __init__(self, team_name: str):
         self.team_name = team_name
 
-    @contextmanager
-    def _write_lock(self):
-        lock_path = _tasks_lock_path(self.team_name)
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-        with lock_path.open("a+", encoding="utf-8") as lock_file:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-            try:
-                yield
-            finally:
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-
     def create(
         self,
         subject: str,
         description: str = "",
         owner: str = "",
+        priority: TaskPriority | None = None,
         blocks: list[str] | None = None,
         blocked_by: list[str] | None = None,
         metadata: dict[str, Any] | None = None,
@@ -70,20 +52,17 @@ class TaskStore:
             subject=subject,
             description=description,
             owner=owner,
+            priority=priority or TaskPriority.medium,
             blocks=blocks or [],
             blocked_by=blocked_by or [],
             metadata=metadata or {},
         )
         if task.blocked_by:
             task.status = TaskStatus.blocked
-        with self._write_lock():
-            self._save_unlocked(task)
+        self._save(task)
         return task
 
     def get(self, task_id: str) -> TaskItem | None:
-        return self._get_unlocked(task_id)
-
-    def _get_unlocked(self, task_id: str) -> TaskItem | None:
         path = _task_path(self.team_name, task_id)
         if not path.exists():
             return None
@@ -100,63 +79,65 @@ class TaskStore:
         owner: str | None = None,
         subject: str | None = None,
         description: str | None = None,
+        priority: TaskPriority | None = None,
         add_blocks: list[str] | None = None,
         add_blocked_by: list[str] | None = None,
         metadata: dict[str, Any] | None = None,
         caller: str = "",
         force: bool = False,
     ) -> TaskItem | None:
-        with self._write_lock():
-            task = self._get_unlocked(task_id)
-            if not task:
-                return None
+        task = self.get(task_id)
+        if not task:
+            return None
 
-            # Lock logic when transitioning to in_progress
-            if status == TaskStatus.in_progress:
-                self._acquire_lock(task, caller, force)
-                # Record when work actually started
-                if not task.started_at:
-                    task.started_at = _now_iso()
+        # Lock logic when transitioning to in_progress
+        if status == TaskStatus.in_progress:
+            self._acquire_lock(task, caller, force)
+            # Record when work actually started
+            if not task.started_at:
+                task.started_at = _now_iso()
 
-            # Clear lock when transitioning to completed or pending
-            if status in (TaskStatus.completed, TaskStatus.pending):
-                task.locked_by = ""
-                task.locked_at = ""
+        # Clear lock when transitioning to completed or pending
+        if status in (TaskStatus.completed, TaskStatus.pending):
+            task.locked_by = ""
+            task.locked_at = ""
 
-            # Compute duration when completing a task that has a start time
-            if status == TaskStatus.completed and task.started_at:
-                try:
-                    start = datetime.fromisoformat(task.started_at)
-                    duration_secs = (datetime.now(timezone.utc) - start).total_seconds()
-                    task.metadata["duration_seconds"] = round(duration_secs, 2)
-                except (ValueError, TypeError):
-                    pass  # malformed timestamp, skip
+        # Compute duration when completing a task that has a start time
+        if status == TaskStatus.completed and task.started_at:
+            try:
+                start = datetime.fromisoformat(task.started_at)
+                duration_secs = (datetime.now(timezone.utc) - start).total_seconds()
+                task.metadata["duration_seconds"] = round(duration_secs, 2)
+            except (ValueError, TypeError):
+                pass  # malformed timestamp, skip
 
-            if status is not None:
-                task.status = status
-            if owner is not None:
-                task.owner = owner
-            if subject is not None:
-                task.subject = subject
-            if description is not None:
-                task.description = description
-            if add_blocks:
-                for b in add_blocks:
-                    if b not in task.blocks:
-                        task.blocks.append(b)
-            if add_blocked_by:
-                for b in add_blocked_by:
-                    if b not in task.blocked_by:
-                        task.blocked_by.append(b)
-            if metadata:
-                task.metadata.update(metadata)
-            task.updated_at = _now_iso()
+        if status is not None:
+            task.status = status
+        if owner is not None:
+            task.owner = owner
+        if subject is not None:
+            task.subject = subject
+        if description is not None:
+            task.description = description
+        if priority is not None:
+            task.priority = priority
+        if add_blocks:
+            for b in add_blocks:
+                if b not in task.blocks:
+                    task.blocks.append(b)
+        if add_blocked_by:
+            for b in add_blocked_by:
+                if b not in task.blocked_by:
+                    task.blocked_by.append(b)
+        if metadata:
+            task.metadata.update(metadata)
+        task.updated_at = _now_iso()
 
-            if task.status == TaskStatus.completed:
-                self._resolve_dependents_unlocked(task_id)
+        if task.status == TaskStatus.completed:
+            self._resolve_dependents(task_id)
 
-            self._save_unlocked(task)
-            return task
+        self._save(task)
+        return task
 
     def _acquire_lock(self, task: TaskItem, caller: str, force: bool) -> None:
         """Acquire lock on a task for the caller agent."""
@@ -183,27 +164,36 @@ class TaskStore:
         from clawteam.spawn.registry import is_agent_alive
 
         released = []
-        with self._write_lock():
-            for task in self._list_tasks_unlocked():
-                if not task.locked_by:
-                    continue
-                alive = is_agent_alive(self.team_name, task.locked_by)
-                if alive is False:
-                    task.locked_by = ""
-                    task.locked_at = ""
-                    task.updated_at = _now_iso()
-                    self._save_unlocked(task)
-                    released.append(task.id)
+        for task in self.list_tasks():
+            if not task.locked_by:
+                continue
+            alive = is_agent_alive(self.team_name, task.locked_by)
+            if alive is False:
+                task.locked_by = ""
+                task.locked_at = ""
+                task.updated_at = _now_iso()
+                self._save(task)
+                released.append(task.id)
         return released
 
     def list_tasks(
-        self, status: TaskStatus | None = None, owner: str | None = None
+        self,
+        status: TaskStatus | None = None,
+        owner: str | None = None,
+        priority: TaskPriority | None = None,
+        sort_by_priority: bool = False,
     ) -> list[TaskItem]:
-        return self._list_tasks_unlocked(status=status, owner=owner)
+        """List tasks with optional filtering and priority sorting.
 
-    def _list_tasks_unlocked(
-        self, status: TaskStatus | None = None, owner: str | None = None
-    ) -> list[TaskItem]:
+        Args:
+            status: Filter by task status
+            owner: Filter by owner
+            priority: Filter by priority level
+            sort_by_priority: If True, sort by priority (urgent > high > medium > low)
+
+        Returns:
+            List of matching tasks
+        """
         root = _tasks_root(self.team_name)
         tasks = []
         for f in sorted(root.glob("task-*.json")):
@@ -214,9 +204,21 @@ class TaskStore:
                     continue
                 if owner and task.owner != owner:
                     continue
+                if priority and task.priority != priority:
+                    continue
                 tasks.append(task)
             except Exception:
                 continue
+
+        if sort_by_priority:
+            priority_order = {
+                TaskPriority.urgent: 0,
+                TaskPriority.high: 1,
+                TaskPriority.medium: 2,
+                TaskPriority.low: 3,
+            }
+            tasks.sort(key=lambda t: priority_order.get(t.priority, 2))
+
         return tasks
 
     def get_stats(self) -> dict[str, Any]:
@@ -243,23 +245,16 @@ class TaskStore:
             "avg_duration_seconds": round(avg_duration, 2),
         }
 
-    def _save_unlocked(self, task: TaskItem) -> None:
+    def _save(self, task: TaskItem) -> None:
         path = _task_path(self.team_name, task.id)
         path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp_name = tempfile.mkstemp(
-            dir=path.parent,
-            prefix=f"{path.stem}-",
-            suffix=".tmp",
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(
+            task.model_dump_json(indent=2, by_alias=True), encoding="utf-8"
         )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
-                tmp_file.write(task.model_dump_json(indent=2, by_alias=True))
-            Path(tmp_name).replace(path)
-        except BaseException:
-            Path(tmp_name).unlink(missing_ok=True)
-            raise
+        tmp.rename(path)
 
-    def _resolve_dependents_unlocked(self, completed_task_id: str) -> None:
+    def _resolve_dependents(self, completed_task_id: str) -> None:
         root = _tasks_root(self.team_name)
         for f in root.glob("task-*.json"):
             try:
@@ -270,6 +265,6 @@ class TaskStore:
                     if not task.blocked_by and task.status == TaskStatus.blocked:
                         task.status = TaskStatus.pending
                     task.updated_at = _now_iso()
-                    self._save_unlocked(task)
+                    self._save(task)
             except Exception:
                 continue

--- a/clawteam/templates/software-dev.toml
+++ b/clawteam/templates/software-dev.toml
@@ -1,0 +1,123 @@
+[template]
+name = "software-dev"
+description = "Software Development Team - multi-agent full-stack development with parallel workstreams"
+command = ["claude"]
+backend = "tmux"
+
+[template.leader]
+name = "tech-lead"
+type = "tech-lead"
+task = """You are the Technical Lead and team coordinator for a software development project.
+Your goal: {goal}
+
+Your responsibilities:
+1. Break down the project into manageable tasks using `clawteam task create {team_name} "Task description" -o [assignee]`
+2. Set up task dependencies using `--blocked-by` for sequential work
+3. Coordinate between frontend, backend, and QA engineers
+4. Review code quality and architectural decisions
+5. Monitor progress via `clawteam board show {team_name}`
+6. Merge completed work via `clawteam workspace merge {team_name} --agent [agent]`
+
+Workflow:
+1. Create initial task breakdown with dependencies
+2. Spawn worker agents for parallel workstreams
+3. Monitor task completion and unblock dependencies
+4. Review and integrate completed work
+5. Report final status to user
+
+Use `clawteam inbox receive {team_name}` to get updates from team members."""
+
+[[template.agents]]
+name = "backend-dev"
+type = "backend-developer"
+task = """You are a Backend Developer. Implement server-side logic and APIs.
+The team goal is: {goal}
+
+Your responsibilities:
+- Design and implement RESTful APIs
+- Database schema and queries
+- Business logic and data validation
+- Authentication and authorization
+- Performance optimization
+
+Check your tasks: `clawteam task list {team_name} --owner {agent_name}`
+Start working: `clawteam task update {team_name} [task-id] --status in_progress`
+When done: `clawteam task update {team_name} [task-id] --status completed`
+Report issues to tech-lead: `clawteam inbox send {team_name} tech-lead "Issue: [description]"`
+Checkpoint your work: `clawteam workspace checkpoint {team_name} --agent {agent_name}`"""
+
+[[template.agents]]
+name = "frontend-dev"
+type = "frontend-developer"
+task = """You are a Frontend Developer. Implement user interfaces and client-side logic.
+The team goal is: {goal}
+
+Your responsibilities:
+- Implement responsive UI components
+- Client-side state management
+- API integration and data fetching
+- User experience optimization
+- Cross-browser compatibility
+
+Check your tasks: `clawteam task list {team_name} --owner {agent_name}`
+Start working: `clawteam task update {team_name} [task-id] --status in_progress`
+When done: `clawteam task update {team_name} [task-id] --status completed`
+Report issues to tech-lead: `clawteam inbox send {team_name} tech-lead "Issue: [description]"`
+Checkpoint your work: `clawteam workspace checkpoint {team_name} --agent {agent_name}`"""
+
+[[template.agents]]
+name = "qa-engineer"
+type = "qa-engineer"
+task = """You are a QA Engineer. Ensure software quality through testing.
+The team goal is: {goal}
+
+Your responsibilities:
+- Write unit tests and integration tests
+- Perform code review for test coverage
+- Identify and report bugs
+- Verify bug fixes
+- Document test cases
+
+Check your tasks: `clawteam task list {team_name} --owner {agent_name}`
+Start working: `clawteam task update {team_name} [task-id] --status in_progress`
+When done: `clawteam task update {team_name} [task-id] --status completed`
+Report bugs to tech-lead: `clawteam inbox send {team_name} tech-lead "BUG: [description]"`
+Verify fixes: `clawteam inbox send {team_name} tech-lead "VERIFIED: [bug-id]"`"""
+
+[[template.agents]]
+name = "devops"
+type = "devops-engineer"
+task = """You are a DevOps Engineer. Handle deployment and infrastructure.
+The team goal is: {goal}
+
+Your responsibilities:
+- Set up CI/CD pipelines
+- Configure deployment environments
+- Infrastructure as code
+- Monitoring and logging setup
+- Security configurations
+
+Check your tasks: `clawteam task list {team_name} --owner {agent_name}`
+Start working: `clawteam task update {team_name} [task-id] --status in_progress`
+When done: `clawteam task update {team_name} [task-id] --status completed`
+Report status to tech-lead: `clawteam inbox send {team_name} tech-lead "DEPLOY: [environment] - [status]"`"""
+
+[[template.tasks]]
+subject = "Create technical specification and task breakdown"
+owner = "tech-lead"
+
+[[template.tasks]]
+subject = "Design and implement backend API endpoints"
+owner = "backend-dev"
+
+[[template.tasks]]
+subject = "Implement frontend UI components"
+owner = "frontend-dev"
+
+[[template.tasks]]
+subject = "Write unit and integration tests"
+owner = "qa-engineer"
+
+[[template.tasks]]
+subject = "Set up CI/CD pipeline"
+owner = "devops"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clawteam"
-version = "0.1.2"
+version = "0.1.3"
 description = "Framework-agnostic multi-agent coordination CLI"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
- Add TaskPriority enum (low, medium, high, urgent) for task ordering
- Add --priority/-p option to task create/update/list commands
- Add --sort-priority option to list tasks by priority
- Refactor duplicate code: extract is_claude_command, is_codex_command into shared clawteam/spawn/utils.py module
- Add software-dev.toml template for full-stack development teams
- Bump version to 0.1.3