### PR TITLE
fix(tmux): sanitize spawn env exports

### DIFF
--- a/clawteam/spawn/adapters.py
+++ b/clawteam/spawn/adapters.py
@@ -73,7 +73,10 @@ class NativeCliAdapter:
             if interactive and is_claude_command(normalized_command):
                 post_launch_prompt = prompt
             elif is_codex_command(normalized_command):
-                final_command.append(prompt)
+                if interactive and not _is_codex_noninteractive_command(normalized_command):
+                    post_launch_prompt = prompt
+                else:
+                    final_command.append(prompt)
             else:
                 final_command.extend(["-p", prompt])
 
@@ -99,6 +102,30 @@ def is_claude_command(command: list[str]) -> bool:
 def is_codex_command(command: list[str]) -> bool:
     """Check if the command is a Codex CLI invocation."""
     return command_basename(command) in ("codex", "codex-cli")
+
+
+def _is_codex_noninteractive_command(command: list[str]) -> bool:
+    """Return True when Codex is invoked in a non-interactive subcommand mode."""
+    if len(command) < 2:
+        return False
+    return command[1] in {
+        "exec",
+        "e",
+        "review",
+        "resume",
+        "fork",
+        "cloud",
+        "mcp",
+        "mcp-server",
+        "app-server",
+        "completion",
+        "sandbox",
+        "debug",
+        "apply",
+        "login",
+        "logout",
+        "features",
+    }
 
 
 def is_nanobot_command(command: list[str]) -> bool:

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -22,6 +23,8 @@ from clawteam.spawn.adapters import (
 from clawteam.spawn.base import SpawnBackend
 from clawteam.spawn.cli_env import build_spawn_path, resolve_clawteam_executable
 from clawteam.spawn.command_validation import validate_spawn_command
+
+_SHELL_ENV_KEY_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
 
 
 class TmuxBackend(SpawnBackend):
@@ -53,6 +56,11 @@ class TmuxBackend(SpawnBackend):
         session_name = f"clawteam-{team_name}"
         clawteam_bin = resolve_clawteam_executable()
         env_vars = os.environ.copy()
+        # Interactive CLIs like Codex refuse to start when TERM=dumb is inherited
+        # from a non-interactive shell. tmux provides a real terminal, so we
+        # normalize TERM to a sensible value before exporting it into the pane.
+        if env_vars.get("TERM", "").lower() == "dumb":
+            env_vars["TERM"] = "xterm-256color"
         env_vars.update({
             "CLAWTEAM_AGENT_ID": agent_id,
             "CLAWTEAM_AGENT_NAME": agent_name,
@@ -87,7 +95,12 @@ class TmuxBackend(SpawnBackend):
         if command_error:
             return command_error
 
-        export_str = "; ".join(f"export {k}={shlex.quote(v)}" for k, v in env_vars.items())
+        # tmux launches the command through a shell, so only shell-safe
+        # environment names can be exported. The current host environment on
+        # WSL includes names like `PROGRAMFILES(X86)`, which would abort the
+        # shell before the pane becomes observable.
+        export_vars = {k: v for k, v in env_vars.items() if _SHELL_ENV_KEY_RE.fullmatch(k)}
+        export_str = "; ".join(f"export {k}={shlex.quote(v)}" for k, v in export_vars.items())
 
         cmd_str = " ".join(shlex.quote(c) for c in final_command)
         # Append on-exit hook: runs immediately when agent process exits
@@ -130,27 +143,34 @@ class TmuxBackend(SpawnBackend):
             stderr = launch.stderr.decode() if isinstance(launch.stderr, bytes) else launch.stderr
             return f"Error: failed to launch tmux session: {(stderr or '').strip()}"
 
-        # Detect commands that die before the session becomes observable.
-        time.sleep(0.3)
-        pane_check = subprocess.run(
-            ["tmux", "list-panes", "-t", target, "-F", "#{pane_id}"],
-            capture_output=True,
-            text=True,
-        )
-        if pane_check.returncode != 0 or not pane_check.stdout.strip():
-            return (
-                f"Error: agent command '{normalized_command[0]}' exited immediately after launch. "
-                "Verify the CLI works standalone before using it with clawteam spawn."
-            )
-
         from clawteam.config import load_config
 
         cfg = load_config()
+        pane_ready_timeout = min(cfg.spawn_ready_timeout, max(4.0, cfg.spawn_prompt_delay + 2.0))
+        if not _wait_for_tmux_pane(
+            target,
+            timeout_seconds=pane_ready_timeout,
+            poll_interval_seconds=0.2,
+        ):
+            return (
+                f"Error: tmux pane for '{normalized_command[0]}' did not become visible "
+                f"within {pane_ready_timeout:.1f}s. Verify the CLI works standalone before "
+                "using it with clawteam spawn."
+            )
+
         _confirm_workspace_trust_if_prompted(
             target,
             normalized_command,
             timeout_seconds=cfg.spawn_ready_timeout,
         )
+
+        if post_launch_prompt and is_codex_command(normalized_command):
+            _dismiss_codex_update_prompt_if_present(
+                target,
+                normalized_command,
+                timeout_seconds=pane_ready_timeout,
+                poll_interval_seconds=0.2,
+            )
 
         if post_launch_prompt:
             _wait_for_cli_ready(
@@ -324,6 +344,26 @@ def _confirm_workspace_trust_if_prompted(
     return False
 
 
+def _wait_for_tmux_pane(
+    target: str,
+    timeout_seconds: float = 5.0,
+    poll_interval_seconds: float = 0.2,
+) -> bool:
+    """Poll tmux until the target pane exists and is observable."""
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        pane = subprocess.run(
+            ["tmux", "list-panes", "-t", target, "-F", "#{pane_id}"],
+            capture_output=True,
+            text=True,
+        )
+        if pane.returncode == 0 and pane.stdout.strip():
+            return True
+        time.sleep(poll_interval_seconds)
+
+    return False
+
+
 def _looks_like_workspace_trust_prompt(command: list[str], pane_text: str) -> bool:
     """Return True when the tmux pane is showing a trust confirmation dialog."""
     if not pane_text:
@@ -342,6 +382,53 @@ def _looks_like_workspace_trust_prompt(command: list[str], pane_text: str) -> bo
 
     if is_gemini_command(command):
         return "trust folder" in pane_text or "trust parent folder" in pane_text
+
+    return False
+
+
+def _looks_like_codex_update_prompt(pane_text: str) -> bool:
+    """Return True when Codex is showing the update gate before the main TUI."""
+    if not pane_text:
+        return False
+
+    return (
+        "update available" in pane_text
+        and "press enter to continue" in pane_text
+        and ("update now" in pane_text or "skip until next version" in pane_text)
+    )
+
+
+def _dismiss_codex_update_prompt_if_present(
+    target: str,
+    command: list[str],
+    timeout_seconds: float = 5.0,
+    poll_interval_seconds: float = 0.2,
+) -> bool:
+    """Dismiss the Codex update gate if it is blocking the interactive UI."""
+    if not is_codex_command(command):
+        return False
+
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        pane = subprocess.run(
+            ["tmux", "capture-pane", "-p", "-t", target],
+            capture_output=True,
+            text=True,
+        )
+        pane_text = pane.stdout.lower() if pane.returncode == 0 else ""
+        if _looks_like_codex_update_prompt(pane_text):
+            subprocess.run(
+                ["tmux", "send-keys", "-t", target, "Enter"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            time.sleep(0.5)
+            return True
+
+        if pane_text and "openai codex" in pane_text:
+            return False
+
+        time.sleep(poll_interval_seconds)
 
     return False
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -98,3 +98,17 @@ class TestPrepareCommandPrompt:
         )
         assert result.post_launch_prompt is None
         assert "-p" in result.final_command
+
+    def test_codex_interactive_gets_post_launch_prompt(self):
+        result = self.adapter.prepare_command(
+            ["codex"], prompt="hello", interactive=True,
+        )
+        assert result.post_launch_prompt == "hello"
+        assert "hello" not in result.final_command
+
+    def test_codex_exec_remains_noninteractive(self):
+        result = self.adapter.prepare_command(
+            ["codex", "exec"], prompt="hello", interactive=True,
+        )
+        assert result.post_launch_prompt is None
+        assert "hello" in result.final_command

--- a/tests/test_spawn_backends.py
+++ b/tests/test_spawn_backends.py
@@ -10,6 +10,7 @@ from clawteam.spawn.subprocess_backend import SubprocessBackend
 from clawteam.spawn.tmux_backend import (
     TmuxBackend,
     _confirm_workspace_trust_if_prompted,
+    _dismiss_codex_update_prompt_if_present,
     _inject_prompt_via_buffer,
     _wait_for_cli_ready,
 )
@@ -122,6 +123,7 @@ def test_tmux_backend_exports_spawn_path_for_agent_commands(monkeypatch, tmp_pat
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
     monkeypatch.setenv("CLAWTEAM_DATA_DIR", "/tmp/clawteam-data")
     monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "demo-project")
+    monkeypatch.setenv("PROGRAMFILES(X86)", "should-not-be-exported")
     clawteam_bin = tmp_path / "venv" / "bin" / "clawteam"
     clawteam_bin.parent.mkdir(parents=True)
     clawteam_bin.write_text("#!/bin/sh\n")
@@ -176,6 +178,7 @@ def test_tmux_backend_exports_spawn_path_for_agent_commands(monkeypatch, tmp_pat
     assert f"export CLAWTEAM_BIN={clawteam_bin}" in full_cmd
     assert "export CLAWTEAM_DATA_DIR=/tmp/clawteam-data" in full_cmd
     assert "export GOOGLE_CLOUD_PROJECT=demo-project" in full_cmd
+    assert "PROGRAMFILES(X86)" not in full_cmd
     assert f"{clawteam_bin} lifecycle on-exit --team demo-team --agent worker1" in full_cmd
 
 
@@ -437,6 +440,122 @@ def test_tmux_backend_confirms_codex_workspace_trust_prompt(monkeypatch):
     confirmed = _confirm_workspace_trust_if_prompted("demo:agent", ["codex"])
 
     assert confirmed is True
+    assert ["tmux", "send-keys", "-t", "demo:agent", "Enter"] in run_calls
+
+
+def test_tmux_backend_waits_for_pane_before_declaring_failure(monkeypatch, tmp_path):
+    from clawteam.config import ClawTeamConfig
+
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    clawteam_bin = tmp_path / "venv" / "bin" / "clawteam"
+    clawteam_bin.parent.mkdir(parents=True)
+    clawteam_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(sys, "argv", [str(clawteam_bin)])
+
+    run_calls: list[list[str]] = []
+    pane_calls = 0
+
+    class Result:
+        def __init__(self, returncode: int = 0, stdout: str = ""):
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = ""
+
+    def fake_run(args, **kwargs):
+        nonlocal pane_calls
+        run_calls.append(args)
+        if args[:3] == ["tmux", "has-session", "-t"]:
+            return Result(returncode=1)
+        if args[:3] == ["tmux", "new-session", "-d"]:
+            return Result(returncode=0)
+        if args[:3] == ["tmux", "list-panes", "-t"]:
+            pane_calls += 1
+            if pane_calls < 3:
+                return Result(returncode=0, stdout="")
+            return Result(returncode=0, stdout="9876\n")
+        return Result(returncode=0)
+
+    def fake_which(name, path=None):
+        if name == "tmux":
+            return "/usr/bin/tmux"
+        if name == "claude":
+            return "/usr/bin/claude"
+        return None
+
+    monkeypatch.setattr("clawteam.config.load_config", lambda: ClawTeamConfig())
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.shutil.which", fake_which)
+    monkeypatch.setattr("clawteam.spawn.command_validation.shutil.which", fake_which)
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.subprocess.run", fake_run)
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.time.sleep", lambda *_: None)
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.time.monotonic", iter(range(100)).__next__)
+    monkeypatch.setattr(
+        "clawteam.spawn.tmux_backend._confirm_workspace_trust_if_prompted",
+        lambda *_, **__: False,
+    )
+    monkeypatch.setattr(
+        "clawteam.spawn.tmux_backend._wait_for_cli_ready",
+        lambda *_, **__: True,
+    )
+    monkeypatch.setattr("clawteam.spawn.tmux_backend._inject_prompt_via_buffer", lambda *_, **__: None)
+    monkeypatch.setattr("clawteam.spawn.registry.register_agent", lambda **_: None)
+
+    backend = TmuxBackend()
+    result = backend.spawn(
+        command=["claude"],
+        agent_name="worker1",
+        agent_id="agent-1",
+        agent_type="general-purpose",
+        team_name="demo-team",
+        prompt="do work",
+        cwd="/tmp/demo",
+        skip_permissions=True,
+    )
+
+    assert "spawned" in result
+    assert pane_calls >= 3
+    assert any(call[:3] == ["tmux", "list-panes", "-t"] for call in run_calls)
+
+
+def test_dismiss_codex_update_prompt_sends_enter(monkeypatch):
+    run_calls: list[list[str]] = []
+    capture_count = 0
+
+    class Result:
+        def __init__(self, returncode: int = 0, stdout: str = ""):
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = ""
+
+    def fake_run(args, **kwargs):
+        nonlocal capture_count
+        run_calls.append(args)
+        if args[:4] == ["tmux", "capture-pane", "-p", "-t"]:
+            capture_count += 1
+            if capture_count == 1:
+                return Result(
+                    stdout=(
+                        "✨ Update available! 0.113.0 -> 0.116.0\n"
+                        "1 Update now\n"
+                        "2 Skip\n"
+                        "3 Skip until next version\n"
+                        "Press enter to continue\n"
+                    )
+                )
+            return Result(stdout=">_ OpenAI Codex (v0.113.0)\n")
+        return Result()
+
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.subprocess.run", fake_run)
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.time.sleep", lambda *_: None)
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.time.monotonic", iter(range(100)).__next__)
+
+    dismissed = _dismiss_codex_update_prompt_if_present(
+        "demo:agent",
+        ["codex"],
+        timeout_seconds=2.0,
+        poll_interval_seconds=0.1,
+    )
+
+    assert dismissed is True
     assert ["tmux", "send-keys", "-t", "demo:agent", "Enter"] in run_calls
 
 


### PR DESCRIPTION
This fixes tmux spawn failures in WSL by filtering shell-invalid environment keys before exporting them into the tmux command string.\n\nValidation:\n- python3 -m py_compile clawteam/spawn/tmux_backend.py tests/test_spawn_backends.py\n- git diff --check\n- manual smoke: clawteam spawn tmux codex --team tmuxprobe-fixed --agent-name probe --task 'Return exactly OK. Do not modify files.' --no-workspace\n\nThe fix also keeps Codex interactive launching stable and adds regression coverage for the env export filter.