### PR TITLE
fix(lifecycle): clean up session file on agent exit

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -2554,14 +2554,20 @@ def lifecycle_on_exit(
     team: str = typer.Option(..., "--team", "-t", help="Team name"),
     agent: str = typer.Option(..., "--agent", "-n", help="Agent name"),
 ):
-    """Handle agent process exit: reset in_progress tasks to pending, notify leader.
+    """Handle agent process exit: clean up session and reset in_progress tasks.
 
     This is called automatically as a post-exit hook when an agent process terminates.
     """
+    from clawteam.spawn.sessions import SessionStore
     from clawteam.team.mailbox import MailboxManager
     from clawteam.team.manager import TeamManager
     from clawteam.team.models import TaskStatus
     from clawteam.team.tasks import TaskStore
+
+    # Always clean up the agent's session file, regardless of task status.
+    # Without this, session files accumulate indefinitely under
+    # ~/.clawteam/sessions/{team}/ after every agent exit.
+    SessionStore(team).clear(agent)
 
     store = TaskStore(team)
     tasks = store.list_tasks()
@@ -2573,7 +2579,6 @@ def lifecycle_on_exit(
     ]
 
     if not abandoned:
-        # Agent exited cleanly (all tasks already completed or pending)
         return
 
     for t in abandoned:


### PR DESCRIPTION
## Summary

- `lifecycle on-exit` now calls `SessionStore.clear(agent)` **before** the abandoned-task check
- Previously, session files under `~/.clawteam/sessions/{team}/` accumulated indefinitely because:
  1. Clean exits (no abandoned tasks) hit an early `return`, skipping all cleanup
  2. Even abnormal exits never called session cleanup — only task status was reset

## Changes

- **`clawteam/cli/commands.py`** — 3 lines added (import + `SessionStore.clear()` call), 1 comment removed

## Test plan

- [x] All 333 existing tests pass (`uv run --extra dev pytest tests/`)
- [ ] Manual: spawn a 2-agent team, let them complete, verify `~/.clawteam/sessions/{team}/` is empty after exit

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)