### PR TITLE
chore(gitignore): ignore uv.lock from local uv runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ build/
 .env
 .venv/
 venv/
+uv.lock
 .claude/*.local.md


### PR DESCRIPTION
## Problem
Running `uv run ...` in this repository creates a root-level `uv.lock`. Since the project does not currently track `uv.lock`, normal `git status` shows it as an untracked file and pollutes the working tree during local development.

## Fix
Ignore `uv.lock` in `.gitignore`.

This keeps the change minimal and avoids changing the project's packaging, CI, or local dependency workflow.

## Verification
- Before the change, `uv run python -c 'print("repro")'` produced `?? uv.lock` in `git status --short`
- After the change, the same command still creates `uv.lock`, but `git status --short` stays clean
- `git status --short --ignored` shows `!! uv.lock`, confirming the file is ignored

## Notes
This assumes the repository does not intend to commit a root-level `uv.lock` at this time. CI currently installs with `pip install -e ".[dev]"`, so this ignore rule does not change CI behavior.
