### PR TITLE
docs: add Qwen Code, pi, Gemini CLI, OpenCode to supported agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,18 @@ clawteam spawn tmux codex --team my-team --agent-name bob --task "Write frontend
 # nanobot
 clawteam spawn tmux nanobot --team my-team --agent-name carol --task "Build the API"
 
+# Qwen Code
+clawteam spawn tmux qwen --team my-team --agent-name eve --task "Refactor the parser"
+
+# pi
+clawteam spawn tmux pi --team my-team --agent-name frank --task "Fix the CI pipeline"
+
+# Gemini CLI
+clawteam spawn tmux gemini --team my-team --agent-name grace --task "Write integration tests"
+
+# OpenCode
+clawteam spawn tmux opencode --team my-team --agent-name heidi --task "Implement the cache layer"
+
 # A configured profile (recommended for non-default providers/models)
 clawteam spawn tmux --profile claude-kimi --team my-team --agent-name dave --task "Refactor the auth flow"
 ```
@@ -539,6 +551,10 @@ All examples below assume the corresponding CLI already runs standalone on your 
 | [OpenClaw](https://github.com/openclaw/openclaw) | `clawteam spawn tmux openclaw --team ...` | ✅ Full support |
 | [nanobot](https://github.com/HKUDS/nanobot) | `clawteam spawn tmux nanobot --team ...` | ✅ Full support |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | `clawteam spawn tmux kimi --team ...` | ✅ Full support |
+| [Qwen Code](https://github.com/QwenLM/qwen-code) | `clawteam spawn tmux qwen --team ...` | 🔮 Experimental |
+| [pi](https://github.com/mariozechner/pi-coding-agent) | `clawteam spawn tmux pi --team ...` | 🔮 Experimental |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `clawteam spawn tmux gemini --team ...` | 🔮 Experimental |
+| [OpenCode](https://github.com/opencode-ai/opencode) | `clawteam spawn tmux opencode --team ...` | 🔮 Experimental |
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | 🔮 Experimental |
 | Custom scripts | `clawteam spawn subprocess python --team ...` | ✅ Full support |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -483,6 +483,10 @@ clawteam spawn subprocess <your-agent> --team my-team --agent-name test --task "
 | [OpenClaw](https://github.com/openclaw/openclaw) | `clawteam spawn tmux openclaw --team ...` | ✅ 完全支持 |
 | [nanobot](https://github.com/HKUDS/nanobot) | `clawteam spawn tmux nanobot --team ...` | ✅ 完全支持 |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | `clawteam spawn tmux kimi --team ...` | ✅ 完全支持 |
+| [Qwen Code](https://github.com/QwenLM/qwen-code) | `clawteam spawn tmux qwen --team ...` | 🔮 实验性 |
+| [pi](https://github.com/mariozechner/pi-coding-agent) | `clawteam spawn tmux pi --team ...` | 🔮 实验性 |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `clawteam spawn tmux gemini --team ...` | 🔮 实验性 |
+| [OpenCode](https://github.com/opencode-ai/opencode) | `clawteam spawn tmux opencode --team ...` | 🔮 实验性 |
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | 🔮 实验性 |
 | 自定义脚本 | `clawteam spawn subprocess python --team ...` | ✅ 完全支持 |
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -430,6 +430,10 @@ ClawTeam은 셸 명령을 실행할 수 있는 **어떤 CLI 에이전트**와도
 | [Codex](https://openai.com/codex) | `clawteam spawn tmux codex --team ...` | ✅ 완전 지원 |
 | [OpenClaw](https://github.com/openclaw/openclaw) | `clawteam spawn tmux openclaw --team ...` | ✅ 완전 지원 |
 | [nanobot](https://github.com/HKUDS/nanobot) | `clawteam spawn tmux nanobot --team ...` | ✅ 완전 지원 |
+| [Qwen Code](https://github.com/QwenLM/qwen-code) | `clawteam spawn tmux qwen --team ...` | 🔮 실험적 |
+| [pi](https://github.com/mariozechner/pi-coding-agent) | `clawteam spawn tmux pi --team ...` | 🔮 실험적 |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `clawteam spawn tmux gemini --team ...` | 🔮 실험적 |
+| [OpenCode](https://github.com/opencode-ai/opencode) | `clawteam spawn tmux opencode --team ...` | 🔮 실험적 |
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | 🔮 실험적 |
 | Custom scripts | `clawteam spawn subprocess python --team ...` | ✅ 완전 지원 |
 


### PR DESCRIPTION
## Summary

Add 4 newly supported coding agents to the Supported Agents table across all READMEs (EN/CN/KR).

### New agents (all 🔮 Experimental)
| Agent | Adapter support |
|-------|----------------|
| [Qwen Code](https://github.com/QwenLM/qwen-code) | `--yolo` skip_permissions, `-p` prompt |
| [pi](https://github.com/mariozechner/pi-coding-agent) | positional/flag prompt, minimal by design |
| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `--yolo` skip_permissions, presets available |
| [OpenCode](https://github.com/opencode-ai/opencode) | `--yolo` skip_permissions, `-p` prompt |

### Changes
- **README.md**: 4 new rows in agent table + spawn command examples for each agent
- **README_CN.md**: 4 new rows (status: 🔮 实验性)
- **README_KR.md**: 4 new rows (status: 🔮 실험적)

All 4 agents already have full adapter support in `clawteam/spawn/adapters.py`.