### PR TITLE
fix: atomic writes and advisory locking for concurrent file safety

### DIFF
--- a/clawteam/config.py
+++ b/clawteam/config.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
+from clawteam.fileutil import atomic_write_text
+
 
 class AgentProfile(BaseModel):
     """Reusable agent runtime profile for spawn/launch."""
@@ -71,12 +73,8 @@ def load_config() -> ClawTeamConfig:
 
 
 def save_config(cfg: ClawTeamConfig) -> None:
-    """Atomically write config to disk (tmp + rename)."""
-    p = config_path()
-    p.parent.mkdir(parents=True, exist_ok=True)
-    tmp = p.with_suffix(".tmp")
-    tmp.write_text(cfg.model_dump_json(indent=2), encoding="utf-8")
-    tmp.rename(p)
+    """Atomically write config to disk (mkstemp + replace)."""
+    atomic_write_text(config_path(), cfg.model_dump_json(indent=2))
 
 
 def get_effective(key: str) -> tuple[str, str]:

--- a/clawteam/fileutil.py
+++ b/clawteam/fileutil.py
@@ -1,0 +1,66 @@
+"""Atomic file writes and advisory file locking.
+
+Provides two primitives used throughout the codebase to guarantee safe
+concurrent access to shared JSON state files (config, cost summaries,
+spawn registries, etc.).
+
+* ``atomic_write_text`` — mkstemp in the target directory, write, then
+  ``os.replace`` so readers never see a partially-written file.
+* ``file_locked`` — context manager that holds an exclusive ``fcntl.flock``
+  on a sidecar ``.lock`` file, serialising read-modify-write sequences.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+
+def atomic_write_text(
+    path: Path,
+    content: str,
+    *,
+    encoding: str = "utf-8",
+) -> None:
+    """Write *content* to *path* atomically.
+
+    A unique temporary file is created via ``mkstemp`` in the same directory
+    as *path*, written to, then moved into place with ``os.replace``.  If
+    anything goes wrong the temp file is cleaned up and the original *path*
+    is left untouched.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as f:
+            f.write(content)
+        os.replace(tmp, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+@contextmanager
+def file_locked(path: Path) -> Iterator[None]:
+    """Exclusive advisory lock scoped to *path*.
+
+    Creates (or opens) a sidecar ``<path>.lock`` file and holds
+    ``fcntl.LOCK_EX`` for the duration of the ``with`` block.  This
+    serialises concurrent read-modify-write sequences on the same
+    logical file across processes.
+    """
+    lock_path = Path(str(path) + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)

--- a/clawteam/spawn/registry.py
+++ b/clawteam/spawn/registry.py
@@ -9,6 +9,7 @@ import subprocess
 import time
 from pathlib import Path
 
+from clawteam.fileutil import atomic_write_text, file_locked
 from clawteam.team.models import get_data_dir
 
 
@@ -24,16 +25,17 @@ def register_agent(
     pid: int = 0,
     command: list[str] | None = None,
 ) -> None:
-    """Record spawn info for an agent (atomic write)."""
+    """Record spawn info for an agent (atomic + locked write)."""
     path = _registry_path(team_name)
-    registry = _load(path)
-    registry[agent_name] = {
-        "backend": backend,
-        "tmux_target": tmux_target,
-        "pid": pid,
-        "command": command or [],
-    }
-    _save(path, registry)
+    with file_locked(path):
+        registry = _load(path)
+        registry[agent_name] = {
+            "backend": backend,
+            "tmux_target": tmux_target,
+            "pid": pid,
+            "command": command or [],
+        }
+        _save(path, registry)
 
 
 def get_registry(team_name: str) -> dict[str, dict]:
@@ -167,15 +169,4 @@ def _load(path: Path) -> dict:
 
 
 def _save(path: Path, data: dict) -> None:
-    import tempfile
-    path.parent.mkdir(parents=True, exist_ok=True)
-    # Atomic write
-    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
-    try:
-        import os
-        with os.fdopen(fd, "w") as f:
-            json.dump(data, f, indent=2)
-        Path(tmp).replace(path)
-    except BaseException:
-        Path(tmp).unlink(missing_ok=True)
-        raise
+    atomic_write_text(path, json.dumps(data, indent=2))

--- a/clawteam/team/costs.py
+++ b/clawteam/team/costs.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
+from clawteam.fileutil import atomic_write_text, file_locked
 from clawteam.team.models import get_data_dir
 
 
@@ -108,10 +109,10 @@ def _load_summary_cache(team_name: str) -> _CostSummaryCache | None:
 
 
 def _write_summary_cache(team_name: str, cache: _CostSummaryCache) -> None:
-    path = _summary_cache_path(team_name)
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(cache.model_dump_json(indent=2, by_alias=True), encoding="utf-8")
-    tmp.rename(path)
+    atomic_write_text(
+        _summary_cache_path(team_name),
+        cache.model_dump_json(indent=2, by_alias=True),
+    )
 
 
 def _normalize_cost(value: float) -> float:
@@ -159,49 +160,51 @@ def _cache_entry_from_event(path: Path, event: CostEvent) -> _CostCacheEntry:
 
 
 def _sync_summary_cache(team_name: str) -> _CostSummaryCache:
-    root = _costs_root(team_name)
-    cache = _load_summary_cache(team_name) or _empty_summary_cache(team_name)
-    cache_exists = _summary_cache_path(team_name).exists()
-    changed = not cache_exists
+    with file_locked(_summary_cache_path(team_name)):
+        root = _costs_root(team_name)
+        cache = _load_summary_cache(team_name) or _empty_summary_cache(team_name)
+        cache_exists = _summary_cache_path(team_name).exists()
+        changed = not cache_exists
 
-    current_files = {path.name: path for path in sorted(root.glob("cost-*.json"))}
+        current_files = {path.name: path for path in sorted(root.glob("cost-*.json"))}
 
-    for filename in list(cache.files):
-        if filename not in current_files:
-            _remove_cache_entry(cache, filename)
+        for filename in list(cache.files):
+            if filename not in current_files:
+                _remove_cache_entry(cache, filename)
+                changed = True
+
+        for filename, path in current_files.items():
+            stat = path.stat()
+            cached_entry = cache.files.get(filename)
+            if (
+                cached_entry is not None
+                and cached_entry.size == stat.st_size
+                and cached_entry.mtime_ns == stat.st_mtime_ns
+            ):
+                continue
+
+            if cached_entry is not None:
+                _remove_cache_entry(cache, filename)
+                changed = True
+
+            event = _read_event_file(path)
+            if event is None:
+                continue
+
+            _add_cache_entry(cache, filename, _cache_entry_from_event(path, event))
             changed = True
 
-    for filename, path in current_files.items():
-        stat = path.stat()
-        cached_entry = cache.files.get(filename)
-        if (
-            cached_entry is not None
-            and cached_entry.size == stat.st_size
-            and cached_entry.mtime_ns == stat.st_mtime_ns
-        ):
-            continue
-
-        if cached_entry is not None:
-            _remove_cache_entry(cache, filename)
-            changed = True
-
-        event = _read_event_file(path)
-        if event is None:
-            continue
-
-        _add_cache_entry(cache, filename, _cache_entry_from_event(path, event))
-        changed = True
-
-    if changed:
-        _write_summary_cache(team_name, cache)
-    return cache
+        if changed:
+            _write_summary_cache(team_name, cache)
+        return cache
 
 
 def _record_event_in_summary_cache(team_name: str, path: Path, event: CostEvent) -> None:
-    cache = _load_summary_cache(team_name) or _empty_summary_cache(team_name)
-    _remove_cache_entry(cache, path.name)
-    _add_cache_entry(cache, path.name, _cache_entry_from_event(path, event))
-    _write_summary_cache(team_name, cache)
+    with file_locked(_summary_cache_path(team_name)):
+        cache = _load_summary_cache(team_name) or _empty_summary_cache(team_name)
+        _remove_cache_entry(cache, path.name)
+        _add_cache_entry(cache, path.name, _cache_entry_from_event(path, event))
+        _write_summary_cache(team_name, cache)
 
 
 def _cache_to_summary(cache: _CostSummaryCache) -> CostSummary:

--- a/clawteam/team/snapshot.py
+++ b/clawteam/team/snapshot.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from clawteam.fileutil import atomic_write_text
 from clawteam.team.models import get_data_dir
 
 
@@ -268,6 +269,4 @@ class SnapshotManager:
 
 
 def _atomic_write(path: Path, data: dict) -> None:
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
-    tmp.rename(path)
+    atomic_write_text(path, json.dumps(data, indent=2, ensure_ascii=False))

--- a/clawteam/transport/file.py
+++ b/clawteam/transport/file.py
@@ -82,14 +82,16 @@ class FileTransport(Transport):
                 file_handle.close()
 
         def _quarantine(error: str) -> None:
-            self._quarantine_bytes(
-                agent_name,
-                data,
-                error,
-                source_name=original_path.name,
-                consumed_path=consumed_path,
-            )
-            file_handle.close()
+            try:
+                self._quarantine_bytes(
+                    agent_name,
+                    data,
+                    error,
+                    source_name=original_path.name,
+                    consumed_path=consumed_path,
+                )
+            finally:
+                file_handle.close()
 
         return ClaimedMessage(data=data, ack=_ack, quarantine=_quarantine)
 

--- a/clawteam/transport/p2p.py
+++ b/clawteam/transport/p2p.py
@@ -11,6 +11,7 @@ import time
 import uuid
 from pathlib import Path
 
+from clawteam.fileutil import atomic_write_text
 from clawteam.team.models import get_data_dir
 from clawteam.transport.base import Transport
 from clawteam.transport.claimed import ClaimedMessage
@@ -127,10 +128,7 @@ class P2PTransport(Transport):
         if not self._bind_agent or self._port is None:
             return
         peer_file = _peers_dir(self.team_name) / f"{self._bind_agent}.json"
-        info = self._peer_info()
-        tmp = peer_file.with_suffix(".tmp")
-        tmp.write_text(json.dumps(info), encoding="utf-8")
-        tmp.rename(peer_file)
+        atomic_write_text(peer_file, json.dumps(self._peer_info()))
 
     def _deregister_peer(self) -> None:
         """Remove peers/{agent}.json."""

--- a/tests/test_fileutil.py
+++ b/tests/test_fileutil.py
@@ -1,0 +1,145 @@
+"""Tests for clawteam.fileutil — atomic writes and advisory file locking."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from clawteam.fileutil import atomic_write_text, file_locked
+
+
+class TestAtomicWriteText:
+
+    def test_creates_file(self, tmp_path: Path):
+        target = tmp_path / "out.json"
+        atomic_write_text(target, '{"ok": true}')
+        assert target.read_text() == '{"ok": true}'
+
+    def test_creates_parent_dirs(self, tmp_path: Path):
+        target = tmp_path / "a" / "b" / "c.json"
+        atomic_write_text(target, "hello")
+        assert target.read_text() == "hello"
+
+    def test_overwrites_existing(self, tmp_path: Path):
+        target = tmp_path / "data.json"
+        target.write_text("old")
+        atomic_write_text(target, "new")
+        assert target.read_text() == "new"
+
+    def test_no_leftover_tmp_on_success(self, tmp_path: Path):
+        target = tmp_path / "clean.json"
+        atomic_write_text(target, "data")
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert tmp_files == []
+
+    def test_cleans_up_on_error(self, tmp_path: Path, monkeypatch):
+        """If os.replace fails the temp file is removed."""
+        target = tmp_path / "fail.json"
+
+        def failing_replace(src, dst):
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr("os.replace", failing_replace)
+
+        try:
+            atomic_write_text(target, "data")
+        except OSError:
+            pass
+
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert tmp_files == []
+        assert not target.exists()
+
+    def test_concurrent_writes_no_collision(self, tmp_path: Path):
+        """Multiple threads writing to the same path never produce a corrupt file."""
+        target = tmp_path / "shared.json"
+        errors: list[Exception] = []
+
+        def writer(value: int):
+            try:
+                for _ in range(20):
+                    atomic_write_text(target, f'{{"v": {value}}}')
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=writer, args=(i,)) for i in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        content = target.read_text()
+        assert content.startswith('{"v":')
+
+
+class TestFileLocked:
+
+    def test_serialises_concurrent_updates(self, tmp_path: Path):
+        """Two threads incrementing a shared counter never lose an update."""
+        counter_path = tmp_path / "counter.json"
+        counter_path.write_text("0")
+        iterations = 50
+
+        def increment():
+            for _ in range(iterations):
+                with file_locked(counter_path):
+                    val = int(counter_path.read_text())
+                    counter_path.write_text(str(val + 1))
+
+        t1 = threading.Thread(target=increment)
+        t2 = threading.Thread(target=increment)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert int(counter_path.read_text()) == iterations * 2
+
+    def test_creates_lock_sidecar(self, tmp_path: Path):
+        target = tmp_path / "data.json"
+        target.write_text("{}")
+        with file_locked(target):
+            lock_file = Path(str(target) + ".lock")
+            assert lock_file.exists()
+
+    def test_lock_released_after_context(self, tmp_path: Path):
+        """After exiting the context, another lock acquisition succeeds immediately."""
+        target = tmp_path / "release.json"
+        target.write_text("{}")
+
+        with file_locked(target):
+            pass
+
+        acquired = threading.Event()
+
+        def try_lock():
+            with file_locked(target):
+                acquired.set()
+
+        t = threading.Thread(target=try_lock)
+        t.start()
+        t.join(timeout=2.0)
+        assert acquired.is_set()
+
+    def test_lock_released_on_exception(self, tmp_path: Path):
+        """Lock is released even when the body raises."""
+        target = tmp_path / "exc.json"
+        target.write_text("{}")
+
+        try:
+            with file_locked(target):
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+
+        acquired = threading.Event()
+
+        def try_lock():
+            with file_locked(target):
+                acquired.set()
+
+        t = threading.Thread(target=try_lock)
+        t.start()
+        t.join(timeout=2.0)
+        assert acquired.is_set()


### PR DESCRIPTION
## Summary

- **New `clawteam/fileutil.py`**: Two shared primitives extracted from patterns already proven correct in `tasks.py`:
  - `atomic_write_text(path, content)` — `mkstemp` + write + `os.replace`, with cleanup on failure. Replaces the fixed-name `.tmp` pattern that let concurrent writers clobber each other's temp files.
  - `file_locked(path)` — context manager holding `fcntl.LOCK_EX` on a sidecar `.lock` file, serialising read-modify-write sequences across processes.

- **`costs.py`** (highest impact): summary cache now uses `atomic_write_text` and wraps both `_sync_summary_cache` and `_record_event_in_summary_cache` in `file_locked`, preventing concurrent `report()`/`summary()` from corrupting totals.

- **`registry.py`**: `register_agent` wrapped in `file_locked` so parallel spawns on the same team cannot lose registry entries; `_save` simplified from 12 lines to 1.

- **`config.py`**: `save_config` uses `atomic_write_text` instead of fixed `config.tmp`.

- **`transport/p2p.py`**: `_register_peer` uses `atomic_write_text` instead of fixed `{agent}.tmp`.

- **`transport/file.py`**: `_quarantine` callback wraps `file_handle.close()` in `finally` so the handle (and its `flock`) is released even when `_quarantine_bytes` raises.

- **`team/snapshot.py`**: `_atomic_write` delegates to `atomic_write_text`.

## Root cause

Multiple files used `path.with_suffix(".tmp")` for "atomic" writes, producing a **fixed temp filename** per target. When two processes write concurrently (e.g., two agents reporting costs, or parallel spawns registering), they write to the **same** temp file, and the last `os.rename` wins — silently dropping the other's data.

Additionally, read-modify-write paths (`_load` -> mutate -> `_save`) had no mutual exclusion, so concurrent updates could read stale state and overwrite each other.

## Test plan

- [x] 336/336 tests pass (zero regressions)
- [x] New `tests/test_fileutil.py`: 10 tests covering atomic writes (creation, overwrite, parent dirs, cleanup on error, concurrent collision resistance) and file locking (mutual exclusion under thread contention, sidecar creation, release after context, release on exception)
- [x] `ruff check` passes on all modified files


Made with [Cursor](https://cursor.com)