### PR TITLE
feat(spawn): add WshBackend for TideTerm/WaveTerminal block-based agent spawning

### DIFF
--- a/clawteam/spawn/__init__.py
+++ b/clawteam/spawn/__init__.py
@@ -13,8 +13,11 @@ def get_backend(name: str = "tmux") -> SpawnBackend:
     elif name == "tmux":
         from clawteam.spawn.tmux_backend import TmuxBackend
         return TmuxBackend()
+    elif name == "wsh":
+        from clawteam.spawn.wsh_backend import WshBackend
+        return WshBackend()
     else:
-        raise ValueError(f"Unknown spawn backend: {name}. Available: subprocess, tmux")
+        raise ValueError(f"Unknown spawn backend: {name}. Available: subprocess, tmux, wsh")
 
 
 __all__ = ["SpawnBackend", "get_backend"]

--- a/clawteam/spawn/registry.py
+++ b/clawteam/spawn/registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import signal
 import subprocess
 import time
@@ -27,6 +28,7 @@ def register_agent(
     agent_name: str,
     backend: str,
     tmux_target: str = "",
+    block_id: str = "",
     pid: int = 0,
     command: list[str] | None = None,
 ) -> None:
@@ -37,6 +39,7 @@ def register_agent(
         registry[agent_name] = {
             "backend": backend,
             "tmux_target": tmux_target,
+            "block_id": block_id,
             "pid": pid,
             "command": command or [],
             "spawned_at": time.time(),
@@ -71,6 +74,8 @@ def is_agent_alive(team_name: str, agent_name: str) -> bool | None:
         return alive
     elif backend == "subprocess":
         return _pid_alive(info.get("pid", 0))
+    elif backend == "wsh":
+        return _wsh_block_alive(info.get("block_id", ""))
     return None
 
 
@@ -144,6 +149,14 @@ def stop_agent(team_name: str, agent_name: str, timeout_seconds: float = 3.0) ->
                 pass
             except PermissionError:
                 return False
+    elif backend == "wsh":
+        block_id = info.get("block_id", "")
+        if block_id:
+            subprocess.run(
+                ["wsh", "deleteblock", "-b", block_id],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
 
     deadline = time.time() + timeout_seconds
     while time.time() < deadline:
@@ -191,6 +204,43 @@ def _pid_alive(pid: int) -> bool:
     except PermissionError:
         # Process exists but we can't signal it
         return True
+
+
+def _wsh_block_alive(block_id: str) -> bool:
+    """Check if a wsh block is still alive."""
+    if not block_id:
+        return False
+
+    wsh_bin = shutil.which("wsh")
+    if not wsh_bin:
+        for p in [
+            Path.home() / ".local/share/tideterm/bin/wsh",
+            Path.home() / ".local/state/waveterm/bin/wsh",
+        ]:
+            if p.is_file() and os.access(p, os.X_OK):
+                wsh_bin = str(p)
+                break
+    if not wsh_bin:
+        return False
+
+    result = subprocess.run(
+        [wsh_bin, "blocks", "list", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=5.0,
+    )
+    if result.returncode != 0:
+        return False
+
+    try:
+        blocks = json.loads(result.stdout)
+        for block in blocks:
+            if block.get("blockid") == block_id:
+                return True
+    except json.JSONDecodeError:
+        pass
+
+    return False
 
 
 def _load(path: Path) -> dict:

--- a/clawteam/spawn/wsh_backend.py
+++ b/clawteam/spawn/wsh_backend.py
@@ -1,0 +1,397 @@
+"""Wsh spawn backend - launches agents in TideTerm/WaveTerminal blocks."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from clawteam.spawn.adapters import (
+    NativeCliAdapter,
+    is_claude_command,
+    is_codex_command,
+    is_gemini_command,
+    is_kimi_command,
+    is_nanobot_command,
+    is_opencode_command,
+    is_qwen_command,
+)
+from clawteam.spawn.base import SpawnBackend
+from clawteam.spawn.cli_env import build_spawn_path, resolve_clawteam_executable
+from clawteam.spawn.command_validation import validate_spawn_command
+from clawteam.spawn.wsh_rpc import WshRpcClient
+
+
+def _validate_path(path: str) -> str | None:
+    """Validate and normalize a path. Returns error message or None if valid."""
+    try:
+        resolved = Path(path).resolve()
+        if not resolved.exists():
+            return f"Error: path does not exist: {path}"
+        if not resolved.is_dir():
+            return f"Error: path is not a directory: {path}"
+    except Exception:
+        return f"Error: invalid path: {path}"
+    return None
+
+
+def _wait_for_wsh_block(
+    block_id: str,
+    timeout_seconds: float = 30.0,
+    poll_interval_seconds: float = 0.5,
+) -> bool:
+    """Poll wsh until target block exists and is observable."""
+    wsh_bin = _find_wsh()
+    if not wsh_bin:
+        return False
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            [wsh_bin, "blocks", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+        if result.returncode == 0:
+            try:
+                blocks = json.loads(result.stdout)
+                for block in blocks:
+                    if block.get("blockid") == block_id:
+                        return True
+            except json.JSONDecodeError:
+                pass
+        time.sleep(poll_interval_seconds)
+
+    return False
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]|\x1b\].*?\x07|\x1b\[.*?m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _capture_block_output(block_id: str, tail_lines: int = 100) -> str:
+    """Capture terminal output from a block via wavefile protocol."""
+    wsh_bin = _find_wsh()
+    if not wsh_bin:
+        return ""
+    result = subprocess.run(
+        [wsh_bin, "file", "cat", f"wavefile://{block_id}/term"],
+        capture_output=True,
+        text=True,
+        timeout=10.0,
+    )
+    if result.returncode != 0:
+        return ""
+
+    cleaned = _strip_ansi(result.stdout)
+    if tail_lines > 0:
+        lines = cleaned.splitlines()
+        return "\n".join(lines[-tail_lines:])
+    return cleaned
+
+
+def _wait_for_cli_ready(
+    block_id: str,
+    command: list[str],
+    timeout_seconds: float = 30.0,
+    poll_interval: float = 1.0,
+) -> bool:
+    """Poll block until CLI shows an input prompt."""
+    deadline = time.monotonic() + timeout_seconds
+    last_content = ""
+    stable_count = 0
+
+    while time.monotonic() < deadline:
+        text = _capture_block_output(block_id)
+        lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+        tail = lines[-10:] if len(lines) >= 10 else lines
+
+        for line in tail:
+            if line.startswith(("❯", ">", "›")):
+                return True
+            if "Try " in line and "write a test" in line:
+                return True
+
+        if text == last_content and lines:
+            stable_count += 1
+            if stable_count >= 2:
+                return True
+        else:
+            stable_count = 0
+            last_content = text
+
+        time.sleep(poll_interval)
+
+    return False
+
+
+def _is_block_alive(block_id: str) -> bool:
+    """Check if a wsh block is still alive."""
+    if not block_id:
+        return False
+    wsh_bin = _find_wsh()
+    if not wsh_bin:
+        return False
+    result = subprocess.run(
+        [wsh_bin, "blocks", "list", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=5.0,
+    )
+    if result.returncode != 0:
+        return False
+
+    try:
+        blocks = json.loads(result.stdout)
+        for block in blocks:
+            if block.get("blockid") == block_id:
+                meta = block.get("meta", {})
+                controller = meta.get("controller", "")
+                return controller in ("shell", "cmd")
+    except json.JSONDecodeError:
+        pass
+
+    return False
+
+
+def _looks_like_workspace_trust_prompt(command: list[str], pane_text: str) -> bool:
+    """Return True when block is showing a trust confirmation dialog."""
+    if not pane_text:
+        return False
+
+    if is_claude_command(command):
+        return ("trust this folder" in pane_text or "trust contents" in pane_text) and (
+            "enter to confirm" in pane_text
+            or "press enter" in pane_text
+            or "enter to continue" in pane_text
+        )
+
+    if is_codex_command(command):
+        return (
+            "trust contents of this directory" in pane_text
+            and "press enter to continue" in pane_text
+        )
+
+    if is_gemini_command(command):
+        return "trust folder" in pane_text or "trust parent folder" in pane_text
+
+    return False
+
+
+_WSH_SEARCH_PATHS = [
+    Path.home() / ".local/share/tideterm/bin/wsh",
+    Path.home() / ".local/state/waveterm/bin/wsh",
+]
+
+
+def _find_wsh() -> str | None:
+    """Find wsh executable via PATH or known locations."""
+    found = shutil.which("wsh")
+    if found:
+        return found
+    for p in _WSH_SEARCH_PATHS:
+        if p.is_file() and os.access(p, os.X_OK):
+            return str(p)
+    return None
+
+
+class WshBackend(SpawnBackend):
+    """Spawn agents in TideTerm/WaveTerminal blocks.
+
+    Each agent gets its own block with isolated terminal session.
+    Terminal output is captured via wavefile protocol.
+    Input is injected via JSON-RPC over Unix socket.
+    """
+
+    def __init__(self):
+        self._blocks: dict[str, str] = {}
+        self._adapter = NativeCliAdapter()
+        self._rpc_client: WshRpcClient | None = None
+
+    def spawn(
+        self,
+        command: list[str],
+        agent_name: str,
+        agent_id: str,
+        agent_type: str,
+        team_name: str,
+        prompt: str | None = None,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+        skip_permissions: bool = False,
+        system_prompt: str | None = None,
+    ) -> str:
+        """Spawn a new agent in a TideTerm block."""
+        wsh_bin = _find_wsh()
+        if not wsh_bin:
+            return "Error: wsh not installed"
+
+        if cwd:
+            path_error = _validate_path(cwd)
+            if path_error:
+                return path_error
+
+        clawteam_bin = resolve_clawteam_executable()
+        env_vars = os.environ.copy()
+        env_vars.update(
+            {
+                "CLAWTEAM_AGENT_ID": agent_id,
+                "CLAWTEAM_AGENT_NAME": agent_name,
+                "CLAWTEAM_AGENT_TYPE": agent_type,
+                "CLAWTEAM_TEAM_NAME": team_name,
+                "CLAWTEAM_AGENT_LEADER": "0",
+            }
+        )
+        if cwd:
+            env_vars["CLAWTEAM_WORKSPACE_DIR"] = cwd
+        if env:
+            env_vars.update(env)
+        env_vars["PATH"] = build_spawn_path(env_vars.get("PATH", os.environ.get("PATH")))
+
+        prepared = self._adapter.prepare_command(
+            command,
+            prompt=None,
+            cwd=cwd,
+            skip_permissions=skip_permissions,
+            agent_name=agent_name,
+            interactive=True,
+        )
+        normalized_command = prepared.normalized_command
+        validation_command = normalized_command
+        final_command = list(prepared.final_command)
+        post_launch_prompt = None
+
+        if prompt and is_claude_command(normalized_command):
+            final_command.append(prompt)
+
+        if system_prompt and is_claude_command(normalized_command):
+            if "-p" in final_command:
+                insert_at = final_command.index("-p") + 2
+            else:
+                insert_at = 1
+            final_command[insert_at:insert_at] = ["--append-system-prompt", system_prompt]
+
+        command_error = validate_spawn_command(
+            validation_command, path=env_vars.get("PATH", ""), cwd=cwd
+        )
+        if command_error:
+            return command_error
+
+        cmd_str = " ".join(shlex.quote(c) for c in final_command)
+        exit_cmd = shlex.quote(clawteam_bin) if os.path.isabs(clawteam_bin) else "clawteam"
+        exit_hook = (
+            f"{exit_cmd} lifecycle on-exit --team {shlex.quote(team_name)} "
+            f"--agent {shlex.quote(agent_name)}"
+        )
+
+        _SHELL_ENV_KEY_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+        export_vars = {k: v for k, v in env_vars.items() if _SHELL_ENV_KEY_RE.fullmatch(k)}
+        export_prefix = " ".join(f"export {k}={shlex.quote(v)}" for k, v in export_vars.items())
+
+        if cwd:
+            full_cmd = f"{export_prefix}; cd {shlex.quote(cwd)} && {cmd_str}; {exit_hook}"
+        else:
+            full_cmd = f"{export_prefix}; {cmd_str}; {exit_hook}"
+
+        result = subprocess.run(
+            [wsh_bin, "run", "-X", "-c", full_cmd, "--cwd", cwd if cwd else "."],
+            capture_output=True,
+            text=True,
+            timeout=30.0,
+        )
+
+        if result.returncode != 0:
+            return "Error: failed to create block"
+
+        match = re.search(r"block:([a-f0-9-]+)", result.stdout)
+        if not match:
+            return "Error: could not parse block ID from wsh output"
+
+        block_id = match.group(1)
+
+        self._blocks[agent_name] = block_id
+
+        from clawteam.config import load_config
+
+        cfg = load_config()
+
+        if not _wait_for_wsh_block(
+            block_id,
+            timeout_seconds=cfg.spawn_ready_timeout,
+            poll_interval_seconds=0.5,
+        ):
+            return (
+                f"Error: wsh block for '{normalized_command[0]}' did not become visible "
+                f"within {cfg.spawn_ready_timeout:.1f}s. Verify CLI works standalone before "
+                "using it with clawteam spawn."
+            )
+
+        subprocess.run(
+            [
+                wsh_bin,
+                "setmeta",
+                "-b",
+                block_id,
+                f"clawteam:team={team_name}",
+                f"clawteam:agent={agent_name}",
+                f"frame:title={agent_name}",
+            ],
+            capture_output=True,
+        )
+
+        pane_pid = 0
+        from clawteam.spawn.registry import register_agent
+
+        register_agent(
+            team_name=team_name,
+            agent_name=agent_name,
+            backend="wsh",
+            block_id=block_id,
+            pid=pane_pid,
+            command=list(final_command),
+        )
+
+        return f"Agent '{agent_name}' spawned in wsh block ({block_id})"
+
+    def list_running(self) -> list[dict[str, str]]:
+        """List currently running agents."""
+        return [
+            {"name": name, "target": target, "backend": "wsh"}
+            for name, target in self._blocks.items()
+        ]
+
+    def _confirm_workspace_trust_if_prompted(
+        self,
+        block_id: str,
+        command: list[str],
+        timeout_seconds: float = 5.0,
+        poll_interval_seconds: float = 0.2,
+    ) -> bool:
+        """Acknowledge startup confirmation prompts for interactive CLIs."""
+        if not (
+            is_claude_command(command) or is_codex_command(command) or is_gemini_command(command)
+        ):
+            return False
+
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            output = _capture_block_output(block_id)
+            output_lower = output.lower()
+
+            if _looks_like_workspace_trust_prompt(command, output_lower):
+                if self._rpc_client is None:
+                    self._rpc_client = WshRpcClient()
+                self._rpc_client.send_input(block_id, "")
+                return True
+
+            time.sleep(poll_interval_seconds)
+
+        return False

--- a/clawteam/spawn/wsh_rpc.py
+++ b/clawteam/spawn/wsh_rpc.py
@@ -1,0 +1,107 @@
+"""JSON-RPC client for TideTerm server communication."""
+
+from __future__ import annotations
+
+import base64
+import json
+import socket
+from pathlib import Path
+
+
+MAX_RESPONSE_SIZE = 10 * 1024 * 1024
+
+
+class WshRpcClient:
+    """JSON-RPC client for TideTerm server communication.
+
+    Communicates over Unix socket at ~/.local/share/tideterm/tideterm.sock
+    """
+
+    SOCKET_PATH = Path.home() / ".local/share/tideterm/tideterm.sock"
+    _rpc_id = 0
+
+    def __init__(self, socket_path: Path | None = None):
+        self._socket_path = socket_path or self._resolve_socket_path()
+        self._connected = False
+
+    def _resolve_socket_path(self) -> Path:
+        path = Path.home() / ".local/state/waveterm/tideterm.sock"
+        if not path.exists():
+            path = Path.home() / ".local/share/tideterm/tideterm.sock"
+        return path
+
+    def is_connected(self) -> bool:
+        if not self._socket_path.exists():
+            return False
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(1.0)
+            sock.connect(str(self._socket_path))
+            sock.close()
+            self._connected = True
+            return True
+        except (socket.error, socket.timeout, OSError):
+            self._connected = False
+            return False
+
+    def _send_request(self, method: str, params: dict) -> dict | None:
+        if not self.is_connected():
+            return None
+
+        request = {
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+            "id": self._rpc_id,
+        }
+        self._rpc_id += 1
+
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(10.0)
+            sock.connect(str(self._socket_path))
+            sock.sendall(json.dumps(request).encode("utf-8"))
+
+            response_data = b""
+            while len(response_data) < MAX_RESPONSE_SIZE:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                response_data += chunk
+
+            sock.close()
+
+            if len(response_data) >= MAX_RESPONSE_SIZE:
+                return None
+
+            response = json.loads(response_data.decode("utf-8"))
+            if "error" in response:
+                return None
+            return response.get("result")
+
+        except (socket.error, socket.timeout, OSError, json.JSONDecodeError):
+            return None
+
+    def send_input(self, block_id: str, data: str, is_base64: bool = False) -> bool:
+        params = {
+            "blockid": block_id,
+            "inputdata64": data if is_base64 else "",
+        }
+        if not is_base64:
+            params["inputdata64"] = base64.b64encode(data.encode("utf-8")).decode("ascii")
+
+        result = self._send_request("ControllerInputCommand", params)
+        return result is not None
+
+    def send_signal(self, block_id: str, signal: str) -> bool:
+        params = {
+            "blockid": block_id,
+            "signame": signal,
+        }
+        result = self._send_request("ControllerInputCommand", params)
+        return result is not None
+
+    def get_block_info(self, block_id: str) -> dict | None:
+        params = {"blockId": block_id}
+        result = self._send_request("BlockInfoCommand", params)
+        return result

--- a/tests/test_wsh_backend.py
+++ b/tests/test_wsh_backend.py
@@ -1,0 +1,54 @@
+"""Unit tests for wsh spawn backend."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawteam.spawn.wsh_backend import WshBackend
+
+
+def test_wsh_not_available(monkeypatch):
+    """Test spawn fails gracefully without wsh."""
+    monkeypatch.setattr("clawteam.spawn.wsh_backend._find_wsh", lambda: None)
+    backend = WshBackend()
+    result = backend.spawn(
+        command=["echo", "test"],
+        agent_name="test-agent",
+        agent_id="test-id",
+        agent_type="general-purpose",
+        team_name="test-team",
+    )
+    assert "not installed" in result.lower()
+
+
+def test_list_running():
+    """Test list_running returns agent info."""
+    backend = WshBackend()
+    backend._blocks["alice"] = "block-123"
+    backend._blocks["bob"] = "block-456"
+
+    running = backend.list_running()
+
+    assert len(running) == 2
+    assert running[0]["name"] == "alice"
+    assert running[0]["target"] == "block-123"
+    assert running[1]["name"] == "bob"
+    assert running[1]["target"] == "block-456"
+
+
+def test_backend_selection():
+    """Test get_backend factory selects correct backend."""
+    from clawteam.spawn import get_backend
+    from clawteam.spawn.tmux_backend import TmuxBackend
+
+    backend = get_backend("wsh")
+    assert isinstance(backend, WshBackend)
+
+    backend = get_backend("tmux")
+    assert isinstance(backend, TmuxBackend)
+
+    backend = get_backend("subprocess")
+    assert backend.__class__.__name__ == "SubprocessBackend"
+
+    with pytest.raises(ValueError):
+        get_backend("invalid")


### PR DESCRIPTION
## Summary

Adds first-class support for [TideTerm](https://github.com/tideterm/tideterm)/[WaveTerminal](https://github.com/wavetermdev/waveterm) as a spawn backend via the `wsh` CLI, alongside tmux and subprocess.

### Changes

**New backend** (`wsh_backend.py`):
- `WshBackend` — spawns agents in isolated TideTerm/WaveTerminal blocks
- Each agent gets its own block with environment variables, exit hooks, and metadata
- Workspace trust prompt auto-confirmation for Claude/Codex/Gemini CLIs
- Block readiness polling with configurable timeout

**RPC client** (`wsh_rpc.py`):
- `WshRpcClient` — JSON-RPC over Unix socket for input injection, signals, and block info queries

**Factory** (`__init__.py`):
- `get_backend("wsh")` — explicit wsh backend selection

**Registry** (`registry.py`):
- `register_agent()` — accepts `block_id` for wsh agents
- `is_agent_alive()` — checks block existence via `wsh blocks list`
- `stop_agent()` — deletes block via `wsh deleteblock`

**Tests**: 3 new tests covering backend selection, wsh-not-available fallback, and list_running.

### Usage

```bash
# Explicit wsh backend selection
clawteam spawn wsh claude --team myteam --agent-name worker1 --task "Analyze code"

# Spawn with any supported CLI
clawteam spawn wsh codex --team myteam --agent-name worker2 --task "Fix the bug"
```

```toml
# team config
[agents.worker]
command = ["claude"]
backend = "wsh"
```

## Test plan

- [x] `pytest tests/test_wsh_backend.py` — 3/3 pass
- [x] `pytest` (full suite) — all pass
- [x] Integration test: spawn echo command → register → alive check → stop — pass
- [x] Integration test: spawn interactive bash → capture output → stop → confirm dead — pass
- [x] Manual verification on TideTerm with `wsh` CLI