### PR TITLE
feat(spawn): add pi-coding-agent spawn adapter

### DIFF
--- a/clawteam/spawn/adapters.py
+++ b/clawteam/spawn/adapters.py
@@ -70,6 +70,14 @@ class NativeCliAdapter:
                     final_command.extend(["--session", agent_name])
                 if prompt:
                     final_command.extend(["--message", prompt])
+        elif is_pi_command(normalized_command):
+            # pi doesn't require special flags for skip_permissions (minimal by design)
+            # pi works in cwd automatically, no workspace flag needed
+            if prompt:
+                if interactive:
+                    final_command.append(prompt)
+                else:
+                    final_command.extend(["-p", prompt])
         elif prompt:
             if interactive and is_claude_command(normalized_command):
                 post_launch_prompt = prompt
@@ -159,6 +167,11 @@ def is_openclaw_command(command: list[str]) -> bool:
     return command_basename(command) == "openclaw"
 
 
+def is_pi_command(command: list[str]) -> bool:
+    """Check if the command is a pi-coding-agent CLI invocation."""
+    return command_basename(command) == "pi"
+
+
 def is_interactive_cli(command: list[str]) -> bool:
     """Check if the command is a known interactive AI coding CLI."""
     return (
@@ -170,6 +183,7 @@ def is_interactive_cli(command: list[str]) -> bool:
         or is_qwen_command(command)
         or is_opencode_command(command)
         or is_openclaw_command(command)
+        or is_pi_command(command)
     )
 
 

--- a/clawteam/spawn/command_validation.py
+++ b/clawteam/spawn/command_validation.py
@@ -99,6 +99,11 @@ def is_opencode_command(command: list[str]) -> bool:
     return _cmd_basename(command) == "opencode"
 
 
+def is_pi_command(command: list[str]) -> bool:
+    """Check if the command is a pi-coding-agent CLI invocation."""
+    return _cmd_basename(command) == "pi"
+
+
 def is_interactive_cli(command: list[str]) -> bool:
     """Check if the command is an interactive AI CLI."""
     return (
@@ -109,6 +114,7 @@ def is_interactive_cli(command: list[str]) -> bool:
         or is_kimi_command(command)
         or is_qwen_command(command)
         or is_opencode_command(command)
+        or is_pi_command(command)
     )
 
 

--- a/clawteam/spawn/subprocess_backend.py
+++ b/clawteam/spawn/subprocess_backend.py
@@ -6,7 +6,7 @@ import os
 import shlex
 import subprocess
 
-from clawteam.spawn.adapters import NativeCliAdapter, is_claude_command
+from clawteam.spawn.adapters import NativeCliAdapter, is_claude_command, is_pi_command
 from clawteam.spawn.base import SpawnBackend
 from clawteam.spawn.cli_env import build_spawn_path, resolve_clawteam_executable
 from clawteam.spawn.command_validation import validate_spawn_command
@@ -70,7 +70,7 @@ class SubprocessBackend(SpawnBackend):
         normalized_command = prepared.normalized_command
         validation_command = normalized_command
         final_command = list(prepared.final_command)
-        if system_prompt and is_claude_command(normalized_command):
+        if system_prompt and (is_claude_command(normalized_command) or is_pi_command(normalized_command)):
             insert_at = final_command.index("-p") if "-p" in final_command else len(final_command)
             final_command[insert_at:insert_at] = ["--append-system-prompt", system_prompt]
 

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -18,6 +18,7 @@ from clawteam.spawn.adapters import (
     is_kimi_command,
     is_nanobot_command,
     is_opencode_command,
+    is_pi_command,
     is_qwen_command,
 )
 from clawteam.spawn.base import SpawnBackend
@@ -91,7 +92,7 @@ class TmuxBackend(SpawnBackend):
         validation_command = normalized_command
         final_command = list(prepared.final_command)
         post_launch_prompt = prepared.post_launch_prompt
-        if system_prompt and is_claude_command(normalized_command):
+        if system_prompt and (is_claude_command(normalized_command) or is_pi_command(normalized_command)):
             insert_at = final_command.index("-p") if "-p" in final_command else len(final_command)
             final_command[insert_at:insert_at] = ["--append-system-prompt", system_prompt]
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -7,6 +7,7 @@ from clawteam.spawn.adapters import (
     command_basename,
     is_interactive_cli,
     is_opencode_command,
+    is_pi_command,
     is_qwen_command,
 )
 
@@ -27,8 +28,14 @@ class TestCLIDetection:
         assert not is_opencode_command(["openai"])
         assert not is_opencode_command([])
 
+    def test_is_pi_command(self):
+        assert is_pi_command(["pi"])
+        assert is_pi_command(["/usr/local/bin/pi"])
+        assert not is_pi_command(["python"])
+        assert not is_pi_command([])
+
     def test_is_interactive_cli_covers_all_known(self):
-        for cmd in ["claude", "codex", "nanobot", "gemini", "kimi", "qwen", "opencode"]:
+        for cmd in ["claude", "codex", "nanobot", "gemini", "kimi", "qwen", "opencode", "pi"]:
             assert is_interactive_cli([cmd]), f"{cmd} should be interactive"
 
     def test_is_interactive_cli_rejects_unknown(self):
@@ -112,3 +119,37 @@ class TestPrepareCommandPrompt:
         )
         assert result.post_launch_prompt is None
         assert "hello" in result.final_command
+
+
+class TestPiCommand:
+    """pi-coding-agent specific command preparation."""
+
+    adapter = NativeCliAdapter()
+
+    def test_pi_interactive_gets_positional_prompt(self):
+        result = self.adapter.prepare_command(
+            ["pi"], prompt="list files", interactive=True,
+        )
+        # pi takes prompt as positional arg in interactive mode (stays in TUI)
+        assert result.final_command == ["pi", "list files"]
+        assert result.post_launch_prompt is None
+
+    def test_pi_noninteractive_gets_flag(self):
+        result = self.adapter.prepare_command(
+            ["pi"], prompt="list files", interactive=False,
+        )
+        assert result.post_launch_prompt is None
+        assert "-p" in result.final_command
+        assert "list files" in result.final_command
+
+    def test_pi_skip_permissions_no_special_flag(self):
+        result = self.adapter.prepare_command(
+            ["pi"], skip_permissions=True,
+        )
+        # pi is minimal by design, no skip_permissions flag needed
+        assert result.final_command == ["pi"]
+
+    def test_pi_without_prompt_unchanged(self):
+        result = self.adapter.prepare_command(["pi"])
+        assert result.final_command == ["pi"]
+        assert result.post_launch_prompt is None

--- a/tests/test_spawn_backends.py
+++ b/tests/test_spawn_backends.py
@@ -1347,3 +1347,100 @@ def test_load_skill_content_returns_none_for_missing(tmp_path, monkeypatch):
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
 
     assert _load_skill_content("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# pi system_prompt tests
+# ---------------------------------------------------------------------------
+
+
+def test_subprocess_backend_pi_injects_system_prompt(monkeypatch, tmp_path):
+    """pi gets --append-system-prompt when system_prompt is provided."""
+    clawteam_bin = tmp_path / "bin" / "clawteam"
+    clawteam_bin.parent.mkdir(parents=True)
+    clawteam_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(sys, "argv", [str(clawteam_bin)])
+
+    captured: dict[str, object] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return DummyProcess()
+
+    monkeypatch.setattr(
+        "clawteam.spawn.command_validation.shutil.which",
+        lambda name, path=None: "/usr/bin/pi" if name == "pi" else None,
+    )
+    monkeypatch.setattr("clawteam.spawn.subprocess_backend.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("clawteam.spawn.registry.register_agent", lambda **_: None)
+
+    backend = SubprocessBackend()
+    backend.spawn(
+        command=["pi"],
+        agent_name="worker1",
+        agent_id="agent-1",
+        agent_type="general-purpose",
+        team_name="demo-team",
+        prompt="do work",
+        system_prompt="You are a team worker.",
+    )
+
+    cmd = captured["cmd"]
+    assert "--append-system-prompt" in cmd
+    assert "You are a team worker." in cmd
+
+
+def test_tmux_backend_pi_injects_system_prompt(monkeypatch, tmp_path):
+    """pi in tmux gets --append-system-prompt when system_prompt is provided."""
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    clawteam_bin = tmp_path / "venv" / "bin" / "clawteam"
+    clawteam_bin.parent.mkdir(parents=True)
+    clawteam_bin.write_text("#!/bin/sh\n")
+    monkeypatch.setattr(sys, "argv", [str(clawteam_bin)])
+
+    run_calls: list[list[str]] = []
+
+    class Result:
+        def __init__(self, returncode: int = 0, stdout: str = ""):
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = ""
+
+    def fake_run(args, **kwargs):
+        run_calls.append(args)
+        if args[:3] == ["tmux", "has-session", "-t"]:
+            return Result(returncode=1)
+        if args[:3] == ["tmux", "list-panes", "-t"]:
+            return Result(returncode=0, stdout="9876\n")
+        return Result(returncode=0)
+
+    def fake_which(name, path=None):
+        if name == "tmux":
+            return "/usr/bin/tmux"
+        if name == "pi":
+            return "/usr/bin/pi"
+        return None
+
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.shutil.which", fake_which)
+    monkeypatch.setattr("clawteam.spawn.command_validation.shutil.which", fake_which)
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.subprocess.run", fake_run)
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.time.sleep", lambda *_: None)
+    monkeypatch.setattr("clawteam.spawn.tmux_backend.time.monotonic", lambda: 0)
+    monkeypatch.setattr("clawteam.spawn.registry.register_agent", lambda **_: None)
+
+    backend = TmuxBackend()
+    backend.spawn(
+        command=["pi"],
+        agent_name="worker1",
+        agent_id="agent-1",
+        agent_type="general-purpose",
+        team_name="demo-team",
+        prompt="do work",
+        cwd="/tmp/demo",
+        system_prompt="You are a team worker.",
+    )
+
+    new_session = next(c for c in run_calls if c[:3] == ["tmux", "new-session", "-d"])
+    full_cmd = new_session[-1]
+    assert "--append-system-prompt" in full_cmd
+    assert "You are a team worker." in full_cmd


### PR DESCRIPTION
## Summary

Adds first-class support for the [pi-coding-agent](https://github.com/mariozechner/pi-coding-agent) CLI (`pi`) as a spawn target, alongside Claude, Codex, Gemini, and others.

### Changes

**Detection** (`command_validation.py`, `adapters.py`):
- `is_pi_command()` — detects `pi` binary (with full path support)
- `_is_interactive_cli()` updated to include pi

**Both backends** (`tmux_backend.py`, `subprocess_backend.py`):
- `--append-system-prompt` injection enabled for pi (same mechanism as Claude)

**Adapter** (`adapters.py`):
- Interactive mode: prompt passed as positional argument — pi starts TUI with the initial prompt, no post-launch buffer injection needed
- Non-interactive mode: uses `-p` flag (`--print`)
- `skip_permissions`: no special flags needed (pi is minimal by design)

**Tests**: 6 new tests covering command detection, interactive/non-interactive prompt delivery, skip-permissions, and system prompt injection (subprocess + tmux). All 423 tests pass.

### Usage

```toml
# team config
[agents.worker]
command = ["pi"]
```

```bash
clawteam spawn tmux pi --team myteam --agent-name worker1 --task "Analyze code"
# → pi "Analyze code"  (interactive TUI with initial prompt)

clawteam spawn subprocess pi --team myteam --agent-name worker2 --task "Fix the bug"
# → pi -p "Fix the bug"  (non-interactive)
```

## Test plan

- [x] `pytest tests/test_adapters.py` — 19/19 pass
- [x] `pytest tests/test_spawn_backends.py` — 38/38 pass
- [x] `pytest` (full suite) — 423/423 pass
- [x] `ruff check` — clean

---

*This is My First public PR and it fully written in [pi](https://github.com/mariozechner/pi-coding-agent).*