### PR TITLE
Upgrade MiniMax presets to M2.7 and add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,10 @@ clawteam preset show moonshot-cn
 # Generate a reusable runtime profile from a preset
 clawteam preset generate-profile moonshot-cn claude --name claude-kimi
 
+# MiniMax (M2.7) — global or China endpoint
+clawteam preset generate-profile minimax-global claude --name claude-minimax
+clawteam preset generate-profile minimax-cn claude --name claude-minimax-cn
+
 # Or use the interactive TUI
 clawteam profile wizard
 
@@ -467,6 +471,7 @@ clawteam profile doctor claude
 
 # Smoke-test the profile before spawning workers
 MOONSHOT_API_KEY=... clawteam profile test claude-kimi
+MINIMAX_API_KEY=... clawteam profile test claude-minimax
 ```
 
 Rules of thumb:
@@ -537,7 +542,7 @@ All examples below assume the corresponding CLI already runs standalone on your 
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | 🔮 Experimental |
 | Custom scripts | `clawteam spawn subprocess python --team ...` | ✅ Full support |
 
-For provider-aware setups such as Claude Code via Moonshot Kimi or Gemini via
+For provider-aware setups such as Claude Code via Moonshot Kimi, MiniMax, or Gemini via
 Vertex, use `profile` + `preset` and then spawn with `--profile`.
 
 ---

--- a/README_CN.md
+++ b/README_CN.md
@@ -407,6 +407,10 @@ clawteam preset show moonshot-cn
 # 从 preset 生成可复用的 runtime profile
 clawteam preset generate-profile moonshot-cn claude --name claude-kimi
 
+# MiniMax（M2.7）— 国际或国内端点
+clawteam preset generate-profile minimax-global claude --name claude-minimax
+clawteam preset generate-profile minimax-cn claude --name claude-minimax-cn
+
 # 或使用交互式 TUI
 clawteam profile wizard
 
@@ -415,6 +419,7 @@ clawteam profile doctor claude
 
 # 在真正 spawn 之前先做 smoke test
 MOONSHOT_API_KEY=... clawteam profile test claude-kimi
+MINIMAX_API_KEY=... clawteam profile test claude-minimax
 ```
 
 可以这样理解：
@@ -481,7 +486,7 @@ clawteam spawn subprocess <your-agent> --team my-team --agent-name test --task "
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | 🔮 实验性 |
 | 自定义脚本 | `clawteam spawn subprocess python --team ...` | ✅ 完全支持 |
 
-像 “Claude Code 走 Moonshot Kimi” 或 “Gemini 走 Vertex” 这类 provider-aware 场景，
+像 “Claude Code 走 Moonshot Kimi”、”Claude Code 走 MiniMax” 或 “Gemini 走 Vertex” 这类 provider-aware 场景，
 推荐先用 `profile` + `preset` 配好，再通过 `--profile` 启动。
 
 ---

--- a/clawteam/spawn/presets.py
+++ b/clawteam/spawn/presets.py
@@ -137,7 +137,7 @@ def builtin_presets() -> dict[str, AgentPreset]:
             "MiniMax China Anthropic-compatible Claude Code endpoint.",
             "MINIMAX_API_KEY",
             "https://api.minimaxi.com/anthropic",
-            "MiniMax-M2.5",
+            "MiniMax-M2.7",
             extra_env={
                 "API_TIMEOUT_MS": "3000000",
                 "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
@@ -147,7 +147,7 @@ def builtin_presets() -> dict[str, AgentPreset]:
             "MiniMax global Anthropic-compatible Claude Code endpoint.",
             "MINIMAX_API_KEY",
             "https://api.minimax.io/anthropic",
-            "MiniMax-M2.5",
+            "MiniMax-M2.7",
             extra_env={
                 "API_TIMEOUT_MS": "3000000",
                 "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -31,6 +31,42 @@ def test_generate_profile_from_openrouter_preset_for_multiple_clients():
     assert gemini_profile.model == "google/gemini-2.5-pro"
 
 
+def test_generate_profile_from_minimax_global_preset():
+    name, profile = generate_profile_from_preset("minimax-global", "claude")
+
+    assert name == "claude-minimax-global"
+    assert profile.agent == "claude"
+    assert profile.model == "MiniMax-M2.7"
+    assert profile.base_url == "https://api.minimax.io/anthropic"
+    assert profile.api_key_env == "MINIMAX_API_KEY"
+    assert profile.env["ANTHROPIC_MODEL"] == "MiniMax-M2.7"
+    assert profile.env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "MiniMax-M2.7"
+    assert profile.env["API_TIMEOUT_MS"] == "3000000"
+    assert profile.env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
+
+
+def test_generate_profile_from_minimax_cn_preset():
+    name, profile = generate_profile_from_preset("minimax-cn", "claude")
+
+    assert name == "claude-minimax-cn"
+    assert profile.agent == "claude"
+    assert profile.model == "MiniMax-M2.7"
+    assert profile.base_url == "https://api.minimaxi.com/anthropic"
+    assert profile.api_key_env == "MINIMAX_API_KEY"
+    assert profile.env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "MiniMax-M2.7"
+    assert profile.env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "MiniMax-M2.7"
+
+
+def test_minimax_presets_in_builtin_list():
+    presets = list_presets()
+    assert "minimax-cn" in presets
+    assert "minimax-global" in presets
+    _, source_cn = presets["minimax-cn"]
+    _, source_global = presets["minimax-global"]
+    assert source_cn == "builtin"
+    assert source_global == "builtin"
+
+
 def test_generate_profile_from_google_ai_studio_preset():
     name, profile = generate_profile_from_preset("google-ai-studio", "gemini")
 


### PR DESCRIPTION
## Summary

- **Upgrade MiniMax presets** from MiniMax-M2.5 to MiniMax-M2.7 (latest model, 1M context window)
- **Add MiniMax documentation** to README.md and README_CN.md with preset usage examples in the Profiles and Presets section
- **Mention MiniMax** in the provider-aware setup notes alongside Moonshot and Vertex
- **Add 3 unit tests** for MiniMax preset profile generation and builtin listing

## Changes

| File | What changed |
|------|-------------|
| clawteam/spawn/presets.py | Model upgrade M2.5 to M2.7 for both minimax-cn and minimax-global |
| README.md | MiniMax preset examples + provider mention |
| README_CN.md | MiniMax preset examples + provider mention (Chinese) |
| tests/test_presets.py | 3 new tests: global preset, CN preset, builtin listing |

## Test plan

- [x] All 336 existing tests pass
- [x] 3 new MiniMax preset tests pass
- [ ] Verify clawteam preset show minimax-global shows M2.7
- [ ] Verify clawteam preset generate-profile minimax-global claude generates correct profile
