### PR TITLE
Fix cwd propagation for spawn --no-workspace --repo

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -1791,6 +1791,9 @@ def spawn_agent(
             cwd = ws_info.worktree_path
             ws_branch = ws_info.branch_name
             console.print(f"[dim]Workspace: {cwd} (branch: {ws_branch})[/dim]")
+    elif repo:
+        import os as _os_repo
+        cwd = _os_repo.path.abspath(repo)
 
     # Build prompt: identity + task + clawteam coordination guide
     prompt = None


### PR DESCRIPTION
## Summary

This fixes a bug where `clawteam spawn` ignored `--repo` when `--no-workspace` was used.

Previously, backend `cwd` was only set when workspace mode created a worktree.
When `--no-workspace` was used, the provided repo path was not propagated to the backend, so spawned agents stayed in the caller/project directory instead of the requested repo.

## Reproduction

1. Prepare a separate git repo with marker files
2. Run:

```bash
clawteam spawn tmux codex --team demo --agent-name worker1 --no-workspace --repo /path/to/repo --task "Run pwd and inspect this repo"
```

3. Observe worker pane output and tmux pane cwd

## Actual result

Worker reports cwd / git root as the ClawTeam source directory instead of `/path/to/repo`.

## Root cause

In `spawn_agent()`, backend `cwd` is only set when workspace mode creates a worktree.

When `--no-workspace` is used, the provided `repo` path is not propagated to backend `cwd`, so tmux backend builds launch command without `cd <repo>`.