### PR TITLE
fix(workspace): pass team_name to _ws_manager in conflicts.py

### DIFF
--- a/clawteam/workspace/conflicts.py
+++ b/clawteam/workspace/conflicts.py
@@ -22,7 +22,7 @@ def detect_overlaps(team_name: str, repo: str | None = None) -> list[dict]:
       - low: agents changed files in the same directory
     """
     owners = file_owners(team_name, repo)
-    mgr = _ws_manager(repo)
+    mgr = _ws_manager(team_name, repo)
 
     overlaps: list[dict] = []
     for fname, agents in owners.items():
@@ -129,7 +129,7 @@ def check_conflicts(
 
     Returns list of dicts with: file, conflict_markers (bool), details.
     """
-    mgr = _ws_manager(repo)
+    mgr = _ws_manager(team_name, repo)
     branch_a = _agent_branch(team_name, agent_a)
     branch_b = _agent_branch(team_name, agent_b)
     base_a = _base_branch(team_name, agent_a, mgr)
@@ -235,7 +235,7 @@ def suggest_rebase(
 
     Returns a suggestion string, or None if no rebase is needed.
     """
-    mgr = _ws_manager(repo)
+    mgr = _ws_manager(team_name, repo)
     branch = _agent_branch(team_name, agent_name)
     base = _base_branch(team_name, agent_name, mgr)
 


### PR DESCRIPTION
## Summary

Fixes #73

`_ws_manager()` requires `(team_name, repo)` but `conflicts.py` calls it as `_ws_manager(repo)` in three places, causing `repo` to be misinterpreted as `team_name`. This breaks all conflict detection commands.

## Root cause

```python
# _ws_manager signature (context.py:31)
def _ws_manager(team_name: str, repo: str | None = None) -> WorkspaceManager:

# Bug: repo passed as team_name (conflicts.py:25, 132, 238)
mgr = _ws_manager(repo)          # wrong
mgr = _ws_manager(team_name, repo)  # correct
```

## What breaks

- `detect_overlaps()` — crashes or returns wrong workspace
- `check_conflicts()` — same
- `suggest_rebase()` — same

When `repo` is `None` (the common case), `Path(None)` raises `TypeError`.

## Fix

One-line fix at each call site — pass the `team_name` argument that is already available in the function scope:

```diff
- mgr = _ws_manager(repo)
+ mgr = _ws_manager(team_name, repo)
```

3 insertions, 3 deletions. Single file changed.