### PR TITLE
Rename ClawTeam skill for Claude Code compatibility

### DIFF
--- a/.agents/skills/clawteam/SKILL.md
+++ b/.agents/skills/clawteam/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ClawTeam Multi-Agent Coordination
+name: ClawTeam
 description: >
   This skill should be used when the user asks to "create a team", "spawn agents",
   "assign tasks", "coordinate multiple agents", "check team status", "view kanban board",


### PR DESCRIPTION
## Summary
- rename the skill from `ClawTeam Multi-Agent Coordination` to `ClawTeam` in `.agents/skills/clawteam/SKILL.md`

## Why
- this skill is intended to be used from Claude Code
- Claude Code did not reliably recognize or use the longer skill name
- shortening the name to `ClawTeam` keeps behavior unchanged while making the skill usable from Claude Code

## Scope
- metadata-only change
- no workflow, reference, or command behavior changes
