### PR TITLE
refactor: extract duplicated command helpers to shared module

### DIFF
--- a/clawteam/spawn/command_validation.py
+++ b/clawteam/spawn/command_validation.py
@@ -1,4 +1,4 @@
-"""Validation helpers for spawned agent commands."""
+"""Validation and classification helpers for spawned agent commands."""
 
 from __future__ import annotations
 
@@ -49,3 +49,49 @@ def normalize_spawn_command(command: list[str]) -> list[str]:
         return [command[0], "agent"]
 
     return list(command)
+
+
+# ---------------------------------------------------------------------------
+# Command type detection helpers (shared by tmux and subprocess backends)
+# ---------------------------------------------------------------------------
+
+def _cmd_basename(command: list[str]) -> str:
+    """Extract the basename of the first element of a command list."""
+    if not command:
+        return ""
+    return command[0].rsplit("/", 1)[-1]
+
+
+def is_claude_command(command: list[str]) -> bool:
+    """Check if the command is a claude CLI invocation."""
+    return _cmd_basename(command) in ("claude", "claude-code")
+
+
+def is_codex_command(command: list[str]) -> bool:
+    """Check if the command is a codex CLI invocation."""
+    return _cmd_basename(command) in ("codex", "codex-cli")
+
+
+def is_nanobot_command(command: list[str]) -> bool:
+    """Check if the command is a nanobot CLI invocation."""
+    return _cmd_basename(command) == "nanobot"
+
+
+def is_gemini_command(command: list[str]) -> bool:
+    """Check if the command is a Gemini CLI invocation."""
+    return _cmd_basename(command) == "gemini"
+
+
+def is_interactive_cli(command: list[str]) -> bool:
+    """Check if the command is an interactive AI CLI."""
+    return (
+        is_claude_command(command)
+        or is_codex_command(command)
+        or is_nanobot_command(command)
+        or is_gemini_command(command)
+    )
+
+
+def command_has_workspace_arg(command: list[str]) -> bool:
+    """Return True when a command already specifies a nanobot workspace."""
+    return "-w" in command or "--workspace" in command

--- a/clawteam/spawn/subprocess_backend.py
+++ b/clawteam/spawn/subprocess_backend.py
@@ -8,7 +8,15 @@ import subprocess
 
 from clawteam.spawn.base import SpawnBackend
 from clawteam.spawn.cli_env import build_spawn_path, resolve_clawteam_executable
-from clawteam.spawn.command_validation import normalize_spawn_command, validate_spawn_command
+from clawteam.spawn.command_validation import (
+    command_has_workspace_arg,
+    is_claude_command,
+    is_codex_command,
+    is_gemini_command,
+    is_nanobot_command,
+    normalize_spawn_command,
+    validate_spawn_command,
+)
 
 
 class SubprocessBackend(SpawnBackend):
@@ -62,20 +70,19 @@ class SubprocessBackend(SpawnBackend):
 
         final_command = list(normalized_command)
         if skip_permissions:
-            if _is_claude_command(normalized_command):
+            if is_claude_command(normalized_command):
                 final_command.append("--dangerously-skip-permissions")
-            elif _is_codex_command(normalized_command):
+            elif is_codex_command(normalized_command):
                 final_command.append("--dangerously-bypass-approvals-and-sandbox")
-            elif _is_gemini_command(normalized_command):
+            elif is_gemini_command(normalized_command):
                 final_command.append("--yolo")
-        if _is_nanobot_command(normalized_command):
-            if cwd and not _command_has_workspace_arg(normalized_command):
+        if is_nanobot_command(normalized_command):
+            if cwd and not command_has_workspace_arg(normalized_command):
                 final_command.extend(["-w", cwd])
             if prompt:
                 final_command.extend(["-m", prompt])
         elif prompt:
-            if _is_codex_command(normalized_command):
-                # Codex accepts prompt as positional argument
+            if is_codex_command(normalized_command):
                 final_command.append(prompt)
             else:
                 final_command.extend(["-p", prompt])
@@ -119,40 +126,3 @@ class SubprocessBackend(SpawnBackend):
             else:
                 self._processes.pop(name, None)
         return result
-
-
-def _is_claude_command(command: list[str]) -> bool:
-    """Check if the command is a claude CLI invocation."""
-    if not command:
-        return False
-    cmd = command[0].rsplit("/", 1)[-1]
-    return cmd in ("claude", "claude-code")
-
-
-def _is_codex_command(command: list[str]) -> bool:
-    """Check if the command is a codex CLI invocation."""
-    if not command:
-        return False
-    cmd = command[0].rsplit("/", 1)[-1]
-    return cmd in ("codex", "codex-cli")
-
-
-def _is_nanobot_command(command: list[str]) -> bool:
-    """Check if the command is a nanobot CLI invocation."""
-    if not command:
-        return False
-    cmd = command[0].rsplit("/", 1)[-1]
-    return cmd == "nanobot"
-
-
-def _is_gemini_command(command: list[str]) -> bool:
-    """Check if the command is a Gemini CLI invocation."""
-    if not command:
-        return False
-    cmd = command[0].rsplit("/", 1)[-1]
-    return cmd == "gemini"
-
-
-def _command_has_workspace_arg(command: list[str]) -> bool:
-    """Return True when a command already specifies a nanobot workspace."""
-    return "-w" in command or "--workspace" in command

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -11,7 +11,15 @@ import time
 
 from clawteam.spawn.base import SpawnBackend
 from clawteam.spawn.cli_env import build_spawn_path, resolve_clawteam_executable
-from clawteam.spawn.command_validation import normalize_spawn_command, validate_spawn_command
+from clawteam.spawn.command_validation import (
+    command_has_workspace_arg,
+    is_claude_command,
+    is_codex_command,
+    is_gemini_command,
+    is_nanobot_command,
+    normalize_spawn_command,
+    validate_spawn_command,
+)
 
 
 class TmuxBackend(SpawnBackend):
@@ -75,21 +83,21 @@ class TmuxBackend(SpawnBackend):
         # Build the command (without prompt — we'll send it via send-keys)
         final_command = list(normalized_command)
         if skip_permissions:
-            if _is_claude_command(normalized_command):
+            if is_claude_command(normalized_command):
                 final_command.append("--dangerously-skip-permissions")
-            elif _is_codex_command(normalized_command):
+            elif is_codex_command(normalized_command):
                 final_command.append("--dangerously-bypass-approvals-and-sandbox")
-            elif _is_gemini_command(normalized_command):
+            elif is_gemini_command(normalized_command):
                 final_command.append("--yolo")
 
-        if _is_nanobot_command(normalized_command):
-            if cwd and not _command_has_workspace_arg(normalized_command):
+        if is_nanobot_command(normalized_command):
+            if cwd and not command_has_workspace_arg(normalized_command):
                 final_command.extend(["-w", cwd])
             if prompt:
                 final_command.extend(["-m", prompt])
-        elif prompt and _is_codex_command(normalized_command):
+        elif prompt and is_codex_command(normalized_command):
             final_command.append(prompt)
-        elif prompt and _is_gemini_command(normalized_command):
+        elif prompt and is_gemini_command(normalized_command):
             final_command.extend(["-p", prompt])
 
         cmd_str = " ".join(shlex.quote(c) for c in final_command)
@@ -150,7 +158,7 @@ class TmuxBackend(SpawnBackend):
 
         # Send the prompt as input to the interactive claude session
         # (codex prompt is passed as positional arg above, so skip here)
-        if prompt and _is_claude_command(normalized_command):
+        if prompt and is_claude_command(normalized_command):
             # Wait for Claude Code to finish startup and show input prompt.
             # Bedrock-backed instances can take 10+ seconds to initialize.
             _wait_for_claude_ready(target, timeout_seconds=30)
@@ -191,7 +199,7 @@ class TmuxBackend(SpawnBackend):
                 stderr=subprocess.PIPE,
             )
             os.unlink(tmp_path)
-        elif prompt and not _is_codex_command(normalized_command) and not _is_nanobot_command(normalized_command) and not _is_gemini_command(normalized_command):
+        elif prompt and not is_codex_command(normalized_command) and not is_nanobot_command(normalized_command) and not is_gemini_command(normalized_command):
             time.sleep(1)
             subprocess.run(
                 ["tmux", "send-keys", "-t", target, prompt, "Enter"],
@@ -305,43 +313,6 @@ class TmuxBackend(SpawnBackend):
         return result
 
 
-def _is_claude_command(command: list[str]) -> bool:
-    """Check if the command is a claude CLI invocation."""
-    if not command:
-        return False
-    cmd = command[0].rsplit("/", 1)[-1]  # basename
-    return cmd in ("claude", "claude-code")
-
-
-def _is_codex_command(command: list[str]) -> bool:
-    """Check if the command is a codex CLI invocation."""
-    if not command:
-        return False
-    cmd = command[0].rsplit("/", 1)[-1]  # basename
-    return cmd in ("codex", "codex-cli")
-
-
-def _is_nanobot_command(command: list[str]) -> bool:
-    """Check if the command is a nanobot CLI invocation."""
-    if not command:
-        return False
-    cmd = command[0].rsplit("/", 1)[-1]
-    return cmd == "nanobot"
-
-
-def _is_gemini_command(command: list[str]) -> bool:
-    """Check if the command is a Gemini CLI invocation."""
-    if not command:
-        return False
-    cmd = command[0].rsplit("/", 1)[-1]
-    return cmd == "gemini"
-
-
-def _command_has_workspace_arg(command: list[str]) -> bool:
-    """Return True when a command already specifies a nanobot workspace."""
-    return "-w" in command or "--workspace" in command
-
-
 def _confirm_workspace_trust_if_prompted(
     target: str,
     command: list[str],
@@ -355,7 +326,7 @@ def _confirm_workspace_trust_if_prompted(
     injection and accept it with a single Enter so the interactive TUI remains
     intact.
     """
-    if not (_is_claude_command(command) or _is_codex_command(command) or _is_gemini_command(command)):
+    if not (is_claude_command(command) or is_codex_command(command) or is_gemini_command(command)):
         return False
 
     deadline = time.monotonic() + timeout_seconds
@@ -385,31 +356,21 @@ def _looks_like_workspace_trust_prompt(command: list[str], pane_text: str) -> bo
     if not pane_text:
         return False
 
-    if _is_claude_command(command):
+    if is_claude_command(command):
         return ("trust this folder" in pane_text or "trust the contents" in pane_text) and (
             "enter to confirm" in pane_text or "press enter" in pane_text or "enter to continue" in pane_text
         )
 
-    if _is_codex_command(command):
+    if is_codex_command(command):
         return (
             "trust the contents of this directory" in pane_text
             and "press enter to continue" in pane_text
         )
 
-    if _is_gemini_command(command):
+    if is_gemini_command(command):
         return "trust folder" in pane_text or "trust parent folder" in pane_text
 
     return False
-
-
-def _is_interactive_cli(command: list[str]) -> bool:
-    """Check if the command is an interactive AI CLI."""
-    return (
-        _is_claude_command(command)
-        or _is_codex_command(command)
-        or _is_nanobot_command(command)
-        or _is_gemini_command(command)
-    )
 
 
 def _wait_for_claude_ready(


### PR DESCRIPTION
## Summary

- Consolidates 5 identical command detection functions (`is_claude_command`, `is_codex_command`, `is_nanobot_command`, `is_gemini_command`, `command_has_workspace_arg`) that were duplicated across `tmux_backend.py` and `subprocess_backend.py` into the shared `command_validation.py` module.
- Introduces a shared `_cmd_basename` helper and `is_interactive_cli` to eliminate repeated patterns.
- Removes ~50 lines of duplicated code with zero behavioral changes.

## Details

Previously, both spawn backends independently defined the same 5 helper functions with identical logic for detecting which AI CLI tool is being used. This created a maintenance burden — any new CLI support (like Gemini, which was added recently) had to be duplicated in both files.

Now `command_validation.py` serves as the single source of truth for command classification, alongside its existing validation/normalization duties. The functions are renamed from private (`_is_*`) to public (`is_*`) since they're now shared across modules.

## Test plan

- [x] All 241 tests pass (no test changes needed)
- [x] Ruff lint clean
- [x] Verified spawn backend tests still validate skip-permissions flags, workspace args, and prompt injection for all CLI types (claude, codex, nanobot, gemini)

Made with [Cursor](https://cursor.com)