### PR TITLE
fix(p2p): treat remote peers as lease-based instead of PID-based

### DIFF
--- a/clawteam/transport/p2p.py
+++ b/clawteam/transport/p2p.py
@@ -6,6 +6,8 @@ import collections
 import json
 import os
 import socket
+import threading
+import time
 import uuid
 from pathlib import Path
 
@@ -30,6 +32,9 @@ class P2PTransport(Transport):
     - Offline fallback: if peer is unreachable, messages go through FileTransport
     """
 
+    _peer_heartbeat_interval_s = 1.0
+    _peer_lease_ms = 5000
+
     def __init__(self, team_name: str, bind_agent: str | None = None):
         self.team_name = team_name
         self._bind_agent = bind_agent
@@ -39,6 +44,8 @@ class P2PTransport(Transport):
         self._push_cache: dict[str, object] = {}
         self._peek_buffer: collections.deque = collections.deque()
         self._port: int | None = None
+        self._heartbeat_stop = threading.Event()
+        self._heartbeat_thread: threading.Thread | None = None
         if bind_agent:
             self._start_listener()
 
@@ -50,17 +57,77 @@ class P2PTransport(Transport):
         self._pull = self._ctx.socket(zmq.PULL)
         self._port = self._pull.bind_to_random_port("tcp://*")
         self._register_peer()
+        self._start_peer_heartbeat()
 
-    def _register_peer(self) -> None:
-        """Write peers/{agent}.json with host/port/pid."""
-        if not self._bind_agent or self._port is None:
-            return
-        peer_file = _peers_dir(self.team_name) / f"{self._bind_agent}.json"
-        info = {
+    @staticmethod
+    def _now_ms() -> int:
+        return int(time.time() * 1000)
+
+    @staticmethod
+    def _as_int(value: object) -> int | None:
+        if isinstance(value, bool):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _is_local_host(host: str) -> bool:
+        return host in {
+            socket.gethostname(),
+            socket.getfqdn(),
+            "localhost",
+            "127.0.0.1",
+            "::1",
+        }
+
+    def _lease_is_fresh(self, info: dict[str, object]) -> bool | None:
+        lease_expires_at_ms = self._as_int(info.get("leaseExpiresAtMs"))
+        if lease_expires_at_ms is not None:
+            return lease_expires_at_ms >= self._now_ms()
+
+        heartbeat_at_ms = self._as_int(info.get("heartbeatAtMs"))
+        lease_duration_ms = self._as_int(info.get("leaseDurationMs"))
+        if heartbeat_at_ms is None or lease_duration_ms is None:
+            return None
+        return heartbeat_at_ms + lease_duration_ms >= self._now_ms()
+
+    def _peer_info(self) -> dict[str, object]:
+        now_ms = self._now_ms()
+        return {
             "host": socket.gethostname(),
             "port": self._port,
             "pid": os.getpid(),
+            "heartbeatAtMs": now_ms,
+            "leaseDurationMs": self._peer_lease_ms,
+            "leaseExpiresAtMs": now_ms + self._peer_lease_ms,
         }
+
+    def _start_peer_heartbeat(self) -> None:
+        if self._heartbeat_thread and self._heartbeat_thread.is_alive():
+            return
+        self._heartbeat_stop.clear()
+        self._heartbeat_thread = threading.Thread(
+            target=self._heartbeat_loop,
+            name=f"clawteam-p2p-heartbeat-{self.team_name}-{self._bind_agent}",
+            daemon=True,
+        )
+        self._heartbeat_thread.start()
+
+    def _heartbeat_loop(self) -> None:
+        while not self._heartbeat_stop.wait(self._peer_heartbeat_interval_s):
+            try:
+                self._register_peer()
+            except Exception:
+                continue
+
+    def _register_peer(self) -> None:
+        """Write peers/{agent}.json with host/port/pid plus lease metadata."""
+        if not self._bind_agent or self._port is None:
+            return
+        peer_file = _peers_dir(self.team_name) / f"{self._bind_agent}.json"
+        info = self._peer_info()
         tmp = peer_file.with_suffix(".tmp")
         tmp.write_text(json.dumps(info), encoding="utf-8")
         tmp.rename(peer_file)
@@ -82,15 +149,31 @@ class P2PTransport(Transport):
             return None
         try:
             info = json.loads(peer_file.read_text(encoding="utf-8"))
-            pid = info.get("pid")
-            if pid and not self._pid_alive(pid):
-                # Stale peer file — clean it up
+            host = str(info["host"])
+            pid = self._as_int(info.get("pid"))
+            lease_is_fresh = self._lease_is_fresh(info)
+            is_local_host = self._is_local_host(host)
+            if is_local_host and pid:
+                # Same-host peers can still be trusted via PID liveness even if
+                # the lease heartbeat is delayed briefly.
+                if self._pid_alive(pid):
+                    return f"tcp://{host}:{info['port']}"
                 try:
                     peer_file.unlink(missing_ok=True)
                 except OSError:
                     pass
                 return None
-            host = info["host"]
+            if lease_is_fresh is False:
+                # Remote peers rely on lease freshness because their PIDs are not
+                # meaningful on this machine.
+                try:
+                    peer_file.unlink(missing_ok=True)
+                except OSError:
+                    pass
+                return None
+            if lease_is_fresh is None and not is_local_host:
+                # Remote peers need lease metadata because the local PID table is meaningless.
+                return None
             port = info["port"]
             return f"tcp://{host}:{port}"
         except Exception:
@@ -219,6 +302,10 @@ class P2PTransport(Transport):
         return list(peers)
 
     def close(self) -> None:
+        self._heartbeat_stop.set()
+        if self._heartbeat_thread:
+            self._heartbeat_thread.join(timeout=self._peer_heartbeat_interval_s + 0.1)
+            self._heartbeat_thread = None
         self._deregister_peer()
         for sock in self._push_cache.values():
             try:

--- a/tests/test_mailbox.py
+++ b/tests/test_mailbox.py
@@ -2,6 +2,9 @@
 
 import fcntl
 import json
+import os
+import socket
+import time
 from pathlib import Path
 
 from clawteam.team.mailbox import MailboxManager
@@ -25,6 +28,12 @@ def _inbox_path(team_name: str, agent_name: str) -> Path:
 
 def _dead_letter_root(team_name: str, agent_name: str) -> Path:
     return get_data_dir() / "teams" / team_name / "dead_letters" / agent_name
+
+
+def _peer_path(team_name: str, agent_name: str) -> Path:
+    peer = get_data_dir() / "teams" / team_name / "peers" / f"{agent_name}.json"
+    peer.parent.mkdir(parents=True, exist_ok=True)
+    return peer
 
 
 class TestSendReceive:
@@ -398,6 +407,78 @@ class TestFileTransport:
 
         assert transport.fetch("bob", limit=3, consume=True) == [b"raw-message"]
         assert seen == {"calls": 1, "acks": 1}
+
+        transport.close()
+
+
+class TestP2PLease:
+    def test_remote_peer_addr_uses_fresh_lease_instead_of_local_pid(self, team_name):
+        from clawteam.transport.p2p import P2PTransport
+
+        transport = P2PTransport(team_name)
+        now_ms = int(time.time() * 1000)
+        _peer_path(team_name, "bob").write_text(
+            json.dumps(
+                {
+                    "host": "remote-host",
+                    "port": 43123,
+                    "pid": 999999999,
+                    "heartbeatAtMs": now_ms,
+                    "leaseExpiresAtMs": now_ms + 5000,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert transport._get_peer_addr("bob") == "tcp://remote-host:43123"
+
+        transport.close()
+
+    def test_remote_peer_addr_rejects_stale_lease_even_if_local_pid_is_alive(self, team_name):
+        from clawteam.transport.p2p import P2PTransport
+
+        transport = P2PTransport(team_name)
+        now_ms = int(time.time() * 1000)
+        peer_file = _peer_path(team_name, "bob")
+        peer_file.write_text(
+            json.dumps(
+                {
+                    "host": "remote-host",
+                    "port": 43123,
+                    "pid": os.getpid(),
+                    "heartbeatAtMs": now_ms - 6000,
+                    "leaseExpiresAtMs": now_ms - 1000,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert transport._get_peer_addr("bob") is None
+        assert not peer_file.exists()
+
+        transport.close()
+
+    def test_same_host_peer_addr_keeps_live_pid_even_when_lease_is_stale(self, team_name):
+        from clawteam.transport.p2p import P2PTransport
+
+        transport = P2PTransport(team_name)
+        now_ms = int(time.time() * 1000)
+        peer_file = _peer_path(team_name, "bob")
+        peer_file.write_text(
+            json.dumps(
+                {
+                    "host": socket.gethostname(),
+                    "port": 43123,
+                    "pid": os.getpid(),
+                    "heartbeatAtMs": now_ms - 6000,
+                    "leaseExpiresAtMs": now_ms - 1000,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert transport._get_peer_addr("bob") == f"tcp://{socket.gethostname()}:43123"
+        assert peer_file.exists()
 
         transport.close()
 


### PR DESCRIPTION
## Summary

`P2PTransport` used the peer file's `pid` to decide whether a peer was alive. That is fine on the same machine, but it breaks for remote peers because a PID from another host has no meaning locally. The result is simple: a remote peer can be treated as dead even when its peer file is fresh.

Refs #8.

## What changed

- listeners now publish `heartbeatAtMs`, `leaseDurationMs`, and `leaseExpiresAtMs`
- remote peers are considered reachable only while the lease is fresh
- same-host peers still use PID checks as the primary liveness signal
- when the lease expires, delivery falls back to `FileTransport` as before
- same-host peers with a live PID are still treated as alive even if the lease heartbeat is briefly stale
- added focused regression coverage for fresh remote lease, stale remote lease, and same-host stale-lease-but-live-pid behavior

## Why this approach

This keeps the two liveness systems separate. `spawn_registry.json` still owns local spawn and lifecycle state. `peers/{agent}.json` now owns remote P2P reachability, while same-host peers keep the existing PID-based behavior.

## Compatibility / Security impact

- Legacy peer files without lease metadata now fall back to file delivery instead of being treated as live P2P peers.
- same-host peers keep PID-based liveness semantics
- no changes to spawn registry, subprocess behavior, board behavior, CLI behavior, auth, or network surface beyond P2P reachability decisions

## Test plan
- [x] Ran `uv run pytest -q tests/test_mailbox.py -k 'remote_peer_addr'`
- [x] Ran `uv run pytest -q tests/test_mailbox.py -k 'same_host_peer_addr_keeps_live_pid_even_when_lease_is_stale or remote_peer_addr'`
- [x] Ran `uv run pytest -q tests/test_mailbox.py tests/test_inbox_routing.py`
- [x] Ran `uv run python -m pytest -q`
- [x] Ran `uv run ruff check clawteam/transport/p2p.py tests/test_mailbox.py`
- [x] Verified fresh remote leases resolve to a live peer address
- [x] Verified stale remote leases are rejected even when the recorded PID is alive locally
- [x] Verified same-host peers with a live PID are not rejected just because the lease is stale

## Evidence / Actual results
- `uv run pytest -q tests/test_mailbox.py -k 'remote_peer_addr'`
  - `2 passed, 29 deselected in 0.08s`
- `uv run pytest -q tests/test_mailbox.py -k 'same_host_peer_addr_keeps_live_pid_even_when_lease_is_stale or remote_peer_addr'`
  - `3 passed, 26 deselected in 0.10s`
- `uv run pytest -q tests/test_mailbox.py tests/test_inbox_routing.py`
  - `31 passed in 0.25s`
- `uv run python -m pytest -q`
  - `321 passed in 13.09s`
- `uv run ruff check clawteam/transport/p2p.py tests/test_mailbox.py`
  - `All checks passed!`

## Human verification
- remote peer freshness now comes from lease metadata in `peers/{agent}.json`
- same-host peers still prefer PID liveness over lease expiry
- remote peers without lease metadata now fall back to file delivery instead of being treated as live

## Risks / rollback

- the timing is still intentionally simple: 1s heartbeat, 5s lease
- there is still no live ZeroMQ integration test in this branch
- rollback: revert the branch commit
