### PR TITLE
feat(spawn): support skill injection and fix Chinese encoding in subprocess mode

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -80,6 +80,27 @@ def _output(data: dict | list, human_fn=None):
         print(json.dumps(data, indent=2, ensure_ascii=False))
 
 
+def _load_skill_content(name: str) -> str | None:
+    """Load skill content from ~/.claude/skills/.
+
+    Supports both directory format (skills/<name>/SKILL.md) and
+    single-file format (skills/<name>.md).
+    """
+    skills_root = Path.home() / ".claude" / "skills"
+    skill_dir = skills_root / name
+    if skill_dir.is_dir():
+        skill_file = skill_dir / "SKILL.md"
+        if not skill_file.exists():
+            md_files = sorted(skill_dir.glob("*.md"))
+            skill_file = md_files[0] if md_files else None
+        if skill_file and skill_file.exists():
+            return skill_file.read_text(encoding="utf-8")
+    single_file = skills_root / f"{name}.md"
+    if single_file.exists():
+        return single_file.read_text(encoding="utf-8")
+    return None
+
+
 # ============================================================================
 # Config Commands
 # ============================================================================
@@ -1586,6 +1607,7 @@ def spawn_agent(
     repo: Optional[str] = typer.Option(None, "--repo", help="Git repo path (default: cwd)"),
     skip_permissions: Optional[bool] = typer.Option(None, "--skip-permissions/--no-skip-permissions", help="Skip tool approval for claude (default: from config, true)"),
     resume: bool = typer.Option(False, "--resume", "-r", help="Resume previous session if available"),
+    skill: Optional[list[str]] = typer.Option(None, "--skill", help="Skill name(s) to inject into the agent's system prompt (repeatable, claude only)"),
 ):
     """Spawn a new agent process with identity + task as its initial prompt.
 
@@ -1689,6 +1711,19 @@ def spawn_agent(
     except ValueError:
         pass  # already a member, ignore
 
+    # Load skill content and build system_prompt
+    system_prompt: str | None = None
+    if skill:
+        skill_parts = []
+        for skill_name in skill:
+            content = _load_skill_content(skill_name)
+            if content is None:
+                console.print(f"[yellow]Warning: skill '{skill_name}' not found in ~/.claude/skills/[/yellow]")
+            else:
+                skill_parts.append(content)
+        if skill_parts:
+            system_prompt = "\n\n".join(skill_parts)
+
     result = be.spawn(
         command=command,
         agent_name=_name,
@@ -1698,6 +1733,7 @@ def spawn_agent(
         prompt=prompt,
         cwd=cwd,
         skip_permissions=skip_permissions,
+        system_prompt=system_prompt,
     )
 
     _output(

--- a/clawteam/spawn/base.py
+++ b/clawteam/spawn/base.py
@@ -20,6 +20,7 @@ class SpawnBackend(ABC):
         env: dict[str, str] | None = None,
         cwd: str | None = None,
         skip_permissions: bool = False,
+        system_prompt: str | None = None,
     ) -> str:
         """Spawn a new agent process. Returns a status message."""
 

--- a/clawteam/spawn/subprocess_backend.py
+++ b/clawteam/spawn/subprocess_backend.py
@@ -27,9 +27,14 @@ class SubprocessBackend(SpawnBackend):
         env: dict[str, str] | None = None,
         cwd: str | None = None,
         skip_permissions: bool = False,
+        system_prompt: str | None = None,
     ) -> str:
         spawn_env = os.environ.copy()
         clawteam_bin = resolve_clawteam_executable()
+        # Ensure UTF-8 locale so Chinese and other non-ASCII characters in
+        # prompts are not mangled when passed through the shell.
+        spawn_env.setdefault("LANG", "en_US.UTF-8")
+        spawn_env.setdefault("LC_CTYPE", "UTF-8")
         spawn_env.update({
             "CLAWTEAM_AGENT_ID": agent_id,
             "CLAWTEAM_AGENT_NAME": agent_name,
@@ -59,6 +64,8 @@ class SubprocessBackend(SpawnBackend):
                 final_command.append("--dangerously-skip-permissions")
             elif _is_codex_command(command):
                 final_command.append("--dangerously-bypass-approvals-and-sandbox")
+        if system_prompt and _is_claude_command(command):
+            final_command.extend(["--append-system-prompt", system_prompt])
         if prompt:
             if _is_codex_command(command):
                 # Codex accepts prompt as positional argument

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -34,6 +34,7 @@ class TmuxBackend(SpawnBackend):
         env: dict[str, str] | None = None,
         cwd: str | None = None,
         skip_permissions: bool = False,
+        system_prompt: str | None = None,
     ) -> str:
         if not shutil.which("tmux"):
             return "Error: tmux not installed"
@@ -72,6 +73,8 @@ class TmuxBackend(SpawnBackend):
                 final_command.append("--dangerously-skip-permissions")
             elif _is_codex_command(command):
                 final_command.append("--dangerously-bypass-approvals-and-sandbox")
+        if system_prompt and _is_claude_command(command):
+            final_command.extend(["--append-system-prompt", system_prompt])
 
         # Codex accepts prompt as a positional argument directly
         if prompt and _is_codex_command(command):

--- a/tests/test_spawn_backends.py
+++ b/tests/test_spawn_backends.py
@@ -149,3 +149,141 @@ def test_resolve_clawteam_executable_accepts_relative_path_with_explicit_directo
 
     assert resolve_clawteam_executable() == str(relative_bin.resolve())
     assert build_spawn_path("/usr/bin:/bin").startswith(f"{relative_bin.parent.resolve()}:")
+
+
+def test_subprocess_backend_injects_system_prompt_for_claude(monkeypatch, tmp_path):
+    """--append-system-prompt is added to the command when system_prompt is given."""
+    clawteam_bin = tmp_path / "bin" / "clawteam"
+    clawteam_bin.parent.mkdir(parents=True)
+    clawteam_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(sys, "argv", [str(clawteam_bin)])
+
+    captured: dict[str, object] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return DummyProcess()
+
+    monkeypatch.setattr("clawteam.spawn.subprocess_backend.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("clawteam.spawn.registry.register_agent", lambda **_: None)
+
+    backend = SubprocessBackend()
+    backend.spawn(
+        command=["claude"],
+        agent_name="worker1",
+        agent_id="agent-1",
+        agent_type="general-purpose",
+        team_name="demo-team",
+        prompt="do work",
+        skip_permissions=True,
+        system_prompt="You are an expert coder.",
+    )
+
+    cmd = captured["cmd"]
+    assert "--append-system-prompt" in cmd
+    assert "You are an expert coder." in cmd
+    # system prompt must appear before -p
+    assert cmd.index("--append-system-prompt") < cmd.index(" -p ")
+
+
+def test_subprocess_backend_skips_system_prompt_for_non_claude(monkeypatch, tmp_path):
+    """--append-system-prompt is NOT added for non-claude commands (e.g. codex)."""
+    clawteam_bin = tmp_path / "bin" / "clawteam"
+    clawteam_bin.parent.mkdir(parents=True)
+    clawteam_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(sys, "argv", [str(clawteam_bin)])
+
+    captured: dict[str, object] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return DummyProcess()
+
+    monkeypatch.setattr("clawteam.spawn.subprocess_backend.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("clawteam.spawn.registry.register_agent", lambda **_: None)
+
+    backend = SubprocessBackend()
+    backend.spawn(
+        command=["codex"],
+        agent_name="worker1",
+        agent_id="agent-1",
+        agent_type="general-purpose",
+        team_name="demo-team",
+        prompt="do work",
+        system_prompt="some system text",
+    )
+
+    assert "--append-system-prompt" not in captured["cmd"]
+
+
+def test_subprocess_backend_sets_utf8_locale(monkeypatch, tmp_path):
+    """LANG and LC_CTYPE are set to UTF-8 so Chinese prompts are not mangled."""
+    clawteam_bin = tmp_path / "bin" / "clawteam"
+    clawteam_bin.parent.mkdir(parents=True)
+    clawteam_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(sys, "argv", [str(clawteam_bin)])
+    monkeypatch.delenv("LANG", raising=False)
+    monkeypatch.delenv("LC_CTYPE", raising=False)
+
+    captured: dict[str, object] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["env"] = kwargs["env"]
+        return DummyProcess()
+
+    monkeypatch.setattr("clawteam.spawn.subprocess_backend.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("clawteam.spawn.registry.register_agent", lambda **_: None)
+
+    backend = SubprocessBackend()
+    backend.spawn(
+        command=["claude"],
+        agent_name="worker1",
+        agent_id="agent-1",
+        agent_type="general-purpose",
+        team_name="demo-team",
+        prompt="使用技能",
+    )
+
+    env = captured["env"]
+    assert env.get("LANG") == "en_US.UTF-8"
+    assert env.get("LC_CTYPE") == "UTF-8"
+
+
+def test_load_skill_content_directory_format(tmp_path, monkeypatch):
+    """Skills stored as directories with SKILL.md are loaded correctly."""
+    from clawteam.cli.commands import _load_skill_content
+
+    skills_root = tmp_path / ".claude" / "skills"
+    skill_dir = skills_root / "my-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("skill content here", encoding="utf-8")
+
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    result = _load_skill_content("my-skill")
+    assert result == "skill content here"
+
+
+def test_load_skill_content_single_file_format(tmp_path, monkeypatch):
+    """Skills stored as a single .md file are loaded correctly."""
+    from clawteam.cli.commands import _load_skill_content
+
+    skills_root = tmp_path / ".claude" / "skills"
+    skills_root.mkdir(parents=True)
+    (skills_root / "gsd-health.md").write_text("# GSD Health\ncheck it", encoding="utf-8")
+
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    result = _load_skill_content("gsd-health")
+    assert result == "# GSD Health\ncheck it"
+
+
+def test_load_skill_content_returns_none_for_missing(tmp_path, monkeypatch):
+    """Returns None when a skill does not exist."""
+    from clawteam.cli.commands import _load_skill_content
+
+    (tmp_path / ".claude" / "skills").mkdir(parents=True)
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    assert _load_skill_content("nonexistent") is None


### PR DESCRIPTION
## Summary

Closes #52

- Add `--skill <name>` flag (repeatable) to `clawteam spawn` — reads skill content from `~/.claude/skills/` and injects it via `--append-system-prompt`, making skills available in non-interactive (`-p`) subprocess mode
- Support both skill formats: directory (`~/.claude/skills/<name>/SKILL.md`) and single-file (`~/.claude/skills/<name>.md`)
- Fix Chinese/non-ASCII prompt mangling by setting `LANG=en_US.UTF-8` and `LC_CTYPE=UTF-8` in subprocess spawn environment (the `M-dM-=M-?` garbling was caused by UTF-8 bytes being interpreted as terminal Meta-key escape sequences when locale was unset)
- Add `system_prompt` parameter to `SpawnBackend.spawn()` interface and both subprocess/tmux backends

## Usage

```bash
clawteam spawn subprocess claude \
  --team myteam --agent-name worker \
  --skill gsd-health \
  --task "Use /gsd-health to check project health" \
  --skip-permissions

# Multiple skills
clawteam spawn subprocess claude \
  --team myteam --agent-name worker \
  --skill gsd-health --skill gsd-review \
  --task "Review and check project health"
```

## Test plan

- [x] All 141 existing tests pass
- [x] 6 new tests added covering: `--append-system-prompt` injection for claude, skip injection for non-claude commands, UTF-8 locale enforcement, directory-format skill loading, single-file skill loading, missing skill returns None

🤖 Generated with [Claude Code](https://claude.com/claude-code)