### PR TITLE
Fix broken OpenClaw links and nanobot markdown syntax in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 Human provides the goal. The Agent Team orchestrates everything else.
 
-Full compatibility with [Claude Code](https://claude.ai/claude-code), [Codex](https://openai.com/codex), [OpenClaw](https://github.com/nicepkg/OpenClaw), [nanobot]([https://github.com/HKUDS/nanobot](https://github.com/HKUDS/nanobot)), [Cursor](https://cursor.com), and any CLI agent.&nbsp;&nbsp;[**中文文档**](README_CN.md) | [**한국어**](README_KR.md)
+Full compatibility with [Claude Code](https://claude.ai/claude-code), [Codex](https://openai.com/codex), [OpenClaw](https://github.com/openclaw/openclaw), [nanobot](https://github.com/HKUDS/nanobot), [Cursor](https://cursor.com), and any CLI agent.&nbsp;&nbsp;[**中文文档**](README_CN.md) | [**한국어**](README_KR.md)
 
 ---
 
@@ -391,7 +391,7 @@ ClawTeam works with **any CLI agent** that can execute shell commands:
 |-------|--------------|--------|
 | [Claude Code](https://claude.ai/claude-code) | `clawteam spawn tmux claude --team ...` | ✅ Full support |
 | [Codex](https://openai.com/codex) | `clawteam spawn tmux codex --team ...` | ✅ Full support |
-| [OpenClaw](https://github.com/nicepkg/OpenClaw) | `clawteam spawn tmux openclaw --team ...` | ✅ Full support |
+| [OpenClaw](https://github.com/openclaw/openclaw) | `clawteam spawn tmux openclaw --team ...` | ✅ Full support |
 | [nanobot](https://github.com/HKUDS/nanobot) | `clawteam spawn tmux nanobot --team ...` | ✅ Full support |
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | 🔮 Experimental |
 | Custom scripts | `clawteam spawn subprocess python --team ...` | ✅ Full support |

--- a/README_CN.md
+++ b/README_CN.md
@@ -21,7 +21,7 @@
   <a href="https://github.com/HKUDS/.github/blob/main/profile/README.md"><img src="https://img.shields.io/badge/微信-交流群-C5EAB4?style=flat&logo=wechat&logoColor=white" alt="WeChat"></a>
 </p>
 
-**一行命令**：给 Agent 一个目标，它自动组建团队完成任务。支持 [Claude Code](https://claude.ai/claude-code)、[Codex](https://openai.com/codex)、[OpenClaw](https://github.com/nicepkg/OpenClaw)、[nanobot](https://github.com/HKUDS/nanobot)、[Cursor](https://cursor.com) 及任意 CLI Agent。&nbsp;&nbsp;[**English**](README.md)
+**一行命令**：给 Agent 一个目标，它自动组建团队完成任务。支持 [Claude Code](https://claude.ai/claude-code)、[Codex](https://openai.com/codex)、[OpenClaw](https://github.com/openclaw/openclaw)、[nanobot](https://github.com/HKUDS/nanobot)、[Cursor](https://cursor.com) 及任意 CLI Agent。&nbsp;&nbsp;[**English**](README.md)
 
 <p align="center">
   <img src="assets/teaser.png" alt="ClawTeam - Agent 群体智能" width="800">
@@ -334,7 +334,7 @@ clawteam board attach my-team
 |-------|---------|------|
 | [Claude Code](https://claude.ai/claude-code) | `clawteam spawn tmux claude --team ...` | ✅ 完全支持 |
 | [Codex](https://openai.com/codex) | `clawteam spawn tmux codex --team ...` | ✅ 完全支持 |
-| [OpenClaw](https://github.com/nicepkg/OpenClaw) | `clawteam spawn tmux openclaw --team ...` | ✅ 完全支持 |
+| [OpenClaw](https://github.com/openclaw/openclaw) | `clawteam spawn tmux openclaw --team ...` | ✅ 完全支持 |
 | [nanobot](https://github.com/HKUDS/nanobot) | `clawteam spawn tmux nanobot --team ...` | ✅ 完全支持 |
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | 🔮 实验性 |
 | 自定义脚本 | `clawteam spawn subprocess python --team ...` | ✅ 完全支持 |

--- a/README_KR.md
+++ b/README_KR.md
@@ -25,7 +25,7 @@
 
 사람은 목표만 제시하면 됩니다. 나머지는 에이전트 팀이 조율합니다.
 
-[Claude Code](https://claude.ai/claude-code), [Codex](https://openai.com/codex), [OpenClaw](https://github.com/nicepkg/OpenClaw), [nanobot](https://github.com/HKUDS/nanobot), [Cursor](https://cursor.com) 그리고 각종 CLI 에이전트와 폭넓게 호환됩니다.&nbsp;&nbsp;[**English**](README.md) | [**中文文档**](README_CN.md)
+[Claude Code](https://claude.ai/claude-code), [Codex](https://openai.com/codex), [OpenClaw](https://github.com/openclaw/openclaw), [nanobot](https://github.com/HKUDS/nanobot), [Cursor](https://cursor.com) 그리고 각종 CLI 에이전트와 폭넓게 호환됩니다.&nbsp;&nbsp;[**English**](README.md) | [**中文文档**](README_CN.md)
 
 <p align="center">
   <img src="assets/teaser.png" alt="ClawTeam - AI agents orchestrating themselves" width="800">
@@ -389,7 +389,7 @@ ClawTeam은 셸 명령을 실행할 수 있는 **어떤 CLI 에이전트**와도
 |-------|--------------|--------|
 | [Claude Code](https://claude.ai/claude-code) | `clawteam spawn tmux claude --team ...` | ✅ 완전 지원 |
 | [Codex](https://openai.com/codex) | `clawteam spawn tmux codex --team ...` | ✅ 완전 지원 |
-| [OpenClaw](https://github.com/nicepkg/OpenClaw) | `clawteam spawn tmux openclaw --team ...` | ✅ 완전 지원 |
+| [OpenClaw](https://github.com/openclaw/openclaw) | `clawteam spawn tmux openclaw --team ...` | ✅ 완전 지원 |
 | [nanobot](https://github.com/HKUDS/nanobot) | `clawteam spawn tmux nanobot --team ...` | ✅ 완전 지원 |
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | 🔮 실험적 |
 | Custom scripts | `clawteam spawn subprocess python --team ...` | ✅ 완전 지원 |


### PR DESCRIPTION
## Summary
- **Fix 404**: OpenClaw link `nicepkg/OpenClaw` no longer exists → updated to `openclaw/openclaw` (6 occurrences across `README.md`, `README_CN.md`, `README_KR.md`)
- **Fix markdown syntax**: nanobot link in `README.md` line 28 had nested markdown `[nanobot]([url](url))` → fixed to `[nanobot](url)`

## Test plan
- [x] Verified `https://github.com/openclaw/openclaw` returns 200
- [x] Verified `https://github.com/nicepkg/OpenClaw` returns 404
- [x] Checked all other external links in READMEs — no other 404s found