### PR TITLE
Add board APIs, review-state support, and transport regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,58 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]"
       - run: python -m pytest tests/ -v --tb=short
+
+  frontend-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm install
+      - run: npm run build
+
+  build-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install hatch
+      - run: hatch build
+
+  check-p2p:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[p2p,dev]"
+      - run: python -m pytest tests/ -v --tb=short
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [frontend-build, lint, test, build-python, check-p2p]
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm install
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -1,0 +1,63 @@
+# Technical Specification: ClawTeam Web Dashboard & API
+
+## Overview
+The goal is to provide a real-time web-based dashboard for monitoring ClawTeam agent swarms. This includes a landing page and a RESTful API for team management, task tracking, and inter-agent communication.
+
+## Backend Architecture (BoardHandler)
+The backend is a lightweight HTTP server implemented in `clawteam/board/server.py` using Python's `http.server` module.
+
+### REST API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET    | `/api/overview` | Returns a list of all active teams. |
+| GET    | `/api/team/{team_name}` | Returns a full snapshot of the specified team (members, tasks, messages). |
+| GET    | `/api/events/{team_name}` | Server-Sent Events (SSE) stream for real-time team updates. |
+| POST   | `/api/teams` | Creates a new team. |
+| POST   | `/api/teams/{team_name}/tasks` | Creates a new task within a team. |
+| PATCH  | `/api/teams/{team_name}/tasks/{task_id}` | Updates an existing task (status, owner, etc.). |
+| POST   | `/api/teams/{team_name}/messages` | Sends a message to an agent or broadcasts to the team. |
+
+### Real-time Synchronization
+- **SSE Stream**: The `/api/events/{team_name}` endpoint provides a continuous stream of team snapshots.
+- **Caching**: `TeamSnapshotCache` with a TTL (default 2s) is used to prevent over-collecting from the filesystem during high-frequency SSE requests.
+
+## Frontend Architecture (Landing Page)
+The frontend is built using React and Vite, located in the `website/` directory.
+
+### Key Components
+- **Hero Section**: High-level value proposition and quick-start guide.
+- **Terminal Mockup**: Visual representation of CLI usage.
+- **Globe Visualization**: Animated 3D globe showing agent connectivity.
+- **Feature Cards**: Summary of core capabilities.
+- **Workflow Steps**: Three-step guide to starting a swarm.
+
+## Testing Strategy
+- **Unit Tests**: Implement comprehensive unit tests for `BoardHandler` in `tests/test_api.py`.
+- **Integration Tests**: Verify end-to-end flows from API calls to filesystem changes.
+- **UI Validation**: Ensure the landing page is responsive and visually consistent.
+
+## Task Breakdown
+
+### Phase 1: API Core Implementation (backend-dev)
+- [x] Implement `_handle_create_team`
+- [x] Implement `_handle_create_task`
+- [x] Implement `_handle_update_task`
+- [x] Implement `_handle_send_message`
+- [ ] Implement robust error handling and validation for all endpoints
+
+### Phase 2: Landing Page & UI (frontend-dev)
+- [x] Design and implement Hero section
+- [x] Build Terminal Mockup component
+- [x] Implement animated Globe visualization
+- [ ] Connect dashboard to real API endpoints (currently mocked)
+
+### Phase 3: Quality Assurance (qa-engineer)
+- [ ] Write unit tests for API endpoints in `tests/test_api.py`
+- [ ] Perform integration testing for task dependency auto-unblocking
+- [ ] Verify message delivery across different transport backends
+
+### Phase 4: DevOps & CI/CD (devops)
+- [x] Set up basic GitHub Actions workflow for linting and testing
+- [ ] Add deployment pipeline for the landing page
+- [ ] Configure performance monitoring for the board server

--- a/clawteam/board/collector.py
+++ b/clawteam/board/collector.py
@@ -93,12 +93,8 @@ class BoardCollector:
 
         # Tasks grouped by status
         all_tasks = store.list_tasks()
-        grouped: dict[str, list[dict]] = {
-            "pending": [],
-            "in_progress": [],
-            "completed": [],
-            "blocked": [],
-        }
+        from clawteam.team.models import TaskStatus
+        grouped: dict[str, list[dict]] = {s.value: [] for s in TaskStatus}
         for t in all_tasks:
             td = json.loads(t.model_dump_json(by_alias=True, exclude_none=True))
             grouped[t.status.value].append(td)

--- a/clawteam/board/renderer.py
+++ b/clawteam/board/renderer.py
@@ -174,10 +174,11 @@ class BoardRenderer:
         return Panel(body, title=title, border_style="red" if high > 0 else "yellow")
 
     def _build_task_kanban(self, tasks: dict, summary: dict) -> Panel:
-        """Build the 4-column kanban task board."""
+        """Build the kanban task board."""
         columns_cfg = [
             ("PENDING", "pending", "yellow"),
             ("IN PROGRESS", "in_progress", "cyan"),
+            ("REVIEW", "review", "magenta"),
             ("COMPLETED", "completed", "green"),
             ("BLOCKED", "blocked", "red"),
         ]

--- a/clawteam/board/server.py
+++ b/clawteam/board/server.py
@@ -46,6 +46,23 @@ class BoardHandler(BaseHTTPRequestHandler):
     interval: float = 2.0
     team_cache: TeamSnapshotCache
 
+    # Performance monitoring stats
+    _total_requests: int = 0
+    _active_connections: int = 0
+    _stats_lock: threading.Lock = threading.Lock()
+
+    def handle(self):
+        """Handle a single HTTP request with performance tracking."""
+        self._start_time = time.monotonic()
+        with self._stats_lock:
+            BoardHandler._active_connections += 1
+            BoardHandler._total_requests += 1
+        try:
+            super().handle()
+        finally:
+            with self._stats_lock:
+                BoardHandler._active_connections -= 1
+
     def do_GET(self):
         path = self.path.split("?")[0]
 
@@ -53,6 +70,8 @@ class BoardHandler(BaseHTTPRequestHandler):
             self._serve_static("index.html", "text/html")
         elif path == "/api/overview":
             self._serve_json(self.collector.collect_overview())
+        elif path == "/api/stats":
+            self._serve_stats()
         elif path.startswith("/api/team/"):
             team_name = path[len("/api/team/"):].strip("/")
             if not team_name:
@@ -67,6 +86,201 @@ class BoardHandler(BaseHTTPRequestHandler):
             self._serve_sse(team_name)
         else:
             self.send_error(404)
+
+    def do_POST(self):
+        path = self.path.split("?")[0]
+
+        if path == "/api/teams":
+            self._handle_create_team()
+        elif path.startswith("/api/teams/") and path.endswith("/tasks"):
+            team_name = path[len("/api/teams/"): -len("/tasks")].strip("/")
+            self._handle_create_task(team_name)
+        elif path.startswith("/api/teams/") and path.endswith("/messages"):
+            team_name = path[len("/api/teams/"): -len("/messages")].strip("/")
+            self._handle_send_message(team_name)
+        else:
+            self.send_error(404)
+
+    def do_PATCH(self):
+        path = self.path.split("?")[0]
+
+        # /api/teams/{team_name}/tasks/{task_id}
+        if path.startswith("/api/teams/"):
+            parts = path[len("/api/teams/"):].strip("/").split("/")
+            if len(parts) == 3 and parts[1] == "tasks":
+                team_name, _, task_id = parts
+                self._handle_update_task(team_name, task_id)
+                return
+
+        self.send_error(404)
+
+    def do_DELETE(self):
+        path = self.path.split("?")[0]
+
+        if path.startswith("/api/teams/"):
+            team_name = path[len("/api/teams/"):].strip("/")
+            if team_name:
+                self._handle_cleanup_team(team_name)
+                return
+
+        self.send_error(404)
+
+    def _get_json_body(self):
+        try:
+            content_length = int(self.headers.get("Content-Length", 0))
+            if content_length == 0:
+                return {}
+            body = self.rfile.read(content_length)
+            return json.loads(body.decode("utf-8"))
+        except Exception:
+            return {}
+
+    def _handle_create_team(self):
+        from clawteam.identity import AgentIdentity
+        from clawteam.team.manager import TeamManager
+
+        body = self._get_json_body()
+        name = body.get("name")
+        if not name:
+            self.send_error(400, "Team name required")
+            return
+
+        description = body.get("description", "")
+        identity = AgentIdentity.from_env()
+
+        try:
+            TeamManager.create_team(
+                name=name,
+                leader_name=body.get("leaderName") or identity.agent_name,
+                leader_id=body.get("leaderId") or identity.agent_id,
+                description=description,
+                user=identity.user,
+            )
+            self._serve_json({"status": "created", "name": name})
+        except ValueError as e:
+            self._serve_error(400, str(e))
+
+    def _handle_create_task(self, team_name: str):
+        from clawteam.team.models import TaskPriority
+        from clawteam.team.tasks import TaskStore
+
+        body = self._get_json_body()
+        subject = body.get("subject")
+        if not subject:
+            self.send_error(400, "Task subject required")
+            return
+
+        try:
+            store = TaskStore(team_name)
+            task = store.create(
+                subject=subject,
+                description=body.get("description", ""),
+                owner=body.get("owner", ""),
+                priority=TaskPriority(body.get("priority", "medium")),
+                blocks=body.get("blocks", []),
+                blocked_by=body.get("blockedBy", []),
+            )
+            self._serve_json(json.loads(task.model_dump_json(by_alias=True, exclude_none=True)))
+        except Exception as e:
+            self._serve_error(400, str(e))
+
+    def _handle_update_task(self, team_name: str, task_id: str):
+        from clawteam.identity import AgentIdentity
+        from clawteam.team.models import TaskPriority, TaskStatus
+        from clawteam.team.tasks import TaskStore
+
+        body = self._get_json_body()
+        try:
+            store = TaskStore(team_name)
+            caller = body.get("caller") or AgentIdentity.from_env().agent_name
+
+            status = body.get("status")
+            priority = body.get("priority")
+
+            task = store.update(
+                task_id,
+                status=TaskStatus(status) if status else None,
+                owner=body.get("owner"),
+                subject=body.get("subject"),
+                description=body.get("description"),
+                priority=TaskPriority(priority) if priority else None,
+                add_blocks=body.get("addBlocks"),
+                add_blocked_by=body.get("addBlockedBy"),
+                caller=caller,
+                force=body.get("force", False),
+            )
+            if not task:
+                self.send_error(404, "Task not found")
+                return
+            self._serve_json(json.loads(task.model_dump_json(by_alias=True, exclude_none=True)))
+        except Exception as e:
+            self._serve_error(400, str(e))
+
+    def _handle_send_message(self, team_name: str):
+        from clawteam.identity import AgentIdentity
+        from clawteam.team.mailbox import MailboxManager
+        from clawteam.team.models import MessageType
+
+        body = self._get_json_body()
+        to = body.get("to")
+        content = body.get("content")
+        if not content:
+            self.send_error(400, "Message content required")
+            return
+
+        try:
+            sender = body.get("from") or AgentIdentity.from_env().agent_name
+            mailbox = MailboxManager(team_name)
+            msg_type = MessageType(body.get("type", "broadcast" if not to else "message"))
+
+            if not to or msg_type == MessageType.broadcast:
+                msgs = mailbox.broadcast(
+                    from_agent=sender,
+                    content=content,
+                    msg_type=msg_type,
+                    key=body.get("key"),
+                )
+                self._serve_json({"status": "sent", "count": len(msgs)})
+            else:
+                msg = mailbox.send(
+                    from_agent=sender,
+                    to=to,
+                    content=content,
+                    msg_type=msg_type,
+                    key=body.get("key"),
+                )
+                self._serve_json(json.loads(msg.model_dump_json(by_alias=True, exclude_none=True)))
+        except Exception as e:
+            self._serve_error(400, str(e))
+
+    def _handle_cleanup_team(self, team_name: str):
+        from clawteam.team.manager import TeamManager
+
+        try:
+            if TeamManager.cleanup(team_name):
+                self._serve_json({"status": "deleted", "name": team_name})
+            else:
+                self.send_error(404, "Team not found")
+        except Exception as e:
+            self._serve_error(400, str(e))
+
+    def _serve_error(self, code: int, message: str):
+        body = json.dumps({"error": message}).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _serve_stats(self):
+        """Serve internal performance stats as JSON."""
+        with self._stats_lock:
+            stats = {
+                "active_connections": self._active_connections,
+                "total_requests": self._total_requests,
+                "uptime_seconds": time.monotonic() - getattr(self.server, "_started_at", time.monotonic()),
+            }
+        self._serve_json(stats)
 
     def _serve_static(self, filename: str, content_type: str):
         filepath = _STATIC_DIR / filename
@@ -130,6 +344,11 @@ class BoardHandler(BaseHTTPRequestHandler):
         if "/api/events/" not in first:
             super().log_message(format, *args)
 
+    def log_request(self, code="-", size="-"):
+        """Override to include duration in logs."""
+        duration = time.monotonic() - getattr(self, "_start_time", time.monotonic())
+        self.log_message('"%s" %s %s [%.4fs]', self.requestline, str(code), str(size), duration)
+
 
 def serve(
     host: str = "127.0.0.1",
@@ -145,6 +364,7 @@ def serve(
     BoardHandler.team_cache = TeamSnapshotCache(ttl_seconds=interval)
 
     server = ThreadingHTTPServer((host, port), BoardHandler)
+    server._started_at = time.monotonic()
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/clawteam/board/static/index.html
+++ b/clawteam/board/static/index.html
@@ -82,7 +82,7 @@ const S = {
 
   // Summary cards
   summaryGrid: {
-    display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)',
+    display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)',
     gap: 12, marginBottom: 24,
   },
   summaryCard: {
@@ -265,7 +265,7 @@ const S = {
 
   // Kanban
   kanban: {
-    display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)',
+    display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)',
     gap: 12,
   },
   kanbanCol: {
@@ -329,6 +329,7 @@ function SummaryCards({ summary }) {
   const items = [
     { key: 'pending', label: 'Pending', color: 'var(--orange)' },
     { key: 'in_progress', label: 'In Progress', color: 'var(--blue)' },
+    { key: 'review', label: 'Review', color: 'var(--purple)' },
     { key: 'completed', label: 'Completed', color: 'var(--green)' },
     { key: 'blocked', label: 'Blocked', color: 'var(--red)' },
   ];
@@ -530,6 +531,7 @@ function Kanban({ tasks }) {
   const cols = [
     { key: 'pending', label: 'Pending', color: 'var(--orange)' },
     { key: 'in_progress', label: 'In Progress', color: 'var(--blue)' },
+    { key: 'review', label: 'Review', color: 'var(--purple)' },
     { key: 'completed', label: 'Completed', color: 'var(--green)' },
     { key: 'blocked', label: 'Blocked', color: 'var(--red)' },
   ];

--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -1825,7 +1825,7 @@ def task_get(
 def task_update(
     team: str = typer.Argument(..., help="Team name"),
     task_id: str = typer.Argument(..., help="Task ID"),
-    status: Optional[str] = typer.Option(None, "--status", "-s", help="New status: pending, in_progress, completed, blocked"),
+    status: Optional[str] = typer.Option(None, "--status", "-s", help="New status: pending, in_progress, review, completed, blocked"),
     owner: Optional[str] = typer.Option(None, "--owner", "-o", help="New owner"),
     subject: Optional[str] = typer.Option(None, "--subject", help="New subject"),
     description: Optional[str] = typer.Option(None, "--description", "-d", help="New description"),
@@ -1905,7 +1905,7 @@ def task_list(
         table.add_column("Blocked By", style="dim")
         for t in items:
             st = t.get("status", "")
-            style = {"pending": "white", "in_progress": "yellow", "completed": "green", "blocked": "red"}.get(st, "")
+            style = {"pending": "white", "in_progress": "yellow", "review": "magenta", "completed": "green", "blocked": "red"}.get(st, "")
             priority_value = t.get("priority", "medium")
             priority_style = {
                 "urgent": "red bold",
@@ -1944,6 +1944,7 @@ def task_stats(
         table.add_row("Total tasks", str(d["total"]))
         table.add_row("Completed", str(d["completed"]))
         table.add_row("In progress", str(d["in_progress"]))
+        table.add_row("Review", str(d.get("review", 0)))
         table.add_row("Pending", str(d["pending"]))
         table.add_row("Blocked", str(d["blocked"]))
         table.add_row("With timing data", str(d["timed_completed"]))
@@ -2152,7 +2153,7 @@ def task_wait(
 
     last_progress = ""
 
-    def _on_progress(completed, total, in_progress, pending, blocked):
+    def _on_progress(completed, total, in_progress, review, pending, blocked):
         nonlocal last_progress
         summary = f"{completed}/{total}"
         if summary == last_progress:
@@ -2164,13 +2165,14 @@ def task_wait(
                 "completed": completed,
                 "total": total,
                 "in_progress": in_progress,
+                "review": review,
                 "pending": pending,
                 "blocked": blocked,
             }), flush=True)
         else:
             console.print(
                 f"  {completed}/{total} tasks completed"
-                f"  ({in_progress} in progress, {pending} pending, {blocked} blocked)"
+                f"  ({in_progress} in progress, {review} review, {pending} pending, {blocked} blocked)"
             )
 
     if not _json_output:
@@ -2216,6 +2218,7 @@ def task_wait(
             "total": result.total,
             "completed": result.completed,
             "in_progress": result.in_progress,
+            "review": result.review,
             "pending": result.pending,
             "blocked": result.blocked,
             "messages_received": result.messages_received,

--- a/clawteam/team/models.py
+++ b/clawteam/team/models.py
@@ -36,6 +36,7 @@ class MemberStatus(str, Enum):
 class TaskStatus(str, Enum):
     pending = "pending"
     in_progress = "in_progress"
+    review = "review"
     completed = "completed"
     blocked = "blocked"
 

--- a/clawteam/team/tasks.py
+++ b/clawteam/team/tasks.py
@@ -121,8 +121,10 @@ class TaskStore:
                 if not task.started_at:
                     task.started_at = _now_iso()
 
-            # Clear lock when transitioning to completed or pending
-            if status in (TaskStatus.completed, TaskStatus.pending):
+            # Clear lock when transitioning out of active execution. Review is
+            # a handoff state, so it should not remain locked to the worker
+            # that finished the implementation.
+            if status in (TaskStatus.completed, TaskStatus.pending, TaskStatus.review):
                 task.locked_by = ""
                 task.locked_at = ""
 
@@ -265,6 +267,7 @@ class TaskStore:
             "total": len(tasks),
             "completed": len(completed),
             "in_progress": sum(1 for t in tasks if t.status == TaskStatus.in_progress),
+            "review": sum(1 for t in tasks if t.status == TaskStatus.review),
             "pending": sum(1 for t in tasks if t.status == TaskStatus.pending),
             "blocked": sum(1 for t in tasks if t.status == TaskStatus.blocked),
             "timed_completed": len(durations),

--- a/clawteam/team/waiter.py
+++ b/clawteam/team/waiter.py
@@ -21,6 +21,7 @@ class WaitResult:
     total: int = 0
     completed: int = 0
     in_progress: int = 0
+    review: int = 0
     pending: int = 0
     blocked: int = 0
     messages_received: int = 0
@@ -47,7 +48,7 @@ class TaskWaiter:
         poll_interval: float = 5.0,
         timeout: float | None = None,
         on_message: Callable[[TeamMessage], None] | None = None,
-        on_progress: Callable[[int, int, int, int, int], None] | None = None,
+        on_progress: Callable[[int, int, int, int, int, int], None] | None = None,
         on_agent_dead: Callable[[str, list[TaskItem]], None] | None = None,
     ):
         self.team_name = team_name
@@ -96,14 +97,15 @@ class TaskWaiter:
                 total = len(tasks)
                 completed = sum(1 for t in tasks if t.status == TaskStatus.completed)
                 in_progress = sum(1 for t in tasks if t.status == TaskStatus.in_progress)
+                review = sum(1 for t in tasks if t.status == TaskStatus.review)
                 pending = sum(1 for t in tasks if t.status == TaskStatus.pending)
                 blocked = sum(1 for t in tasks if t.status == TaskStatus.blocked)
 
                 # Deduplicate progress output
-                summary = f"{completed}/{total}/{in_progress}/{pending}/{blocked}"
+                summary = f"{completed}/{total}/{in_progress}/{review}/{pending}/{blocked}"
                 if summary != last_summary:
                     if self.on_progress:
-                        self.on_progress(completed, total, in_progress, pending, blocked)
+                        self.on_progress(completed, total, in_progress, review, pending, blocked)
                     last_summary = summary
 
                 # 4. All done?
@@ -120,6 +122,7 @@ class TaskWaiter:
                         total=total,
                         completed=completed,
                         in_progress=0,
+                        review=0,
                         pending=0,
                         blocked=0,
                         messages_received=self._messages_received,
@@ -135,6 +138,7 @@ class TaskWaiter:
                         total=total,
                         completed=completed,
                         in_progress=in_progress,
+                        review=review,
                         pending=pending,
                         blocked=blocked,
                         messages_received=self._messages_received,
@@ -154,6 +158,7 @@ class TaskWaiter:
                 total=total,
                 completed=sum(1 for t in tasks if t.status == TaskStatus.completed),
                 in_progress=sum(1 for t in tasks if t.status == TaskStatus.in_progress),
+                review=sum(1 for t in tasks if t.status == TaskStatus.review),
                 pending=sum(1 for t in tasks if t.status == TaskStatus.pending),
                 blocked=sum(1 for t in tasks if t.status == TaskStatus.blocked),
                 messages_received=self._messages_received,

--- a/clawteam/transport/file.py
+++ b/clawteam/transport/file.py
@@ -17,19 +17,23 @@ def _teams_root() -> Path:
     return get_data_dir() / "teams"
 
 
-def _inbox_dir(team_name: str, agent_name: str) -> Path:
+def _inbox_dir(team_name: str, agent_name: str, create: bool = True) -> Path:
     d = _teams_root() / team_name / "inboxes" / agent_name
-    d.mkdir(parents=True, exist_ok=True)
+    if create:
+        d.mkdir(parents=True, exist_ok=True)
     return d
 
 
-def _dead_letter_dir(team_name: str, agent_name: str) -> Path:
+def _dead_letter_dir(team_name: str, agent_name: str, create: bool = True) -> Path:
     d = _teams_root() / team_name / "dead_letters" / agent_name
-    d.mkdir(parents=True, exist_ok=True)
+    if create:
+        d.mkdir(parents=True, exist_ok=True)
     return d
 
 
 def _claimable_paths(inbox: Path) -> list[Path]:
+    if not inbox.exists():
+        return []
     paths = list(inbox.glob("msg-*.json"))
     paths.extend(inbox.glob("msg-*.consumed"))
     return sorted(paths)
@@ -108,7 +112,7 @@ class FileTransport(Transport):
             raise
 
     def claim_messages(self, agent_name: str, limit: int = 10) -> list[ClaimedMessage]:
-        inbox = _inbox_dir(self.team_name, agent_name)
+        inbox = _inbox_dir(self.team_name, agent_name, create=False)
         claimed: list[ClaimedMessage] = []
         for path in _claimable_paths(inbox)[:limit]:
             consumed = path
@@ -180,7 +184,7 @@ class FileTransport(Transport):
         )
 
     def fetch(self, agent_name: str, limit: int = 10, consume: bool = True) -> list[bytes]:
-        inbox = _inbox_dir(self.team_name, agent_name)
+        inbox = _inbox_dir(self.team_name, agent_name, create=False)
         if consume:
             messages = []
             for claimed in self.claim_messages(agent_name, limit):
@@ -200,7 +204,9 @@ class FileTransport(Transport):
         return messages
 
     def count(self, agent_name: str) -> int:
-        inbox = _inbox_dir(self.team_name, agent_name)
+        inbox = _inbox_dir(self.team_name, agent_name, create=False)
+        if not inbox.exists():
+            return 0
         return sum(
             1
             for path in _claimable_paths(inbox)

--- a/docs/skills/clawteam/references/cli-reference.md
+++ b/docs/skills/clawteam/references/cli-reference.md
@@ -199,7 +199,7 @@ clawteam task update <team> <task-id> [options]
 
 | Option | Description |
 |--------|-------------|
-| `--status, -s` | New status: `pending`, `in_progress`, `completed`, `blocked` |
+| `--status, -s` | New status: `pending`, `in_progress`, `review`, `completed`, `blocked` |
 | `--owner, -o` | New owner |
 | `--subject` | New subject |
 | `--description, -d` | New description |
@@ -369,6 +369,7 @@ eval $(clawteam identity set --agent-name alice --team dev-team)
 |--------|-------------|
 | `pending` | Not yet started |
 | `in_progress` | Currently being worked on |
+| `review` | Submitted for review |
 | `completed` | Done (auto-unblocks dependents) |
 | `blocked` | Waiting on other tasks |
 

--- a/skills/clawteam/references/cli-reference.md
+++ b/skills/clawteam/references/cli-reference.md
@@ -199,7 +199,7 @@ clawteam task update <team> <task-id> [options]
 
 | Option | Description |
 |--------|-------------|
-| `--status, -s` | New status: `pending`, `in_progress`, `completed`, `blocked` |
+| `--status, -s` | New status: `pending`, `in_progress`, `review`, `completed`, `blocked` |
 | `--owner, -o` | New owner |
 | `--subject` | New subject |
 | `--description, -d` | New description |
@@ -369,6 +369,7 @@ eval $(clawteam identity set --agent-name alice --team dev-team)
 |--------|-------------|
 | `pending` | Not yet started |
 | `in_progress` | Currently being worked on |
+| `review` | Submitted for review |
 | `completed` | Done (auto-unblocks dependents) |
 | `blocked` | Waiting on other tasks |
 

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import io
+import json
 from pathlib import Path
 
 from clawteam.board.collector import BoardCollector
+from clawteam.board.renderer import BoardRenderer
 from clawteam.board.server import BoardHandler
 from clawteam.team.mailbox import MailboxManager
 from clawteam.team.manager import TeamManager
+from clawteam.team.tasks import TaskStore
+from rich.console import Console
 
 
 def test_collect_overview_does_not_call_collect_team(monkeypatch, tmp_path: Path):
@@ -121,6 +125,32 @@ def test_collect_team_preserves_conflicts_field(monkeypatch, tmp_path: Path):
     data = BoardCollector().collect_team("demo")
 
     assert "conflicts" in data
+
+
+def test_renderer_shows_review_column_and_tasks():
+    console = Console(record=True, width=200)
+    renderer = BoardRenderer(console=console)
+
+    data = {
+        "team": {"name": "demo", "createdAt": "2026-03-24T00:00:00+00:00", "description": "", "leaderName": "lead"},
+        "members": [{"name": "lead", "agentType": "lead", "joinedAt": "2026-03-24T00:00:00+00:00", "inboxCount": 0}],
+        "tasks": {
+            "pending": [],
+            "in_progress": [],
+            "review": [{"id": "task-review-1", "subject": "Review API changes", "owner": "qa"}],
+            "completed": [],
+            "blocked": [],
+        },
+        "taskSummary": {"total": 1, "pending": 0, "in_progress": 0, "review": 1, "completed": 0, "blocked": 0},
+        "conflicts": {"totalOverlaps": 0},
+        "cost": {},
+    }
+
+    renderer.render_team_board(data)
+    output = console.export_text()
+
+    assert "REVIEW (1)" in output
+    assert "Review API changes" in output
 
 
 def test_collect_team_exposes_member_inbox_identity(monkeypatch, tmp_path: Path):
@@ -282,3 +312,108 @@ def test_serve_sse_uses_shared_team_snapshot_cache(monkeypatch):
     handler._serve_sse("demo")
 
     assert calls["count"] == 1
+
+
+def test_handle_create_team(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path))
+
+    handler = object.__new__(BoardHandler)
+    body = json.dumps({"name": "new-team"}).encode("utf-8")
+    handler.headers = {"Content-Length": str(len(body))}
+    handler.rfile = io.BytesIO(body)
+
+    served = {}
+    handler._serve_json = lambda data: served.update(data)
+    handler.send_error = lambda code, msg: served.update({"error_code": code, "error_msg": msg})
+
+    handler._handle_create_team()
+
+    assert "error_code" not in served, f"Error: {served.get('error_msg')}"
+    assert served == {"status": "created", "name": "new-team"}
+    assert TeamManager.get_team("new-team") is not None
+
+
+def test_handle_create_task(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path))
+    TeamManager.create_team("demo", "lead", "l1")
+
+    handler = object.__new__(BoardHandler)
+    body = json.dumps({"subject": "task1", "description": "desc1"}).encode("utf-8")
+    handler.headers = {"Content-Length": str(len(body))}
+    handler.rfile = io.BytesIO(body)
+
+    served = {}
+    handler._serve_json = lambda data: served.update(data)
+    handler.send_error = lambda code, msg: served.update({"error_code": code, "error_msg": msg})
+
+    handler._handle_create_task("demo")
+
+    assert "error_code" not in served, f"Error: {served.get('error_msg')}"
+    assert served["subject"] == "task1"
+    assert served["description"] == "desc1"
+    assert "id" in served
+
+    store = TaskStore("demo")
+    assert len(store.list_tasks()) == 1
+
+
+def test_handle_update_task(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path))
+    TeamManager.create_team("demo", "lead", "l1")
+    store = TaskStore("demo")
+    task = store.create("original", owner="lead")
+
+    handler = object.__new__(BoardHandler)
+    body = json.dumps({"status": "completed", "caller": "lead"}).encode("utf-8")
+    handler.headers = {"Content-Length": str(len(body))}
+    handler.rfile = io.BytesIO(body)
+
+    served = {}
+    handler._serve_json = lambda data: served.update(data)
+    handler.send_error = lambda code, msg: served.update({"error_code": code, "error_msg": msg})
+
+    handler._handle_update_task("demo", task.id)
+
+    assert "error_code" not in served, f"Error: {served.get('error_msg')}"
+    assert served["status"] == "completed"
+
+    updated_task = store.get(task.id)
+    assert updated_task.status.value == "completed"
+
+
+def test_handle_send_message(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path))
+    TeamManager.create_team("demo", "lead", "l1")
+    TeamManager.add_member("demo", "worker", "w1")
+
+    handler = object.__new__(BoardHandler)
+    body = json.dumps({"to": "worker", "content": "hello", "from": "lead"}).encode("utf-8")
+    handler.headers = {"Content-Length": str(len(body))}
+    handler.rfile = io.BytesIO(body)
+
+    served = {}
+    handler._serve_json = lambda data: served.update(data)
+    handler.send_error = lambda code, msg: served.update({"error_code": code, "error_msg": msg})
+
+    handler._handle_send_message("demo")
+
+    assert "error_code" not in served, f"Error: {served.get('error_msg')}"
+    assert served["content"] == "hello"
+    assert served["to"] == "worker"
+    assert served["from"] == "lead"
+
+
+def test_handle_cleanup_team(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path))
+    TeamManager.create_team("demo", "lead", "l1")
+
+    handler = object.__new__(BoardHandler)
+
+    served = {}
+    handler._serve_json = lambda data: served.update(data)
+    handler.send_error = lambda code, msg: served.update({"error_code": code, "error_msg": msg})
+
+    handler._handle_cleanup_team("demo")
+
+    assert served == {"status": "deleted", "name": "demo"}
+    assert TeamManager.get_team("demo") is None

--- a/tests/test_conflicts.py
+++ b/tests/test_conflicts.py
@@ -1,0 +1,84 @@
+
+import pytest
+from unittest.mock import MagicMock, patch
+from clawteam.workspace.conflicts import detect_overlaps, _changed_lines, _compute_severity
+
+@pytest.fixture
+def mock_git():
+    with patch("clawteam.workspace.git._run") as mock:
+        yield mock
+
+def test_changed_lines_parsing(mock_git):
+    # Mock diff output with hunk headers
+    mock_git.return_value = """@@ -10,2 +10,3 @@
+ line1
++line2
++line3
++line4
+@@ -20,1 +23,1 @@
+-old
++new
+"""
+    from pathlib import Path
+    lines = _changed_lines("file.txt", "branch", "base", Path("/tmp/repo"))
+    
+    # +10,3 -> lines 10, 11, 12
+    # +23,1 -> line 23
+    assert lines == {10, 11, 12, 23}
+
+def test_changed_lines_single_line_hunk(mock_git):
+    mock_git.return_value = "@@ -5 +5 @@\n+added"
+    from pathlib import Path
+    lines = _changed_lines("file.txt", "branch", "base", Path("/tmp/repo"))
+    assert lines == {5}
+
+@patch("clawteam.workspace.conflicts.file_owners")
+@patch("clawteam.workspace.conflicts._ws_manager")
+@patch("clawteam.workspace.conflicts._compute_severity")
+def test_detect_overlaps_basic(mock_severity, mock_mgr, mock_owners):
+    mock_owners.return_value = {
+        "file1.txt": ["alice", "bob"],
+        "file2.txt": ["alice"],
+    }
+    mock_severity.return_value = "high"
+    
+    overlaps = detect_overlaps("test-team")
+    
+    assert len(overlaps) == 1
+    assert overlaps[0]["file"] == "file1.txt"
+    assert overlaps[0]["agents"] == ["alice", "bob"]
+    assert overlaps[0]["severity"] == "high"
+
+@patch("clawteam.workspace.conflicts._changed_lines")
+def test_compute_severity_high(mock_changed_lines):
+    # Overlapping lines
+    mock_changed_lines.side_effect = [
+        {10, 11, 12}, # alice
+        {12, 13, 14}, # bob
+    ]
+    
+    mgr = MagicMock()
+    mgr.repo_root = "/tmp/repo"
+    ws_alice = MagicMock(branch_name="br-alice", base_branch="main")
+    ws_bob = MagicMock(branch_name="br-bob", base_branch="main")
+    mgr.get_workspace.side_effect = [ws_alice, ws_bob]
+    
+    severity = _compute_severity("file.txt", ["alice", "bob"], "team", mgr)
+    assert severity == "high"
+
+@patch("clawteam.workspace.conflicts._changed_lines")
+def test_compute_severity_medium(mock_changed_lines):
+    # No overlapping lines
+    mock_changed_lines.side_effect = [
+        {10, 11, 12}, # alice
+        {20, 21, 22}, # bob
+    ]
+    
+    mgr = MagicMock()
+    mgr.repo_root = "/tmp/repo"
+    ws_alice = MagicMock(branch_name="br-alice", base_branch="main")
+    ws_bob = MagicMock(branch_name="br-bob", base_branch="main")
+    mgr.get_workspace.side_effect = [ws_alice, ws_bob]
+    
+    severity = _compute_severity("file.txt", ["alice", "bob"], "team", mgr)
+    assert severity == "medium"

--- a/tests/test_spawn_backends.py
+++ b/tests/test_spawn_backends.py
@@ -25,6 +25,7 @@ class DummyProcess:
 
 
 def test_subprocess_backend_prepends_current_clawteam_bin_to_path(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWTEAM_BIN", raising=False)
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
     clawteam_bin = tmp_path / "venv" / "bin" / "clawteam"
     clawteam_bin.parent.mkdir(parents=True)
@@ -120,6 +121,7 @@ def test_subprocess_backend_discards_output_and_preserves_exit_hook_and_registry
 
 
 def test_tmux_backend_exports_spawn_path_for_agent_commands(monkeypatch, tmp_path):
+    monkeypatch.delenv("CLAWTEAM_BIN", raising=False)
     monkeypatch.setenv("PATH", "/usr/bin:/bin")
     monkeypatch.setenv("CLAWTEAM_DATA_DIR", "/tmp/clawteam-data")
     monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "demo-project")

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -108,6 +108,14 @@ class TestTaskUpdate:
         assert completed.locked_by == ""
         assert completed.locked_at == ""
 
+    def test_review_clears_lock(self, store):
+        t = store.create("ready for review")
+        with patch("clawteam.team.tasks.TaskStore._acquire_lock"):
+            store.update(t.id, status=TaskStatus.in_progress, caller="agent-1")
+        reviewed = store.update(t.id, status=TaskStatus.review)
+        assert reviewed.locked_by == ""
+        assert reviewed.locked_at == ""
+
     def test_updated_at_changes(self, store):
         t = store.create("ts-check")
         original_ts = t.updated_at
@@ -126,9 +134,16 @@ class TestTaskList:
     def test_list_filter_by_status(self, store):
         store.create("pending-one")
         t2 = store.create("blocked-one", blocked_by=["fake-dep"])
+        t3 = store.create("review-one")
+        store.update(t3.id, status=TaskStatus.review)
+
         tasks = store.list_tasks(status=TaskStatus.blocked)
         assert len(tasks) == 1
         assert tasks[0].id == t2.id
+
+        review_tasks = store.list_tasks(status=TaskStatus.review)
+        assert len(review_tasks) == 1
+        assert review_tasks[0].id == t3.id
 
     def test_list_filter_by_owner(self, store):
         store.create("alice-task", owner="alice")
@@ -309,10 +324,13 @@ class TestGetStats:
         store.create("two")
         t3 = store.create("three")
         store.update(t3.id, status=TaskStatus.completed)
+        t4 = store.create("four")
+        store.update(t4.id, status=TaskStatus.review)
 
         stats = store.get_stats()
-        assert stats["total"] == 3
+        assert stats["total"] == 4
         assert stats["completed"] == 1
+        assert stats["review"] == 1
         assert stats["pending"] == 2
 
     def test_stats_with_timed_tasks(self, store):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,166 @@
+
+import pytest
+import os
+import time
+import fcntl
+from pathlib import Path
+from clawteam.transport.file import FileTransport
+from clawteam.transport.p2p import P2PTransport
+from clawteam.team.models import get_data_dir
+
+@pytest.fixture
+def transport(team_name):
+    return FileTransport(team_name)
+
+@pytest.fixture
+def p2p_transport(team_name):
+    t = P2PTransport(team_name, bind_agent="listener")
+    yield t
+    t.close()
+
+def test_p2p_transport_deliver_and_fetch(team_name):
+    # Receiver
+    receiver = P2PTransport(team_name, bind_agent="bob")
+    
+    # Sender
+    sender = P2PTransport(team_name)
+    
+    try:
+        data = b"p2p message"
+        sender.deliver("bob", data)
+        
+        # Fetch on receiver (should use ZMQ)
+        # We might need a small sleep to allow ZMQ to connect and deliver
+        time.sleep(0.2)
+        
+        fetched = receiver.fetch("bob", consume=True)
+        assert len(fetched) == 1
+        assert fetched[0] == data
+        
+    finally:
+        receiver.close()
+        sender.close()
+
+def test_p2p_transport_fallback_to_file(team_name):
+    # Sender only, no receiver listening on ZMQ
+    sender = P2PTransport(team_name)
+    
+    try:
+        data = b"fallback message"
+        # Since "alice" is not registered as a peer, it should fall back to file
+        sender.deliver("alice", data)
+        
+        # Check if file exists
+        inbox_dir = get_data_dir() / "teams" / team_name / "inboxes" / "alice"
+        files = list(inbox_dir.glob("msg-*.json"))
+        assert len(files) == 1
+        
+        # Fetch should work via file fallback
+        receiver = P2PTransport(team_name)
+        fetched = receiver.fetch("alice", consume=True)
+        assert fetched == [data]
+        receiver.close()
+    finally:
+        sender.close()
+
+def test_file_transport_deliver_and_fetch(transport, team_name):
+    data = b"hello world"
+    recipient = "agent1"
+    
+    transport.deliver(recipient, data)
+    
+    # Check if file exists in inbox
+    inbox_dir = get_data_dir() / "teams" / team_name / "inboxes" / recipient
+    files = list(inbox_dir.glob("msg-*.json"))
+    assert len(files) == 1
+    assert files[0].read_bytes() == data
+    
+    # Fetch (consume)
+    fetched = transport.fetch(recipient, consume=True)
+    assert len(fetched) == 1
+    assert fetched[0] == data
+    
+    # Fetch again should be empty
+    assert transport.fetch(recipient, consume=True) == []
+
+def test_file_transport_claim_and_ack(transport, team_name):
+    data = b"test message"
+    recipient = "agent2"
+    
+    transport.deliver(recipient, data)
+    
+    # Claim
+    claimed_msgs = transport.claim_messages(recipient)
+    assert len(claimed_msgs) == 1
+    claimed = claimed_msgs[0]
+    assert claimed.data == data
+    
+    # While claimed, it should be marked as .consumed and locked
+    inbox_dir = get_data_dir() / "teams" / team_name / "inboxes" / recipient
+    consumed_files = list(inbox_dir.glob("msg-*.consumed"))
+    assert len(consumed_files) == 1
+    
+    # Another claim should return nothing (because it's locked)
+    assert transport.claim_messages(recipient) == []
+    
+    # Ack
+    claimed.ack()
+    
+    # File should be gone
+    assert not consumed_files[0].exists()
+    assert transport.claim_messages(recipient) == []
+
+def test_file_transport_quarantine(transport, team_name):
+    data = b"bad message"
+    recipient = "agent3"
+    
+    transport.deliver(recipient, data)
+    claimed = transport.claim_messages(recipient)[0]
+    
+    # Quarantine
+    claimed.quarantine("something went wrong")
+    
+    # Dead letter should exist
+    dead_letter_dir = get_data_dir() / "teams" / team_name / "dead_letters" / recipient
+    # Filter out .meta.json files
+    dead_letters = [p for p in dead_letter_dir.glob("msg-*.json") if not p.name.endswith(".meta.json")]
+    assert len(dead_letters) == 1
+    assert dead_letters[0].read_bytes() == data
+    
+    # Meta file should exist
+    meta_files = list(dead_letter_dir.glob("msg-*.meta.json"))
+    assert len(meta_files) == 1
+
+def test_file_transport_count_and_list_recipients(transport, team_name):
+    transport.deliver("r1", b"m1")
+    transport.deliver("r1", b"m2")
+    transport.deliver("r2", b"m3")
+    
+    # list_recipients before any count side effects
+    recipients = transport.list_recipients()
+    assert set(recipients) == {"r1", "r2"}
+
+    assert transport.count("r1") == 2
+    assert transport.count("r2") == 1
+    
+    assert transport.count("r3") == 0
+    # Bug fixed: count() no longer creates the directory
+    assert "r3" not in transport.list_recipients()
+
+def test_file_transport_fetch_without_consume(transport, team_name):
+    data = b"peek me"
+    recipient = "agent4"
+    transport.deliver(recipient, data)
+    
+    # Fetch without consume
+    fetched = transport.fetch(recipient, consume=False)
+    assert len(fetched) == 1
+    assert fetched[0] == data
+    
+    # Should still be there
+    assert transport.count(recipient) == 1
+    
+    # Fetch with consume
+    fetched_again = transport.fetch(recipient, consume=True)
+    assert fetched_again == [data]
+    assert transport.count(recipient) == 0

--- a/tests/test_waiter.py
+++ b/tests/test_waiter.py
@@ -1,0 +1,135 @@
+
+import pytest
+from unittest.mock import MagicMock, patch
+from clawteam.team.waiter import TaskWaiter, WaitResult, TaskStatus
+
+@pytest.fixture
+def mock_mailbox():
+    return MagicMock()
+
+@pytest.fixture
+def mock_task_store():
+    return MagicMock()
+
+def test_waiter_completion(mock_mailbox, mock_task_store):
+    # Setup mock tasks: first poll has one in progress, second poll all completed
+    task1 = MagicMock(id="1", subject="task1", status=TaskStatus.in_progress, owner="alice")
+    task2 = MagicMock(id="1", subject="task1", status=TaskStatus.completed, owner="alice")
+    
+    mock_task_store.list_tasks.side_effect = [
+        [task1],
+        [task2],
+    ]
+    mock_mailbox.receive.return_value = []
+    
+    waiter = TaskWaiter(
+        team_name="test-team",
+        agent_name="leader",
+        mailbox=mock_mailbox,
+        task_store=mock_task_store,
+        poll_interval=0.01
+    )
+    
+    result = waiter.wait()
+    
+    assert result.status == "completed"
+    assert result.total == 1
+    assert result.completed == 1
+    assert mock_task_store.list_tasks.call_count == 2
+
+def test_waiter_timeout(mock_mailbox, mock_task_store):
+    task = MagicMock(id="1", subject="task1", status=TaskStatus.in_progress, owner="alice")
+    mock_task_store.list_tasks.return_value = [task]
+    mock_mailbox.receive.return_value = []
+    
+    waiter = TaskWaiter(
+        team_name="test-team",
+        agent_name="leader",
+        mailbox=mock_mailbox,
+        task_store=mock_task_store,
+        poll_interval=0.01,
+        timeout=0.05
+    )
+    
+    result = waiter.wait()
+    
+    assert result.status == "timeout"
+    assert result.completed == 0
+    assert result.in_progress == 1
+
+def test_waiter_counts_review_tasks(mock_mailbox, mock_task_store):
+    task = MagicMock(id="1", subject="task1", status=TaskStatus.review, owner="alice")
+    mock_task_store.list_tasks.return_value = [task]
+    mock_mailbox.receive.return_value = []
+
+    waiter = TaskWaiter(
+        team_name="test-team",
+        agent_name="leader",
+        mailbox=mock_mailbox,
+        task_store=mock_task_store,
+        poll_interval=0.01,
+        timeout=0.05
+    )
+
+    result = waiter.wait()
+
+    assert result.status == "timeout"
+    assert result.completed == 0
+    assert result.review == 1
+    assert result.in_progress == 0
+
+def test_waiter_on_message_callback(mock_mailbox, mock_task_store):
+    task = MagicMock(id="1", subject="task1", status=TaskStatus.completed, owner="alice")
+    mock_task_store.list_tasks.return_value = [task]
+    
+    msg = MagicMock()
+    mock_mailbox.receive.side_effect = [[msg], []]
+    
+    received_msgs = []
+    def on_message(m):
+        received_msgs.append(m)
+        
+    waiter = TaskWaiter(
+        team_name="test-team",
+        agent_name="leader",
+        mailbox=mock_mailbox,
+        task_store=mock_task_store,
+        poll_interval=0.01,
+        on_message=on_message
+    )
+    
+    result = waiter.wait()
+    
+    assert result.status == "completed"
+    assert len(received_msgs) == 1
+    assert result.messages_received == 1
+
+@patch("clawteam.spawn.registry.list_dead_agents")
+def test_waiter_dead_agent_recovery(mock_list_dead, mock_mailbox, mock_task_store):
+    # Setup: alice is dead and has an in_progress task
+    mock_list_dead.return_value = ["alice"]
+    
+    task1 = MagicMock(id="t1", subject="task1", status=TaskStatus.in_progress, owner="alice")
+    # After recovery, it should be pending (but our mock list_tasks will just return it)
+    # We want to check if task_store.update was called
+    
+    # Poll 1: alice dead, task in_progress -> recovery triggered -> task2 (completed)
+    # We'll make it complete on second poll to stop the waiter
+    task2 = MagicMock(id="t1", subject="task1", status=TaskStatus.completed, owner="alice")
+    
+    mock_task_store.list_tasks.side_effect = [[task1], [task2]]
+    mock_mailbox.receive.return_value = []
+    
+    waiter = TaskWaiter(
+        team_name="test-team",
+        agent_name="leader",
+        mailbox=mock_mailbox,
+        task_store=mock_task_store,
+        poll_interval=0.01
+    )
+    
+    result = waiter.wait()
+    
+    assert result.status == "completed"
+    # Check if recovery was called
+    mock_task_store.update.assert_called_with("t1", status=TaskStatus.pending)

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,0 +1,70 @@
+
+import pytest
+from unittest.mock import MagicMock, patch
+from clawteam.team.watcher import InboxWatcher
+
+@pytest.fixture
+def mock_mailbox():
+    return MagicMock()
+
+def test_watcher_polling(mock_mailbox):
+    msg = MagicMock(
+        timestamp="2026-03-24",
+        type=MagicMock(value="message"),
+        from_agent="alice",
+        to="bob",
+        content="hello"
+    )
+    # Return one message then stop the loop
+    mock_mailbox.receive.side_effect = [[msg], []]
+    
+    watcher = InboxWatcher(
+        team_name="test-team",
+        agent_name="bob",
+        mailbox=mock_mailbox,
+        poll_interval=0.01
+    )
+    
+    # We need a way to stop the loop after one poll
+    # Patching time.sleep to stop the loop
+    def stop_running(*args):
+        watcher._running = False
+        
+    with patch("time.sleep", side_effect=stop_running):
+        watcher.watch()
+        
+    assert mock_mailbox.receive.call_count >= 1
+    mock_mailbox.receive.assert_any_call("bob", limit=10)
+
+@patch("subprocess.run")
+def test_watcher_exec_callback(mock_run, mock_mailbox):
+    msg = MagicMock(
+        timestamp="2026-03-24",
+        type=MagicMock(value="message"),
+        from_agent="alice",
+        to="bob",
+        content="hello"
+    )
+    msg.model_dump_json.return_value = '{"content": "hello"}'
+    
+    mock_mailbox.receive.side_effect = [[msg], []]
+    
+    watcher = InboxWatcher(
+        team_name="test-team",
+        agent_name="bob",
+        mailbox=mock_mailbox,
+        poll_interval=0.01,
+        exec_cmd="echo $CLAWTEAM_MSG_CONTENT"
+    )
+    
+    def stop_running(*args):
+        watcher._running = False
+        
+    with patch("time.sleep", side_effect=stop_running):
+        watcher.watch()
+        
+    assert mock_run.call_count == 1
+    args, kwargs = mock_run.call_args
+    assert args[0] == "echo $CLAWTEAM_MSG_CONTENT"
+    assert kwargs["env"]["CLAWTEAM_MSG_CONTENT"] == "hello"
+    assert kwargs["env"]["CLAWTEAM_MSG_FROM"] == "alice"

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -182,7 +182,7 @@ function TerminalMockup() {
           <div className="t-status-header">docs-sprint <span className="t-dim">3 agents active</span></div>
           <div className="t-status-row"><span className="t-success">{"\u25cf"}</span> T-001 Build landing page <span className="t-badge t-done">done</span></div>
           <div className="t-status-row"><span className="t-active">{"\u25cf"}</span> T-002 Write API docs <span className="t-badge t-progress">active</span></div>
-          <div className="t-status-row"><span className="t-dim">{"\u25cb"}</span> T-003 Review &amp; merge <span className="t-badge t-blocked">blocked</span></div>
+          <div className="t-status-row"><span className="t-active">{"\u25cf"}</span> T-003 Review &amp; merge <span className="t-badge t-review">review</span></div>
         </div>
         <div className="terminal-line" style={{marginTop:10}}><span className="t-prompt">$</span> <span className="terminal-cursor"/></div>
       </div>

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -13,6 +13,7 @@
   --green: #22c55e;
   --blue: #3b82f6;
   --red: #ef4444;
+  --purple: #a855f7;
   --border: rgba(255, 255, 255, 0.06);
   --border-strong: rgba(255, 255, 255, 0.12);
   --glow: rgba(249, 115, 22, 0.15);
@@ -422,6 +423,10 @@ img {
 .t-blocked {
   background: rgba(239, 68, 68, 0.1);
   color: var(--red);
+}
+.t-review {
+  background: rgba(168, 85, 247, 0.12);
+  color: var(--purple);
 }
 
 .terminal-cursor {


### PR DESCRIPTION
## Summary
- add board server mutation APIs and performance stats endpoints
- add review task status support across the dashboard, CLI, and task accounting
- harden file transport inbox handling so reads and counts do not create missing inboxes
- expand CI and regression coverage for board, waiter, transport, watcher, and conflict handling

## Follow-up fixes from integration review
- release task locks when work moves into review so review handoffs are not blocked
- include review counts in waiter and CLI progress output
- show a REVIEW column in the Rich terminal board to keep terminal and web views aligned

## Validation
- ran targeted regression coverage for board, tasks, transport, waiter, watcher, conflicts, and spawn backends
- result: 107 tests passed
