### PR TITLE
fix: include nanobot in _is_claude_command for proper prompt handling

### DIFF
--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -301,11 +301,11 @@ class TmuxBackend(SpawnBackend):
 
 
 def _is_claude_command(command: list[str]) -> bool:
-    """Check if the command is a claude CLI invocation."""
+    """Check if the command is a claude CLI invocation (or nanobot which uses similar behavior)."""
     if not command:
         return False
     cmd = command[0].rsplit("/", 1)[-1]  # basename
-    return cmd in ("claude", "claude-code")
+    return cmd in ("claude", "claude-code", "nanobot")
 
 
 def _is_codex_command(command: list[str]) -> bool:


### PR DESCRIPTION
Nanobot requires the 'agent' subcommand to enter interactive mode and needs longer initialization time (1-2 seconds) compared to Claude CLI.

By adding 'nanobot' to _is_claude_command(), nanobot sessions will:
- Use tmux paste-buffer instead of send-keys (more reliable for long prompts)
- Get the 2-second wait time instead of 1-second (safer for nanobot initialization)

This fixes the race condition where prompts were sent while nanobot was still loading, causing prompts to be flushed from TTY buffer.

Closes: #22