### PR TITLE
chore: ignore uv.lock from local uv runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 .venv/
 venv/
 .claude/*.local.md
+uv.lock


### PR DESCRIPTION
Fixes #29 - Running `uv run` creates a root-level uv.lock which pollutes git status. Added uv.lock to .gitignore.

## Verification
- Before the change, `uv run python -c 'print("repro")'` produced `?? uv.lock` in `git status`
- After the change, uv.lock is ignored