### PR TITLE
feat: add strategy-room template

### DIFF
--- a/clawteam/templates/strategy-room.toml
+++ b/clawteam/templates/strategy-room.toml
@@ -1,0 +1,121 @@
+[template]
+name = "strategy-room"
+description = "Cross-functional strategy team for planning, tradeoff analysis, and execution sequencing"
+command = ["claude"]
+backend = "tmux"
+
+[template.leader]
+name = "strategy-lead"
+type = "strategy-lead"
+task = """You are the Strategy Lead coordinating a cross-functional strategy room.
+Your goal: {goal}
+
+Workflow:
+1. Frame the decision or planning problem clearly
+2. Create focused tasks for each specialist via `clawteam task create {team_name} "[task]" -o [member]`
+3. Send context and instructions via `clawteam inbox send {team_name} [member] "[instructions]"`
+4. Monitor progress via `clawteam board show {team_name}`
+5. Wait for the decision-editor's strategy memo
+6. Produce a final recommendation with:
+   - recommended path
+   - rejected alternatives
+   - key risks
+   - execution sequence
+   - next steps
+
+You must not finalize the recommendation until the decision-editor has delivered the memo."""
+
+[[template.agents]]
+name = "systems-analyst"
+type = "systems-analyst"
+task = """You are a Systems Analyst. Evaluate the systems, architecture, and operational implications of the goal.
+The team goal is: {goal}
+
+Your focus:
+- system boundaries and dependencies
+- architectural tradeoffs
+- operational complexity
+- compatibility and migration risks
+- likely bottlenecks
+
+Check your tasks: `clawteam task list {team_name} --owner {agent_name}`
+Send findings to decision-editor:
+`clawteam inbox send {team_name} decision-editor "SYSTEMS: [key constraints, tradeoffs, and implications]"`
+Then update task status: `clawteam task update {team_name} [task-id] --status completed`"""
+
+[[template.agents]]
+name = "delivery-planner"
+type = "delivery-planner"
+task = """You are a Delivery Planner. Turn the goal into a staged execution path.
+The team goal is: {goal}
+
+Your focus:
+- milestone breakdown
+- sequencing and dependencies
+- shortest viable delivery path
+- rollback and fallback points
+- resource and coordination needs
+
+Check your tasks: `clawteam task list {team_name} --owner {agent_name}`
+Send findings to decision-editor:
+`clawteam inbox send {team_name} decision-editor "DELIVERY: [staged plan, priorities, and execution path]"`
+Then update task status: `clawteam task update {team_name} [task-id] --status completed`"""
+
+[[template.agents]]
+name = "risk-mapper"
+type = "risk-mapper"
+task = """You are a Risk Mapper. Identify major risks, blockers, and hidden assumptions.
+The team goal is: {goal}
+
+Your focus:
+- execution risks
+- dependency risks
+- hidden assumptions
+- failure modes
+- mitigation options
+- what should stop or delay execution
+
+Check your tasks: `clawteam task list {team_name} --owner {agent_name}`
+Send findings to decision-editor:
+`clawteam inbox send {team_name} decision-editor "RISK: [risks, blockers, assumptions, and mitigations]"`
+Then update task status: `clawteam task update {team_name} [task-id] --status completed`"""
+
+[[template.agents]]
+name = "decision-editor"
+type = "decision-editor"
+task = """You are the Decision Editor. Consolidate specialist outputs into a decision-ready memo.
+The team goal is: {goal}
+
+Workflow:
+1. Wait for messages from systems-analyst, delivery-planner, and risk-mapper via `clawteam inbox receive {team_name}`
+2. Consolidate them into:
+   - problem framing
+   - options considered
+   - major risks
+   - execution sequence
+   - unresolved assumptions
+3. Send the memo to strategy-lead:
+   `clawteam inbox send {team_name} strategy-lead "MEMO: [decision-ready strategy memo]"`
+4. Update your task status when done
+
+Do not recommend the final path yourself. Your job is to turn specialist output into a decision-ready memo for the strategy-lead."""
+
+[[template.tasks]]
+subject = "Coordinate strategy room and finalize recommendation"
+owner = "strategy-lead"
+
+[[template.tasks]]
+subject = "Analyze system and architecture implications"
+owner = "systems-analyst"
+
+[[template.tasks]]
+subject = "Build staged delivery plan"
+owner = "delivery-planner"
+
+[[template.tasks]]
+subject = "Map risks, blockers, and assumptions"
+owner = "risk-mapper"
+
+[[template.tasks]]
+subject = "Synthesize decision-ready strategy memo"
+owner = "decision-editor"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -88,6 +88,49 @@ class TestLoadBuiltinTemplate:
             if task.owner:
                 assert task.owner in agent_names, f"Task owner '{task.owner}' not in agents"
 
+    def test_load_strategy_room(self):
+        tmpl = load_template("strategy-room")
+        assert tmpl.name == "strategy-room"
+        assert tmpl.leader.name == "strategy-lead"
+        assert len(tmpl.agents) == 4
+        assert len(tmpl.tasks) == 5
+
+    def test_strategy_room_agent_names(self):
+        tmpl = load_template("strategy-room")
+        names = {agent.name for agent in tmpl.agents}
+        assert names == {
+            "systems-analyst",
+            "delivery-planner",
+            "risk-mapper",
+            "decision-editor",
+        }
+
+    def test_strategy_room_task_owners_match_agents(self):
+        tmpl = load_template("strategy-room")
+        agent_names = {tmpl.leader.name} | {a.name for a in tmpl.agents}
+        for task in tmpl.tasks:
+            if task.owner:
+                assert task.owner in agent_names, f"Task owner '{task.owner}' not in agents"
+
+    def test_strategy_room_specialists_route_to_decision_editor(self):
+        tmpl = load_template("strategy-room")
+        for agent in tmpl.agents:
+            if agent.name == "decision-editor":
+                continue
+            assert "decision-editor" in agent.task
+            assert "strategy-lead" not in agent.task
+
+    def test_strategy_room_decision_editor_routes_to_strategy_lead(self):
+        tmpl = load_template("strategy-room")
+        decision_editor = next(agent for agent in tmpl.agents if agent.name == "decision-editor")
+        assert "strategy-lead" in decision_editor.task
+        assert "Do not recommend the final path yourself" in decision_editor.task
+
+    def test_strategy_room_leader_waits_for_decision_editor_memo(self):
+        tmpl = load_template("strategy-room")
+        assert "Wait for the decision-editor's strategy memo" in tmpl.leader.task
+        assert "supporting specialist outputs" not in tmpl.leader.task
+
 
 class TestLoadTemplateNotFound:
     def test_missing_template_raises(self):
@@ -128,6 +171,7 @@ class TestListTemplates:
         templates = list_templates()
         names = {t["name"] for t in templates}
         assert "hedge-fund" in names
+        assert "strategy-room" in names
 
     def test_list_entry_format(self):
         templates = list_templates()


### PR DESCRIPTION
## Summary
This adds a new `strategy-room` template for work that needs planning before execution.

It defines five roles:
- `strategy-lead`
- `systems-analyst`
- `delivery-planner`
- `risk-mapper`
- `decision-editor`

The reporting chain is:
- specialists report to `decision-editor`
- `decision-editor` sends a memo to `strategy-lead`
- `strategy-lead` makes the final recommendation

## What changed
- added `clawteam/templates/strategy-room.toml`
- added template coverage in `tests/test_templates.py`

## Why this template
ClawTeam already ships templates for code review, research writing, and hedge fund analysis. `strategy-room` fills the gap for pre-execution planning and tradeoff work.

Use it for questions like:
- Which path should we take?
- What are the biggest risks?
- What should happen first?
- What should we defer?

## Test plan
- [x] Ran `python -m pytest -q tests/test_templates.py`
- [x] Ran `python -m pytest -q`
- [x] Ran `ruff check clawteam tests`
- [x] Loaded `strategy-room` and verified the expected leader, agents, and tasks
- [x] Verified `clawteam template list` includes `strategy-room`
- [x] Verified the reporting chain: specialists -> `decision-editor` -> `strategy-lead`
