### PR TITLE
fix(spawn): stop subprocess agents from blocking on unread pipes

### DIFF
--- a/clawteam/spawn/subprocess_backend.py
+++ b/clawteam/spawn/subprocess_backend.py
@@ -84,8 +84,9 @@ class SubprocessBackend(SpawnBackend):
             shell_cmd,
             shell=True,
             env=spawn_env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            # Subprocess agents are fire-and-forget; unread pipes can block long-lived runs.
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             cwd=cwd,
         )
         self._processes[agent_name] = process

--- a/tests/test_spawn_backends.py
+++ b/tests/test_spawn_backends.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 
 from clawteam.spawn.cli_env import build_spawn_path, resolve_clawteam_executable
@@ -58,6 +59,63 @@ def test_subprocess_backend_prepends_current_clawteam_bin_to_path(monkeypatch, t
     env = captured["env"]
     assert env["PATH"].startswith(f"{clawteam_bin.parent}:")
     assert env["CLAWTEAM_BIN"] == str(clawteam_bin)
+
+
+def test_subprocess_backend_discards_output_and_preserves_exit_hook_and_registry(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    clawteam_bin = tmp_path / "venv" / "bin" / "clawteam"
+    clawteam_bin.parent.mkdir(parents=True)
+    clawteam_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(sys, "argv", [str(clawteam_bin)])
+
+    captured: dict[str, object] = {}
+    registered: dict[str, object] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["stdout"] = kwargs["stdout"]
+        captured["stderr"] = kwargs["stderr"]
+        captured["cwd"] = kwargs["cwd"]
+        return DummyProcess(pid=9876)
+
+    def fake_register_agent(**kwargs):
+        registered.update(kwargs)
+
+    monkeypatch.setattr(
+        "clawteam.spawn.command_validation.shutil.which",
+        lambda name, path=None: "/usr/bin/codex" if name == "codex" else None,
+    )
+    monkeypatch.setattr("clawteam.spawn.subprocess_backend.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("clawteam.spawn.registry.register_agent", fake_register_agent)
+
+    backend = SubprocessBackend()
+    result = backend.spawn(
+        command=["codex"],
+        agent_name="worker1",
+        agent_id="agent-1",
+        agent_type="general-purpose",
+        team_name="demo-team",
+        prompt="do work",
+        cwd="/tmp/demo",
+        skip_permissions=True,
+    )
+
+    assert result == "Agent 'worker1' spawned as subprocess (pid=9876)"
+    assert captured["stdout"] is subprocess.DEVNULL
+    assert captured["stderr"] is subprocess.DEVNULL
+    assert captured["cwd"] == "/tmp/demo"
+    assert (
+        f"{clawteam_bin} lifecycle on-exit --team demo-team --agent worker1" in captured["cmd"]
+    )
+    assert registered == {
+        "team_name": "demo-team",
+        "agent_name": "worker1",
+        "backend": "subprocess",
+        "pid": 9876,
+        "command": ["codex", "--dangerously-bypass-approvals-and-sandbox", "do work"],
+    }
 
 
 def test_tmux_backend_exports_spawn_path_for_agent_commands(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

`SubprocessBackend.spawn()` launched long-lived agent processes with both `stdout` and `stderr` set to `subprocess.PIPE`, but nothing ever drained those pipes. A noisy child process could eventually block once the OS pipe buffer filled up.

## What changed

- `stdout` now goes to `subprocess.DEVNULL`
- `stderr` now goes to `subprocess.DEVNULL`
- the existing shell `on-exit` lifecycle hook stays in place
- registry writes still record the spawned subprocess as before

## Why this approach

There are two obvious fixes here: drain the pipes in the background, or stop creating unread pipes in the first place.

For this backend, the simpler choice is better. These subprocess agents are not managed as interactive streams, and the backend was never surfacing their output to callers. Redirecting to `DEVNULL` removes the hang risk without adding thread or process management.

## Compatibility / Security impact

- tmux behavior is unchanged
- transport behavior is unchanged
- registry writes are unchanged
- lifecycle `on-exit` behavior is unchanged
- child stdout/stderr is now discarded instead of buffered

## Test plan
- [x] Ran `uv run pytest -q tests/test_spawn_backends.py -k discards_output_and_preserves_exit_hook_and_registry`
- [x] Ran `uv run pytest -q tests/test_spawn_backends.py`
- [x] Ran `uv run python -m pytest -q`
- [x] Verified subprocess spawns no longer use unread pipes
- [x] Verified the lifecycle hook is still appended to the shell command
- [x] Verified `register_agent(...)` still receives the expected subprocess payload

## Evidence / Actual results
- `uv run pytest -q tests/test_spawn_backends.py -k discards_output_and_preserves_exit_hook_and_registry`
  - `1 passed, 24 deselected in 0.07s`
- `uv run pytest -q tests/test_spawn_backends.py`
  - `25 passed in 10.33s`
- `uv run python -m pytest -q`
  - `319 passed in 13.06s`

## Human verification
- subprocess agents no longer create unread `PIPE`s that can fill and block
- the branch keeps the existing lifecycle and registry contract intact

## Risks / rollback

- child output is now discarded instead of buffered
- if we later want retained subprocess logs, that should be a separate feature with explicit log handling instead of hidden unread pipes
- rollback: revert the branch commit
