### PR TITLE
feat: add team snapshot/restore for checkpoint and recovery

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -533,6 +533,126 @@ def team_status(
     _output(data, _human)
 
 
+@team_app.command("snapshot")
+def team_snapshot(
+    team: str = typer.Argument(..., help="Team name"),
+    tag: str = typer.Option("", "--tag", "-t", help="Label for this snapshot"),
+):
+    """Save a snapshot of the entire team state (config, tasks, events, sessions, costs)."""
+    from clawteam.team.snapshot import SnapshotManager
+
+    try:
+        meta = SnapshotManager(team).create(tag=tag)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    data = json.loads(meta.model_dump_json(by_alias=True))
+
+    def _human(d):
+        console.print(f"[green]OK[/green] Snapshot [cyan]{d['id']}[/cyan] created")
+        console.print(
+            f"  {d['taskCount']} tasks, {d['eventCount']} events, "
+            f"{d['sessionCount']} sessions, {d['costEventCount']} cost events"
+        )
+
+    _output(data, _human)
+
+
+@team_app.command("snapshots")
+def team_snapshots(
+    team: str = typer.Argument(..., help="Team name"),
+):
+    """List available snapshots for a team."""
+    from clawteam.team.snapshot import SnapshotManager
+
+    snaps = SnapshotManager(team).list_snapshots()
+    data = [json.loads(s.model_dump_json(by_alias=True)) for s in snaps]
+
+    def _human(items):
+        if not items:
+            console.print("[dim]No snapshots found[/dim]")
+            return
+        table = Table(title=f"Snapshots for {team}")
+        table.add_column("ID", style="cyan")
+        table.add_column("Tag")
+        table.add_column("Members", justify="right")
+        table.add_column("Tasks", justify="right")
+        table.add_column("Events", justify="right")
+        table.add_column("Created", style="dim")
+        for s in items:
+            table.add_row(
+                s["id"],
+                s.get("tag", ""),
+                str(s["memberCount"]),
+                str(s["taskCount"]),
+                str(s["eventCount"]),
+                s["createdAt"][:19],
+            )
+        console.print(table)
+
+    _output(data, _human)
+
+
+@team_app.command("restore")
+def team_restore(
+    team: str = typer.Argument(..., help="Team name"),
+    snapshot_id: str = typer.Argument(..., help="Snapshot ID to restore"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without writing"),
+    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+):
+    """Restore team state from a snapshot."""
+    from clawteam.team.snapshot import SnapshotManager
+
+    mgr = SnapshotManager(team)
+
+    try:
+        summary = mgr.restore(snapshot_id, dry_run=True)
+    except ValueError as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+    if dry_run:
+        _output(summary, lambda d: console.print(
+            f"[yellow]Dry run[/yellow] Would restore: "
+            f"{d['tasks']} tasks, {d['events']} events, "
+            f"{d['sessions']} sessions, {d['costs']} costs, "
+            f"{d['inboxes']} inbox messages"
+        ))
+        return
+
+    if not force and not _json_output:
+        console.print(
+            f"Will restore: {summary['tasks']} tasks, {summary['events']} events, "
+            f"{summary['sessions']} sessions, {summary['costs']} costs"
+        )
+        if not typer.confirm("Proceed?"):
+            raise typer.Abort()
+
+    result = mgr.restore(snapshot_id)
+    _output(result, lambda d: console.print(
+        f"[green]OK[/green] Restored from snapshot [cyan]{snapshot_id}[/cyan]"
+    ))
+
+
+@team_app.command("snapshot-delete")
+def team_snapshot_delete(
+    team: str = typer.Argument(..., help="Team name"),
+    snapshot_id: str = typer.Argument(..., help="Snapshot ID to delete"),
+):
+    """Delete a snapshot."""
+    from clawteam.team.snapshot import SnapshotManager
+
+    if SnapshotManager(team).delete(snapshot_id):
+        _output(
+            {"status": "deleted", "id": snapshot_id},
+            lambda d: console.print(f"[green]OK[/green] Snapshot '{snapshot_id}' deleted"),
+        )
+    else:
+        console.print(f"[yellow]Snapshot '{snapshot_id}' not found[/yellow]")
+        raise typer.Exit(1)
+
+
 # ============================================================================
 # Inbox Commands
 # ============================================================================

--- a/clawteam/team/snapshot.py
+++ b/clawteam/team/snapshot.py
@@ -1,0 +1,221 @@
+"""Team state snapshots for checkpoint/restore."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from clawteam.team.models import get_data_dir
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _snapshots_root(team_name: str) -> Path:
+    d = get_data_dir() / "snapshots" / team_name
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+class SnapshotMeta(BaseModel):
+    """Metadata header stored inside each snapshot bundle."""
+
+    model_config = {"populate_by_name": True}
+
+    id: str
+    team_name: str = Field(alias="teamName")
+    tag: str = ""
+    created_at: str = Field(default_factory=_now_iso, alias="createdAt")
+    member_count: int = Field(default=0, alias="memberCount")
+    task_count: int = Field(default=0, alias="taskCount")
+    event_count: int = Field(default=0, alias="eventCount")
+    session_count: int = Field(default=0, alias="sessionCount")
+    cost_event_count: int = Field(default=0, alias="costEventCount")
+
+
+def _read_json_dir(directory: Path, pattern: str) -> list[dict]:
+    if not directory.exists():
+        return []
+    items = []
+    for f in sorted(directory.glob(pattern)):
+        try:
+            items.append(json.loads(f.read_text("utf-8")))
+        except Exception:
+            continue
+    return items
+
+
+class SnapshotManager:
+    """Create and restore full team state snapshots.
+
+    Bundles config, tasks, events, sessions, costs, and pending inbox
+    messages into a single JSON file under ``{data_dir}/snapshots/{team}/``.
+    """
+
+    def __init__(self, team_name: str):
+        self.team_name = team_name
+
+    def _team_dir(self) -> Path:
+        return get_data_dir() / "teams" / self.team_name
+
+    def create(self, tag: str = "") -> SnapshotMeta:
+        """Capture current team state."""
+        data_dir = get_data_dir()
+        team_dir = self._team_dir()
+
+        config_path = team_dir / "config.json"
+        if not config_path.exists():
+            raise ValueError(f"Team '{self.team_name}' not found")
+        config = json.loads(config_path.read_text("utf-8"))
+
+        tasks = _read_json_dir(data_dir / "tasks" / self.team_name, "task-*.json")
+        events = _read_json_dir(team_dir / "events", "evt-*.json")
+        sessions = _read_json_dir(data_dir / "sessions" / self.team_name, "*.json")
+        costs = _read_json_dir(data_dir / "costs" / self.team_name, "cost-*.json")
+
+        # pending inbox messages (not yet consumed)
+        inboxes: dict[str, list[dict]] = {}
+        inbox_root = team_dir / "inboxes"
+        if inbox_root.exists():
+            for agent_dir in sorted(inbox_root.iterdir()):
+                if agent_dir.is_dir():
+                    msgs = _read_json_dir(agent_dir, "msg-*.json")
+                    if msgs:
+                        inboxes[agent_dir.name] = msgs
+
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        snap_id = f"{ts}-{tag}" if tag else ts
+
+        meta = SnapshotMeta(
+            id=snap_id,
+            team_name=self.team_name,
+            tag=tag,
+            member_count=len(config.get("members", [])),
+            task_count=len(tasks),
+            event_count=len(events),
+            session_count=len(sessions),
+            cost_event_count=len(costs),
+        )
+
+        bundle = {
+            "meta": json.loads(meta.model_dump_json(by_alias=True)),
+            "config": config,
+            "tasks": tasks,
+            "events": events,
+            "sessions": sessions,
+            "costs": costs,
+            "inboxes": inboxes,
+        }
+
+        path = _snapshots_root(self.team_name) / f"snap-{snap_id}.json"
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(
+            json.dumps(bundle, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        tmp.rename(path)
+        return meta
+
+    def list_snapshots(self) -> list[SnapshotMeta]:
+        """List available snapshots, newest first."""
+        root = _snapshots_root(self.team_name)
+        out: list[SnapshotMeta] = []
+        for f in sorted(root.glob("snap-*.json"), reverse=True):
+            try:
+                data = json.loads(f.read_text("utf-8"))
+                out.append(SnapshotMeta.model_validate(data["meta"]))
+            except Exception:
+                continue
+        return out
+
+    def load_bundle(self, snapshot_id: str) -> dict[str, Any]:
+        """Load a snapshot bundle from disk."""
+        path = _snapshots_root(self.team_name) / f"snap-{snapshot_id}.json"
+        if not path.exists():
+            raise ValueError(f"Snapshot '{snapshot_id}' not found")
+        return json.loads(path.read_text("utf-8"))
+
+    def restore(self, snapshot_id: str, dry_run: bool = False) -> dict[str, Any]:
+        """Restore team state from a snapshot.
+
+        Returns a summary dict. With dry_run=True nothing is written.
+        """
+        bundle = self.load_bundle(snapshot_id)
+
+        summary: dict[str, Any] = {
+            "snapshot_id": snapshot_id,
+            "dry_run": dry_run,
+            "config": bool(bundle.get("config")),
+            "tasks": len(bundle.get("tasks", [])),
+            "events": len(bundle.get("events", [])),
+            "sessions": len(bundle.get("sessions", [])),
+            "costs": len(bundle.get("costs", [])),
+            "inboxes": sum(len(v) for v in bundle.get("inboxes", {}).values()),
+        }
+        if dry_run:
+            return summary
+
+        data_dir = get_data_dir()
+        team_dir = self._team_dir()
+
+        # config
+        if bundle.get("config"):
+            team_dir.mkdir(parents=True, exist_ok=True)
+            _atomic_write(team_dir / "config.json", bundle["config"])
+
+        # tasks
+        tasks_dir = data_dir / "tasks" / self.team_name
+        tasks_dir.mkdir(parents=True, exist_ok=True)
+        for task in bundle.get("tasks", []):
+            tid = task.get("id", "unknown")
+            _atomic_write(tasks_dir / f"task-{tid}.json", task)
+
+        # events -- restored with sequential names to avoid collisions
+        events_dir = team_dir / "events"
+        events_dir.mkdir(parents=True, exist_ok=True)
+        for i, evt in enumerate(bundle.get("events", [])):
+            _atomic_write(events_dir / f"evt-restored-{i:06d}.json", evt)
+
+        # sessions
+        sessions_dir = data_dir / "sessions" / self.team_name
+        sessions_dir.mkdir(parents=True, exist_ok=True)
+        for sess in bundle.get("sessions", []):
+            name = sess.get("agentName", sess.get("agent_name", "unknown"))
+            _atomic_write(sessions_dir / f"{name}.json", sess)
+
+        # costs
+        costs_dir = data_dir / "costs" / self.team_name
+        costs_dir.mkdir(parents=True, exist_ok=True)
+        for cost in bundle.get("costs", []):
+            cid = cost.get("id", "unknown")
+            ts = cost.get("reportedAt", "x").replace(":", "-").replace("+", "p")
+            _atomic_write(costs_dir / f"cost-{ts}-{cid}.json", cost)
+
+        # inbox messages
+        inbox_root = team_dir / "inboxes"
+        for agent_name, messages in bundle.get("inboxes", {}).items():
+            agent_inbox = inbox_root / agent_name
+            agent_inbox.mkdir(parents=True, exist_ok=True)
+            for j, msg in enumerate(messages):
+                _atomic_write(
+                    agent_inbox / f"msg-restored-{j:06d}.json", msg
+                )
+
+        return summary
+
+    def delete(self, snapshot_id: str) -> bool:
+        path = _snapshots_root(self.team_name) / f"snap-{snapshot_id}.json"
+        if path.exists():
+            path.unlink()
+            return True
+        return False
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    tmp.rename(path)

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,0 +1,212 @@
+"""Tests for clawteam.team.snapshot — team state checkpoint/restore."""
+
+import json
+
+import pytest
+
+from clawteam.team.costs import CostStore
+from clawteam.team.manager import TeamManager
+from clawteam.team.models import get_data_dir
+from clawteam.team.snapshot import SnapshotManager, SnapshotMeta, _snapshots_root
+from clawteam.team.tasks import TaskStore
+
+
+def _setup_team(team_name: str) -> None:
+    """Create a team with some state to snapshot."""
+    TeamManager.create_team(
+        name=team_name,
+        leader_name="leader",
+        leader_id="lid001",
+        description="snapshot test team",
+    )
+
+
+@pytest.fixture
+def team_with_data(team_name):
+    """A team with tasks, costs, and an event log entry."""
+    _setup_team(team_name)
+
+    ts = TaskStore(team_name)
+    ts.create("task one", owner="leader")
+    ts.create("task two", owner="worker")
+
+    cs = CostStore(team_name)
+    cs.report("leader", provider="openai", model="gpt-4", cost_cents=12.5)
+
+    # drop a message into the event log via mailbox
+    from clawteam.team.mailbox import MailboxManager
+    mb = MailboxManager(team_name)
+    mb.send("leader", "leader", content="hello from leader")
+
+    return team_name
+
+
+class TestSnapshotCreate:
+    def test_basic(self, team_with_data):
+        mgr = SnapshotManager(team_with_data)
+        meta = mgr.create()
+        assert isinstance(meta, SnapshotMeta)
+        assert meta.team_name == team_with_data
+        assert meta.member_count == 1
+        assert meta.task_count == 2
+        assert meta.cost_event_count == 1
+        assert meta.event_count >= 1
+
+    def test_with_tag(self, team_with_data):
+        meta = SnapshotManager(team_with_data).create(tag="before-deploy")
+        assert meta.tag == "before-deploy"
+        assert "before-deploy" in meta.id
+
+    def test_snapshot_file_written(self, team_with_data):
+        meta = SnapshotManager(team_with_data).create()
+        path = _snapshots_root(team_with_data) / f"snap-{meta.id}.json"
+        assert path.exists()
+        bundle = json.loads(path.read_text("utf-8"))
+        assert "meta" in bundle
+        assert "config" in bundle
+        assert "tasks" in bundle
+        assert len(bundle["tasks"]) == 2
+
+    def test_nonexistent_team(self, team_name):
+        with pytest.raises(ValueError, match="not found"):
+            SnapshotManager("no-such-team").create()
+
+    def test_captures_inbox_messages(self, team_with_data):
+        # send a message that stays in inbox (don't consume it)
+        from clawteam.team.mailbox import MailboxManager
+        mb = MailboxManager(team_with_data)
+        mb.send("leader", "leader", content="pending msg")
+
+        meta = SnapshotManager(team_with_data).create()
+        path = _snapshots_root(team_with_data) / f"snap-{meta.id}.json"
+        bundle = json.loads(path.read_text("utf-8"))
+        # should have captured the inbox messages
+        total_inbox = sum(len(v) for v in bundle["inboxes"].values())
+        assert total_inbox >= 1
+
+
+class TestSnapshotList:
+    def test_empty(self, team_name):
+        _setup_team(team_name)
+        assert SnapshotManager(team_name).list_snapshots() == []
+
+    def test_lists_created(self, team_with_data):
+        mgr = SnapshotManager(team_with_data)
+        mgr.create(tag="first")
+        mgr.create(tag="second")
+        snaps = mgr.list_snapshots()
+        assert len(snaps) == 2
+        # newest first
+        assert snaps[0].tag == "second"
+        assert snaps[1].tag == "first"
+
+
+class TestSnapshotRestore:
+    def test_dry_run(self, team_with_data):
+        mgr = SnapshotManager(team_with_data)
+        meta = mgr.create()
+        summary = mgr.restore(meta.id, dry_run=True)
+        assert summary["dry_run"] is True
+        assert summary["tasks"] == 2
+        assert summary["config"] is True
+
+    def test_restore_tasks(self, team_with_data):
+        mgr = SnapshotManager(team_with_data)
+        meta = mgr.create(tag="checkpoint")
+
+        # wipe the tasks
+        ts = TaskStore(team_with_data)
+        data_dir = get_data_dir()
+        tasks_dir = data_dir / "tasks" / team_with_data
+        for f in tasks_dir.glob("task-*.json"):
+            f.unlink()
+        assert ts.list_tasks() == []
+
+        # restore
+        summary = mgr.restore(meta.id)
+        assert summary["dry_run"] is False
+        assert summary["tasks"] == 2
+        restored = ts.list_tasks()
+        assert len(restored) == 2
+
+    def test_restore_config(self, team_with_data):
+        mgr = SnapshotManager(team_with_data)
+        meta = mgr.create()
+
+        # overwrite the config
+        team_dir = get_data_dir() / "teams" / team_with_data
+        (team_dir / "config.json").write_text('{"name": "broken"}')
+
+        mgr.restore(meta.id)
+        cfg = TeamManager.get_team(team_with_data)
+        assert cfg is not None
+        assert cfg.description == "snapshot test team"
+
+    def test_restore_events(self, team_with_data):
+        mgr = SnapshotManager(team_with_data)
+        meta = mgr.create()
+
+        # wipe events
+        events_dir = get_data_dir() / "teams" / team_with_data / "events"
+        for f in events_dir.glob("evt-*.json"):
+            f.unlink()
+
+        summary = mgr.restore(meta.id)
+        assert summary["events"] >= 1
+        restored_files = list(events_dir.glob("evt-*.json"))
+        assert len(restored_files) >= 1
+
+    def test_restore_nonexistent_snapshot(self, team_with_data):
+        with pytest.raises(ValueError, match="not found"):
+            SnapshotManager(team_with_data).restore("nope")
+
+    def test_restore_costs(self, team_with_data):
+        mgr = SnapshotManager(team_with_data)
+        meta = mgr.create()
+
+        # wipe costs
+        costs_dir = get_data_dir() / "costs" / team_with_data
+        for f in costs_dir.glob("cost-*.json"):
+            f.unlink()
+        assert CostStore(team_with_data).list_events() == []
+
+        mgr.restore(meta.id)
+        assert len(CostStore(team_with_data).list_events()) == 1
+
+
+class TestSnapshotDelete:
+    def test_delete_existing(self, team_with_data):
+        mgr = SnapshotManager(team_with_data)
+        meta = mgr.create()
+        assert mgr.delete(meta.id) is True
+        assert mgr.list_snapshots() == []
+
+    def test_delete_nonexistent(self, team_with_data):
+        assert SnapshotManager(team_with_data).delete("nope") is False
+
+
+class TestSnapshotRoundTrip:
+    """End-to-end: create → snapshot → cleanup → restore → verify."""
+
+    def test_full_cycle(self, team_name):
+        _setup_team(team_name)
+        ts = TaskStore(team_name)
+        ts.create("important task", owner="leader", metadata={"key": "val"})
+
+        mgr = SnapshotManager(team_name)
+        meta = mgr.create(tag="full-cycle")
+
+        # nuke everything except the snapshot
+        TeamManager.cleanup(team_name)
+        assert TeamManager.get_team(team_name) is None
+
+        # restore
+        mgr.restore(meta.id)
+        cfg = TeamManager.get_team(team_name)
+        assert cfg is not None
+        assert cfg.name == team_name
+
+        tasks = TaskStore(team_name).list_tasks()
+        assert len(tasks) == 1
+        assert tasks[0].subject == "important task"
+        assert tasks[0].metadata.get("key") == "val"


### PR DESCRIPTION
## Summary

- New `clawteam team snapshot` / `restore` / `snapshots` / `snapshot-delete` commands
- Captures full team state (config, tasks, events, sessions, costs, pending inbox messages) into a single JSON bundle under `{data_dir}/snapshots/{team}/`
- Restore with `--dry-run` to preview before writing, `--force` to skip confirmation
- Atomic writes throughout (tmp + rename), consistent with existing store patterns

## Motivation

Long-running agent swarms need a way to checkpoint and recover. Today, if a session crashes mid-way there's no holistic team-level snapshot — `session save` only covers individual agents. This fills that gap.

## What's included

| File | What |
|------|------|
| `clawteam/team/snapshot.py` | `SnapshotManager` — create, list, restore, delete snapshots |
| `clawteam/cli/commands.py` | 4 new CLI commands under `team` subgroup |
| `tests/test_snapshots.py` | 16 tests: create, list, restore, delete, dry-run, full round-trip |

## Test plan

- [x] `pytest tests/test_snapshots.py` — 16/16 passed
- [x] `pytest tests/` — 151/151 passed (no regressions)
- [x] `ruff check` — clean