### PR TITLE
fix(spawn): add native OpenClaw prompt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,9 @@ All examples below assume the corresponding CLI already runs standalone on your 
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | 🔮 Experimental |
 | Custom scripts | `clawteam spawn subprocess python --team ...` | ✅ Full support |
 
+OpenClaw commands are normalized to `openclaw agent --message ...` automatically.
+For headless/report-style workflows, prefer `subprocess` or a dedicated `profile`.
+
 For provider-aware setups such as Claude Code via Moonshot Kimi or Gemini via
 Vertex, use `profile` + `preset` and then spawn with `--profile`.
 

--- a/clawteam/spawn/adapters.py
+++ b/clawteam/spawn/adapters.py
@@ -18,7 +18,7 @@ class PreparedCommand:
 
 
 class NativeCliAdapter:
-    """Adapter for direct CLI runtimes such as claude, codex, gemini, kimi, nanobot, qwen, opencode."""
+    """Adapter for direct CLI runtimes such as claude, codex, gemini, kimi, nanobot, openclaw, qwen, opencode."""
 
     def prepare_command(
         self,
@@ -60,6 +60,8 @@ class NativeCliAdapter:
                 post_launch_prompt = prompt
             elif is_codex_command(normalized_command):
                 final_command.append(prompt)
+            elif is_openclaw_command(normalized_command):
+                final_command.extend(["--message", prompt])
             else:
                 final_command.extend(["-p", prompt])
 
@@ -105,6 +107,11 @@ def is_kimi_command(command: list[str]) -> bool:
 def is_qwen_command(command: list[str]) -> bool:
     """Check if the command is a Qwen Code CLI invocation."""
     return command_basename(command) in ("qwen", "qwen-code")
+
+
+def is_openclaw_command(command: list[str]) -> bool:
+    """Check if the command is an OpenClaw CLI invocation."""
+    return command_basename(command) == "openclaw"
 
 
 def is_opencode_command(command: list[str]) -> bool:

--- a/clawteam/spawn/command_validation.py
+++ b/clawteam/spawn/command_validation.py
@@ -47,6 +47,8 @@ def normalize_spawn_command(command: list[str]) -> list[str]:
     executable = Path(command[0]).name
     if executable == "nanobot" and len(command) == 1:
         return [command[0], "agent"]
+    if executable == "openclaw" and len(command) == 1:
+        return [command[0], "agent"]
 
     return list(command)
 
@@ -90,6 +92,11 @@ def is_kimi_command(command: list[str]) -> bool:
 def is_qwen_command(command: list[str]) -> bool:
     """Check if the command is a Qwen Code CLI invocation."""
     return _cmd_basename(command) in ("qwen", "qwen-code")
+
+
+def is_openclaw_command(command: list[str]) -> bool:
+    """Check if the command is an OpenClaw CLI invocation."""
+    return _cmd_basename(command) == "openclaw"
 
 
 def is_opencode_command(command: list[str]) -> bool:

--- a/docs/skills/clawteam/SKILL.md
+++ b/docs/skills/clawteam/SKILL.md
@@ -35,7 +35,7 @@ Requires Python 3.10+. For P2P transport support: `pip install clawteam[p2p]`.
 ## Prerequisites
 
 - `tmux` installed (default spawn backend)
-- A CLI coding agent such as `claude`, `codex`, `gemini`, `kimi`, or `nanobot`
+- A CLI coding agent such as `claude`, `codex`, `gemini`, `kimi`, `nanobot`, or `openclaw`
 - A git repository for worktree isolation and context features
 - Default dependencies installed if you want the TUI wizard (`clawteam profile wizard`)
 
@@ -187,6 +187,10 @@ Common validated CLIs include:
 - `gemini`
 - `kimi`
 - `nanobot`
+- `openclaw`
+
+OpenClaw commands are normalized to `openclaw agent --message ...` automatically.
+For headless/report-style workflows, prefer `subprocess` or a dedicated `profile`.
 
 Configure non-default providers through `profile` + `preset` instead of hardcoding env vars into prompts.
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -6,6 +6,7 @@ from clawteam.spawn.adapters import (
     NativeCliAdapter,
     command_basename,
     is_interactive_cli,
+    is_openclaw_command,
     is_opencode_command,
     is_qwen_command,
 )
@@ -26,6 +27,12 @@ class TestCLIDetection:
         assert is_opencode_command(["/opt/bin/opencode"])
         assert not is_opencode_command(["openai"])
         assert not is_opencode_command([])
+
+    def test_is_openclaw_command(self):
+        assert is_openclaw_command(["openclaw"])
+        assert is_openclaw_command(["/usr/local/bin/openclaw"])
+        assert not is_openclaw_command(["opencode"])
+        assert not is_openclaw_command([])
 
     def test_is_interactive_cli_covers_all_known(self):
         for cmd in ["claude", "codex", "nanobot", "gemini", "kimi", "qwen", "opencode"]:
@@ -83,6 +90,16 @@ class TestPrepareCommandPrompt:
         )
         assert "-p" in result.final_command
         assert "analyse this" in result.final_command
+        assert result.post_launch_prompt is None
+
+    def test_openclaw_prompt_uses_message_flag_and_normalizes_agent(self):
+        result = self.adapter.prepare_command(
+            ["openclaw"], prompt="analyse this",
+        )
+        assert result.final_command[:2] == ["openclaw", "agent"]
+        assert "--message" in result.final_command
+        assert "analyse this" in result.final_command
+        assert "-p" not in result.final_command
         assert result.post_launch_prompt is None
 
     def test_claude_interactive_gets_post_launch_prompt(self):

--- a/tests/test_spawn_backends.py
+++ b/tests/test_spawn_backends.py
@@ -349,6 +349,96 @@ def test_subprocess_backend_normalizes_nanobot_and_uses_message_flag(monkeypatch
     assert "nanobot agent -w /tmp/demo -m 'do work'" in captured["cmd"]
 
 
+def test_tmux_backend_normalizes_bare_openclaw_and_uses_message_flag(monkeypatch, tmp_path):
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    clawteam_bin = tmp_path / "venv" / "bin" / "clawteam"
+    clawteam_bin.parent.mkdir(parents=True)
+    clawteam_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(sys, "argv", [str(clawteam_bin)])
+
+    run_calls: list[list[str]] = []
+
+    class Result:
+        def __init__(self, returncode: int = 0, stdout: str = ""):
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = ""
+
+    def fake_run(args, **kwargs):
+        run_calls.append(args)
+        if args[:3] == ["tmux", "has-session", "-t"]:
+            return Result(returncode=1)
+        if args[:3] == ["tmux", "list-panes", "-t"]:
+            return Result(returncode=0, stdout="9876\n")
+        return Result(returncode=0)
+
+    def fake_which(name, path=None):
+        if name == "tmux":
+            return "/usr/bin/tmux"
+        if name == "openclaw":
+            return "/usr/bin/openclaw"
+        return None
+
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.shutil.which", fake_which)
+    monkeypatch.setattr("clawteam.spawn.command_validation.shutil.which", fake_which)
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.subprocess.run", fake_run)
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.time.sleep", lambda *_: None)
+    monkeypatch.setattr("clawteam.spawn.registry.register_agent", lambda **_: None)
+
+    backend = TmuxBackend()
+    backend.spawn(
+        command=["openclaw"],
+        agent_name="worker1",
+        agent_id="agent-1",
+        agent_type="general-purpose",
+        team_name="demo-team",
+        prompt="do work",
+        cwd="/tmp/demo",
+        skip_permissions=True,
+    )
+
+    new_session = next(call for call in run_calls if call[:3] == ["tmux", "new-session", "-d"])
+    full_cmd = new_session[-1]
+    assert " openclaw agent --message 'do work';" in full_cmd
+    assert " openclaw agent -p 'do work';" not in full_cmd
+
+
+def test_subprocess_backend_normalizes_openclaw_and_uses_message_flag(monkeypatch, tmp_path):
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    clawteam_bin = tmp_path / "venv" / "bin" / "clawteam"
+    clawteam_bin.parent.mkdir(parents=True)
+    clawteam_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(sys, "argv", [str(clawteam_bin)])
+
+    captured: dict[str, object] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return DummyProcess()
+
+    monkeypatch.setattr(
+        "clawteam.spawn.command_validation.shutil.which",
+        lambda name, path=None: "/usr/bin/openclaw" if name == "openclaw" else None,
+    )
+    monkeypatch.setattr("clawteam.spawn.subprocess_backend.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("clawteam.spawn.registry.register_agent", lambda **_: None)
+
+    backend = SubprocessBackend()
+    backend.spawn(
+        command=["openclaw"],
+        agent_name="worker1",
+        agent_id="agent-1",
+        agent_type="general-purpose",
+        team_name="demo-team",
+        prompt="do work",
+        cwd="/tmp/demo",
+        skip_permissions=True,
+    )
+
+    assert "openclaw agent --message 'do work'" in captured["cmd"]
+    assert "openclaw agent -p 'do work'" not in captured["cmd"]
+
+
 def test_tmux_backend_gemini_skip_permissions_and_prompt(monkeypatch, tmp_path):
     """Gemini gets --yolo for permissions and -p for prompt."""
     monkeypatch.setenv("PATH", "/usr/bin:/bin")


### PR DESCRIPTION
## Summary

ClawTeam currently documents OpenClaw as a first-class runtime, but the generic adapter path still injects prompts with `-p`. That does not match the current OpenClaw CLI, which expects one-shot agent runs through `openclaw agent --message ...`.

This patch adds native OpenClaw command preparation so bare `openclaw` spawns are normalized to `openclaw agent`, and the initial task prompt is passed via `--message` instead of `-p`.

## What changed

- normalize bare `openclaw` to `openclaw agent`
- inject task prompts with `--message` for OpenClaw
- add adapter/backend regression tests for tmux + subprocess paths
- document the normalized OpenClaw invocation and note that `subprocess`/profiles are a better fit for headless report workflows

## Why

Without this change, commands like:

```bash
clawteam spawn tmux openclaw --team ... --task "..."
```

end up launching OpenClaw with `-p`, which the current CLI does not support.

This makes the README claim actionable again and removes the need for a local wrapper just to translate ClawTeam prompts into `openclaw agent --message`.

## Related work

- PR #54 fixes a different but adjacent subprocess issue (unread pipe blocking). I did not duplicate that change here.

## Validation

```bash
ruff check clawteam/spawn/adapters.py clawteam/spawn/command_validation.py tests/test_adapters.py tests/test_spawn_backends.py tests/test_spawn_cli.py
/root/.openclaw/workspace/.venvs/clawteam/bin/python -m pytest -q tests/test_adapters.py tests/test_spawn_backends.py tests/test_spawn_cli.py
```

Result:

- `ruff check` ✅
- `50 passed` ✅
