### PR TITLE
fix(test): merge conflicting shutil.which mocks in tmux spawn test

### DIFF
--- a/tests/test_spawn_backends.py
+++ b/tests/test_spawn_backends.py
@@ -79,14 +79,17 @@ def test_tmux_backend_exports_spawn_path_for_agent_commands(monkeypatch, tmp_pat
         return Result(returncode=0)
 
     original_which = __import__("shutil").which
-    monkeypatch.setattr(
-        "clawteam.spawn.tmux_backend.shutil.which",
-        lambda name, path=None: "/opt/homebrew/bin/tmux" if name == "tmux" else original_which(name),
-    )
-    monkeypatch.setattr(
-        "clawteam.spawn.command_validation.shutil.which",
-        lambda name, path=None: "/usr/bin/codex" if name == "codex" else original_which(name),
-    )
+
+    def fake_which(name, path=None):
+        if name == "tmux":
+            return "/opt/homebrew/bin/tmux"
+        if name == "codex":
+            return "/usr/bin/codex"
+        return original_which(name)
+
+    # Both modules share the same shutil object, so a single setattr
+    # covers tmux_backend.shutil.which AND command_validation.shutil.which.
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.shutil.which", fake_which)
     monkeypatch.setattr("clawteam.spawn.tmux_backend.subprocess.run", fake_run)
     monkeypatch.setattr("clawteam.spawn.tmux_backend.time.sleep", lambda *_: None)
     monkeypatch.setattr("clawteam.spawn.registry.register_agent", lambda **_: None)


### PR DESCRIPTION
## Problem
`test_tmux_backend_exports_spawn_path_for_agent_commands` is failing on current `main` in recent CI runs after `0d7fa0f`.

The test patches `tmux_backend.shutil.which` and `command_validation.shutil.which` separately, but both names point at the same Python `shutil` module object. The second patch overwrites the first. Under the test's restricted `PATH` (`/usr/bin:/bin`), `shutil.which("tmux")` then falls back to the real implementation and returns `None`. `spawn()` exits early with `Error: tmux not installed`, so the test never reaches `tmux new-session` and ends with `StopIteration`.

## Fix
Replace the two separate `shutil.which` patches with one `fake_which` helper that handles both `tmux` and `codex`, and apply it once.

This is a test-only change. Production code is unchanged.

## Test Plan
- Reproduced the failure on an `origin/main` checkout:
  `/Users/huluobo/workSpace/ClawTeam/.venv/bin/python -m pytest tests/test_spawn_backends.py::test_tmux_backend_exports_spawn_path_for_agent_commands -v --tb=short`
  Fails with `StopIteration`
- `uv run python -m pytest tests/test_spawn_backends.py -v --tb=short`
  `11 passed in 5.20s`
- `uv run python -m pytest tests/ -v --tb=short`
  `142 passed in 5.97s`

## Backward Compatibility
- No production code changed
- No new dependencies
- No behavioral changes outside this test
