### PR TITLE
Fix OpenClaw worker spawning via agent --local session adapter

### DIFF
--- a/clawteam/spawn/adapters.py
+++ b/clawteam/spawn/adapters.py
@@ -28,6 +28,7 @@ class NativeCliAdapter:
         cwd: str | None = None,
         skip_permissions: bool = False,
         interactive: bool = False,
+        agent_name: str | None = None,
     ) -> PreparedCommand:
         normalized_command = normalize_spawn_command(command)
         final_command = list(normalized_command)
@@ -55,6 +56,19 @@ class NativeCliAdapter:
                 final_command.extend(["-w", cwd])
             if prompt:
                 final_command.extend(["-m", prompt])
+        elif is_openclaw_command(normalized_command):
+            if "agent" in normalized_command:
+                if "--local" not in normalized_command:
+                    final_command.append("--local")
+                if agent_name and "--session-id" not in normalized_command:
+                    final_command.extend(["--session-id", agent_name])
+                if prompt:
+                    final_command.extend(["--message", prompt])
+            else:
+                if agent_name and "--session" not in normalized_command:
+                    final_command.extend(["--session", agent_name])
+                if prompt:
+                    final_command.extend(["--message", prompt])
         elif prompt:
             if interactive and is_claude_command(normalized_command):
                 post_launch_prompt = prompt
@@ -112,6 +126,11 @@ def is_opencode_command(command: list[str]) -> bool:
     return command_basename(command) == "opencode"
 
 
+def is_openclaw_command(command: list[str]) -> bool:
+    """Check if the command is an OpenClaw CLI invocation."""
+    return command_basename(command) == "openclaw"
+
+
 def is_interactive_cli(command: list[str]) -> bool:
     """Check if the command is a known interactive AI coding CLI."""
     return (
@@ -122,6 +141,7 @@ def is_interactive_cli(command: list[str]) -> bool:
         or is_kimi_command(command)
         or is_qwen_command(command)
         or is_opencode_command(command)
+        or is_openclaw_command(command)
     )
 
 

--- a/clawteam/spawn/command_validation.py
+++ b/clawteam/spawn/command_validation.py
@@ -47,6 +47,8 @@ def normalize_spawn_command(command: list[str]) -> list[str]:
     executable = Path(command[0]).name
     if executable == "nanobot" and len(command) == 1:
         return [command[0], "agent"]
+    if executable == "openclaw" and len(command) == 1:
+        return [command[0], "agent", "--local"]
 
     return list(command)
 

--- a/clawteam/spawn/subprocess_backend.py
+++ b/clawteam/spawn/subprocess_backend.py
@@ -61,6 +61,7 @@ class SubprocessBackend(SpawnBackend):
             prompt=prompt,
             cwd=cwd,
             skip_permissions=skip_permissions,
+            agent_name=agent_name,
             interactive=False,
         )
         normalized_command = prepared.normalized_command

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -75,6 +75,7 @@ class TmuxBackend(SpawnBackend):
             prompt=prompt,
             cwd=cwd,
             skip_permissions=skip_permissions,
+            agent_name=agent_name,
             interactive=True,
         )
         normalized_command = prepared.normalized_command


### PR DESCRIPTION
## Summary

This PR fixes the documented OpenClaw worker path for ClawTeam.

The README currently lists OpenClaw as fully supported via:

```bash
clawteam spawn tmux openclaw --team ...
```

But in `0.1.2`, bare `openclaw` falls through the generic prompt adapter path, which constructs an invalid command shape for OpenClaw and prevents workers from running correctly.

## Root cause

OpenClaw had no dedicated spawn adapter handling, so it was treated like a generic CLI that accepts prompt-style flags.

In practice, OpenClaw workers need a different invocation model from Claude/Codex/Gemini-style CLIs.

## What this changes

### 1. Normalize bare `openclaw` to a runnable worker entrypoint

Bare:

```bash
openclaw
```

now normalizes to:

```bash
openclaw agent --local
```

### 2. Add an OpenClaw-specific adapter path

For OpenClaw agent workers, ClawTeam now:

- preserves / adds `--local`
- injects `--session-id <agent_name>` automatically
- passes the task prompt via `--message <prompt>`

### 3. Pass `agent_name` into the adapter

This is needed so OpenClaw workers get stable per-agent session ids.

## Why this approach

`openclaw tui --message` can connect successfully, but it does not behave reliably as an unattended worker process.

`openclaw agent --local --session-id <agent> --message <prompt>` behaves much better as a ClawTeam worker:

- isolated per-agent session
- one-shot execution model
- correct prompt delivery
- successful local file/task execution

## Validation

Validated locally with OpenClaw workers after this patch:

- worker was spawned through ClawTeam
- worker modified `README.md`
- worker created a git commit
- worker sent a completion message via `clawteam inbox`

Observed working command shape:

```bash
openclaw agent --local --session-id worker1 --message "<full prompt>"
```

## Files changed

- `clawteam/spawn/command_validation.py`
- `clawteam/spawn/adapters.py`
- `clawteam/spawn/subprocess_backend.py`
- `clawteam/spawn/tmux_backend.py`

## User-visible impact

After this patch, the README-documented OpenClaw spawn path becomes functional instead of falling into an incompatible generic adapter path.
