### PR TITLE
perf(cost): cache rolling team cost summaries

### DIFF
--- a/clawteam/team/costs.py
+++ b/clawteam/team/costs.py
@@ -44,10 +44,175 @@ class CostSummary(BaseModel):
     event_count: int = Field(default=0, alias="eventCount")
 
 
+class _CostCacheEntry(BaseModel):
+    """Cached contribution from a single event file."""
+
+    model_config = {"populate_by_name": True}
+
+    agent_name: str = Field(alias="agentName")
+    input_tokens: int = Field(default=0, alias="inputTokens")
+    output_tokens: int = Field(default=0, alias="outputTokens")
+    cost_cents: float = Field(default=0.0, alias="costCents")
+    size: int = 0
+    mtime_ns: int = Field(default=0, alias="mtimeNs")
+
+
+class _CostSummaryCache(BaseModel):
+    """Internal rolling cache stored alongside cost events."""
+
+    model_config = {"populate_by_name": True}
+
+    team_name: str = Field(alias="teamName")
+    total_cost_cents: float = Field(default=0.0, alias="totalCostCents")
+    total_input_tokens: int = Field(default=0, alias="totalInputTokens")
+    total_output_tokens: int = Field(default=0, alias="totalOutputTokens")
+    by_agent: dict[str, float] = Field(default_factory=dict, alias="byAgent")
+    event_count: int = Field(default=0, alias="eventCount")
+    files: dict[str, _CostCacheEntry] = Field(default_factory=dict)
+
+
 def _costs_root(team_name: str) -> Path:
     d = get_data_dir() / "costs" / team_name
     d.mkdir(parents=True, exist_ok=True)
     return d
+
+
+def _summary_cache_path(team_name: str) -> Path:
+    return _costs_root(team_name) / "summary.json"
+
+
+def _read_event_file(path: Path) -> CostEvent | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return CostEvent.model_validate(data)
+    except Exception:
+        return None
+
+
+def _empty_summary_cache(team_name: str) -> _CostSummaryCache:
+    return _CostSummaryCache(team_name=team_name)
+
+
+def _load_summary_cache(team_name: str) -> _CostSummaryCache | None:
+    path = _summary_cache_path(team_name)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        cache = _CostSummaryCache.model_validate(data)
+        if cache.team_name != team_name:
+            return None
+        return cache
+    except Exception:
+        return None
+
+
+def _write_summary_cache(team_name: str, cache: _CostSummaryCache) -> None:
+    path = _summary_cache_path(team_name)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(cache.model_dump_json(indent=2, by_alias=True), encoding="utf-8")
+    tmp.rename(path)
+
+
+def _normalize_cost(value: float) -> float:
+    return 0.0 if abs(value) < 1e-12 else value
+
+
+def _add_cache_entry(
+    cache: _CostSummaryCache, filename: str, entry: _CostCacheEntry
+) -> None:
+    cache.total_cost_cents += entry.cost_cents
+    cache.total_input_tokens += entry.input_tokens
+    cache.total_output_tokens += entry.output_tokens
+    cache.by_agent[entry.agent_name] = (
+        cache.by_agent.get(entry.agent_name, 0.0) + entry.cost_cents
+    )
+    cache.files[filename] = entry
+    cache.event_count = len(cache.files)
+
+
+def _remove_cache_entry(cache: _CostSummaryCache, filename: str) -> None:
+    entry = cache.files.pop(filename, None)
+    if entry is None:
+        return
+    cache.total_cost_cents = _normalize_cost(cache.total_cost_cents - entry.cost_cents)
+    cache.total_input_tokens -= entry.input_tokens
+    cache.total_output_tokens -= entry.output_tokens
+    remaining = _normalize_cost(cache.by_agent.get(entry.agent_name, 0.0) - entry.cost_cents)
+    if remaining == 0.0:
+        cache.by_agent.pop(entry.agent_name, None)
+    else:
+        cache.by_agent[entry.agent_name] = remaining
+    cache.event_count = len(cache.files)
+
+
+def _cache_entry_from_event(path: Path, event: CostEvent) -> _CostCacheEntry:
+    stat = path.stat()
+    return _CostCacheEntry(
+        agent_name=event.agent_name,
+        input_tokens=event.input_tokens,
+        output_tokens=event.output_tokens,
+        cost_cents=event.cost_cents,
+        size=stat.st_size,
+        mtime_ns=stat.st_mtime_ns,
+    )
+
+
+def _sync_summary_cache(team_name: str) -> _CostSummaryCache:
+    root = _costs_root(team_name)
+    cache = _load_summary_cache(team_name) or _empty_summary_cache(team_name)
+    cache_exists = _summary_cache_path(team_name).exists()
+    changed = not cache_exists
+
+    current_files = {path.name: path for path in sorted(root.glob("cost-*.json"))}
+
+    for filename in list(cache.files):
+        if filename not in current_files:
+            _remove_cache_entry(cache, filename)
+            changed = True
+
+    for filename, path in current_files.items():
+        stat = path.stat()
+        cached_entry = cache.files.get(filename)
+        if (
+            cached_entry is not None
+            and cached_entry.size == stat.st_size
+            and cached_entry.mtime_ns == stat.st_mtime_ns
+        ):
+            continue
+
+        if cached_entry is not None:
+            _remove_cache_entry(cache, filename)
+            changed = True
+
+        event = _read_event_file(path)
+        if event is None:
+            continue
+
+        _add_cache_entry(cache, filename, _cache_entry_from_event(path, event))
+        changed = True
+
+    if changed:
+        _write_summary_cache(team_name, cache)
+    return cache
+
+
+def _record_event_in_summary_cache(team_name: str, path: Path, event: CostEvent) -> None:
+    cache = _load_summary_cache(team_name) or _empty_summary_cache(team_name)
+    _remove_cache_entry(cache, path.name)
+    _add_cache_entry(cache, path.name, _cache_entry_from_event(path, event))
+    _write_summary_cache(team_name, cache)
+
+
+def _cache_to_summary(cache: _CostSummaryCache) -> CostSummary:
+    return CostSummary(
+        team_name=cache.team_name,
+        total_cost_cents=cache.total_cost_cents,
+        total_input_tokens=cache.total_input_tokens,
+        total_output_tokens=cache.total_output_tokens,
+        by_agent=dict(cache.by_agent),
+        event_count=cache.event_count,
+    )
 
 
 class CostStore:
@@ -85,38 +250,23 @@ class CostStore:
             event.model_dump_json(indent=2, by_alias=True), encoding="utf-8"
         )
         tmp.rename(path)
+        try:
+            _record_event_in_summary_cache(self.team_name, path, event)
+        except Exception:
+            pass
         return event
 
     def list_events(self, agent_name: str = "") -> list[CostEvent]:
         root = _costs_root(self.team_name)
         events = []
         for f in sorted(root.glob("cost-*.json")):
-            try:
-                data = json.loads(f.read_text(encoding="utf-8"))
-                event = CostEvent.model_validate(data)
-                if agent_name and event.agent_name != agent_name:
-                    continue
-                events.append(event)
-            except Exception:
+            event = _read_event_file(f)
+            if event is None:
                 continue
+            if agent_name and event.agent_name != agent_name:
+                continue
+            events.append(event)
         return events
 
     def summary(self) -> CostSummary:
-        events = self.list_events()
-        total_cents = 0.0
-        total_in = 0
-        total_out = 0
-        by_agent: dict[str, float] = {}
-        for e in events:
-            total_cents += e.cost_cents
-            total_in += e.input_tokens
-            total_out += e.output_tokens
-            by_agent[e.agent_name] = by_agent.get(e.agent_name, 0.0) + e.cost_cents
-        return CostSummary(
-            team_name=self.team_name,
-            total_cost_cents=total_cents,
-            total_input_tokens=total_in,
-            total_output_tokens=total_out,
-            by_agent=by_agent,
-            event_count=len(events),
-        )
+        return _cache_to_summary(_sync_summary_cache(self.team_name))

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -1,5 +1,7 @@
 """Tests for clawteam.team.costs — CostStore report/list/summary."""
 
+from pathlib import Path
+
 from clawteam.team.costs import CostEvent, CostStore, CostSummary
 
 
@@ -84,6 +86,32 @@ class TestCostStoreSummary:
         assert summary.event_count == 3
         assert summary.by_agent["a1"] == 4.0
         assert summary.by_agent["a2"] == 2.0
+
+    def test_summary_uses_cached_totals_without_rereading_event_files(
+        self, team_name, monkeypatch
+    ):
+        store = CostStore(team_name)
+        store.report(agent_name="a1", input_tokens=100, output_tokens=50, cost_cents=1.0)
+        store.report(agent_name="a2", input_tokens=200, output_tokens=100, cost_cents=2.0)
+
+        event_payload_reads: list[str] = []
+        original_read_text = Path.read_text
+
+        def tracked_read_text(path: Path, *args, **kwargs):
+            if path.name.startswith("cost-") and path.suffix == ".json":
+                event_payload_reads.append(path.name)
+            return original_read_text(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", tracked_read_text)
+
+        summary = CostStore(team_name).summary()
+
+        assert summary.total_cost_cents == 3.0
+        assert summary.total_input_tokens == 300
+        assert summary.total_output_tokens == 150
+        assert summary.event_count == 2
+        assert summary.by_agent == {"a1": 1.0, "a2": 2.0}
+        assert event_payload_reads == []
 
 
 class TestCostSummaryModel:


### PR DESCRIPTION
## Summary

This improves the cost summary path without changing the public `CostSummary` contract.

Before this patch, every call to `CostStore.summary()` rebuilt totals by reopening and reparsing every `cost-*.json` event file. That is simple, but it gets slower as a team accumulates more cost events.

## What changed

- `report()` updates a private `summary.json` cache
- `summary()` syncs that cache against the current `cost-*.json` file set
- unchanged event files are no longer reparsed on every summary read
- returned `CostSummary` fields and caller behavior stay the same

## Why this approach

The goal here is small and boring: keep the API stable and stop paying the full reread cost on every summary call.

Callers still ask for `CostStore.summary()` and still receive the same `CostSummary` payload. The only change is how totals are maintained internally. The cache also self-heals by syncing against current files, so it can recover from out-of-band file changes better than a write-only accumulator.

## Compatibility / Security impact

- The new `summary.json` file is internal cache state, not a public artifact format.
- `summary()` still scans filenames and file metadata so it stays correct if event files are added, removed, or replaced outside the normal `report()` path.
- If cache writes fail, the next `summary()` call rebuilds from the current files and repairs the cache.
- no board, renderer, or CLI call sites changed

## Test plan
- [x] Ran `uv run python -m pytest tests/test_costs.py -q`
- [x] Ran `uv run python -m pytest tests/test_snapshots.py -q`
- [x] Ran `uv run python -m pytest -q`
- [x] Ran `uv run ruff check clawteam/team/costs.py tests/test_costs.py`
- [x] Verified repeated summary reads do not reopen unchanged `cost-*.json` payload files
- [x] Verified snapshot-related tests still pass with the new internal cache file present

## Evidence / Actual results
- `uv run python -m pytest tests/test_costs.py -q`
  - `11 passed in 0.10s`
- `uv run python -m pytest tests/test_snapshots.py -q`
  - `21 passed in 0.23s`
- `uv run python -m pytest -q`
  - `319 passed in 13.06s`
- `uv run ruff check clawteam/team/costs.py tests/test_costs.py`
  - `All checks passed!`

## Human verification
- `CostStore.summary()` still returns the same public `CostSummary` shape
- unchanged event files are no longer reparsed on every summary read
- the cache is internal state only; callers still use the same API

## Risks / rollback

- cache coherence still relies on file metadata plus resync, not a stronger transactional mechanism
- there is still no dedicated concurrency stress test in this branch
- rollback: revert the branch commit
