### PR TITLE
docs: fix README video embeds and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ Full compatibility with [Claude Code](https://claude.ai/claude-code), [Codex](ht
 
 <p align="center"><strong>• Autonomous Full-Stack Development</strong></p>
 
-<p align="center"><strong>• Self-Evolving Software<strong></p>
+<p align="center"><strong>• Self-Evolving Software</strong></p>
 
-<p align="center"><strong>• Collaborative Open Source Development<strong></p>
+<p align="center"><strong>• Collaborative Open Source Development</strong></p>
 
-<p align="center"><strong>• Real-Time System Integration<strong></p>
+<p align="center"><strong>• Real-Time System Integration</strong></p>
 
 </td>
 <td width="25%" align="center" style="vertical-align: top; padding: 15px;">
@@ -114,8 +114,14 @@ Full compatibility with [Claude Code](https://claude.ai/claude-code), [Codex](ht
 
 ---
 
-
-https://github.com/user-attachments/assets/7e2f0ecd-8fe3-4970-90ac-5c9669ff060c
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/7e2f0ecd-8fe3-4970-90ac-5c9669ff060c" controls muted playsinline width="800">
+    <a href="https://github.com/user-attachments/assets/7e2f0ecd-8fe3-4970-90ac-5c9669ff060c">Watch the demo video</a>
+  </video>
+</p>
+<p align="center">
+  <a href="https://github.com/user-attachments/assets/7e2f0ecd-8fe3-4970-90ac-5c9669ff060c">Open the demo video directly</a>
+</p>
 
 
 ☝️ Intelligent leader agent orchestrates 8 specialized sub-agents across 8 H100 GPUs, autonomously designing experiments and dynamically reallocating resources based on real-time performance.
@@ -146,7 +152,7 @@ ClawTeam unlocks **Agent Swarm Intelligence** — where AI agents self-organize 
 
 • **🔄 Adapts strategies dynamically** — reallocates resources and redirects efforts
 
-#### ✨ The Result?**
+#### ✨ The Result?
 You set the vision. The swarm executes with collective intelligence.
 
 <p align="center">
@@ -718,7 +724,7 @@ We welcome contributions! ClawTeam is designed to be extensible:
 
 ## ⭐ Star History
 
-If you find ClawTeam helpful, please consider to give us a star! ⭐
+If you find ClawTeam helpful, please consider giving us a star! ⭐
 
 <div align="center">
   <a href="https://star-history.com/#HKUDS/ClawTeam&Date">

--- a/README_CN.md
+++ b/README_CN.md
@@ -29,7 +29,14 @@
 
 ---
 
-https://github.com/user-attachments/assets/f6f0b220-9a5e-4d0a-a25d-f80753d3639b
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/7e2f0ecd-8fe3-4970-90ac-5c9669ff060c" controls muted playsinline width="800">
+    <a href="https://github.com/user-attachments/assets/7e2f0ecd-8fe3-4970-90ac-5c9669ff060c">观看演示视频</a>
+  </video>
+</p>
+<p align="center">
+  <a href="https://github.com/user-attachments/assets/7e2f0ecd-8fe3-4970-90ac-5c9669ff060c">直接打开演示视频</a>
+</p>
 
 *☝️ 一个 Leader Claude Agent 在 8 块 H100 GPU 上自主创建 8 个子 Agent，分配实验方向，监控进度，交叉融合发现，并及时纠正无效方向 —— 全程无人干预。*
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -118,7 +118,14 @@
 
 ---
 
-https://github.com/user-attachments/assets/f6f0b220-9a5e-4d0a-a25d-f80753d3639b
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/7e2f0ecd-8fe3-4970-90ac-5c9669ff060c" controls muted playsinline width="800">
+    <a href="https://github.com/user-attachments/assets/7e2f0ecd-8fe3-4970-90ac-5c9669ff060c">데모 비디오 보기</a>
+  </video>
+</p>
+<p align="center">
+  <a href="https://github.com/user-attachments/assets/7e2f0ecd-8fe3-4970-90ac-5c9669ff060c">데모 비디오 직접 열기</a>
+</p>
 
 ☝️ 지능형 리더 에이전트가 8대의 H100 GPU에 걸쳐 8개의 전문 서브에이전트를 조율하며, 실시간 성능에 맞춰 자원을 동적으로 재배치하면서 실험을 자율적으로 설계합니다.
 


### PR DESCRIPTION
This PR fixes a few README presentation issues across the English, Chinese, and Korean docs.

Changes:
- replace broken bare mp4 links with embedded `<video>` blocks plus direct fallback links
- point `README_CN.md` and `README_KR.md` to the same working demo video as `README.md`
- fix a few obvious README.md typos / malformed HTML tags

Files changed:
- README.md
- README_CN.md
- README_KR.md