### PR TITLE
feat(prompt): Leader orchestration discipline — synthesis, concurrency, verification

### DIFF
--- a/.agents/skills/clawteam/SKILL.md
+++ b/.agents/skills/clawteam/SKILL.md
@@ -255,6 +255,46 @@ clawteam --json task list my-team --status pending
 - For Claude Code on a fresh machine/home, run `clawteam profile doctor claude` once before spawning.
 - `context inject` and `context conflicts` are the recommended way to hand off cross-worktree tasks safely.
 
+## Leader Orchestration Guide
+
+Leaders coordinate workers. These patterns maximize output quality and minimize wasted cycles.
+
+### Continue vs New Worker
+
+After synthesizing worker findings, decide whether to continue or spawn fresh:
+
+| Situation | Action | Reason |
+|-----------|--------|--------|
+| Research explored exactly the files needing edits | Continue (`clawteam inbox send`) | Worker already has file context |
+| Research was broad but implementation is narrow | Spawn new worker | Clean context avoids exploration noise |
+| Correcting a recent failure | Continue | Worker has the error context and knows what it tried |
+| Verifying code another worker wrote | Spawn new worker | Verifier needs fresh eyes, no implementation bias |
+| First attempt used wrong approach entirely | Spawn new worker | Clean slate avoids anchoring on the failed path |
+
+### Worker Prompt Anti-Patterns
+
+**Bad — lazy delegation:**
+- `"Fix the bug we discussed"` — workers cannot see your conversation
+- `"Based on your findings, implement the fix"` — delegates understanding
+- `"Create a PR for the recent changes"` — ambiguous scope: which changes? which branch?
+- `"Something went wrong with the tests, can you look?"` — no error message, no file path
+
+**Good — synthesized specs:**
+- `"Fix the null pointer in src/auth/validate.ts:42. Add a null check before user.id access. Commit and report the hash."`
+- `"Run pytest tests/auth/ and verify the session expiry test passes. Report any failures with full stack traces."`
+- `"Create branch fix/session-expiry from main. Cherry-pick commit abc123. Push and create a draft PR targeting main."`
+
+### Task Workflow Phases
+
+Most tasks follow four phases:
+
+| Phase | Who | Purpose |
+|-------|-----|---------|
+| Research | Workers (parallel) | Investigate codebase, find files, understand the problem |
+| Synthesis | **Leader** | Read findings, understand the problem, craft implementation specs |
+| Implementation | Workers | Make targeted changes per spec, commit |
+| Verification | Workers (fresh spawn) | Prove changes work — run tests, typechecks, edge cases |
+
 ## Additional Resources
 
 - **`references/cli-reference.md`** — Complete CLI reference with commands, options, and data models

--- a/clawteam/spawn/prompt.py
+++ b/clawteam/spawn/prompt.py
@@ -79,6 +79,35 @@ def build_agent_prompt(
             context_block,
         ])
 
+    # Leader-only orchestration discipline (inspired by Coordinator pattern)
+    if agent_type == "leader":
+        lines.extend([
+            "",
+            "## Synthesis Protocol\n",
+            "When workers report findings, YOU must synthesize before delegating follow-up:",
+            "1. Read the findings carefully. Identify the root cause or approach.",
+            "2. Write a follow-up prompt with SPECIFIC file paths, line numbers, and exact changes.",
+            '3. NEVER write "based on your findings" or "based on the research" — these delegate understanding.\n',
+            'Bad: "Based on your findings, fix the auth bug"',
+            'Good: "Fix the null pointer in src/auth/validate.ts:42. The user field is undefined '
+            'when sessions expire but the token remains cached. Add a null check before user.id '
+            'access — if null, return 401."',
+            "",
+            "## Concurrency Guidelines\n",
+            "Parallelism is your superpower. Launch independent workers concurrently:",
+            "- Read-only tasks (research, reading files) — run in parallel freely",
+            "- Write-heavy tasks (implementation) — one worker at a time per file set to avoid conflicts",
+            "- Verification — can run alongside implementation on different file areas",
+            "- When doing research, cover multiple angles simultaneously",
+            "",
+            "## Verification Standards\n",
+            "Verification means PROVING the code works, not confirming it exists:",
+            '- Run tests with the feature enabled — not just "tests pass"',
+            '- Run type checks and investigate errors — do not dismiss as "unrelated"',
+            "- Test independently — prove the change works, do not rubber-stamp",
+            "- Try edge cases and error paths — do not just re-run what the implementation worker ran",
+        ])
+
     lines.extend([
         "",
         "## Coordination Protocol\n",


### PR DESCRIPTION
## Summary

Inject 3 key orchestration patterns into leader prompts, inspired by analysis of Claude Code's Coordinator system prompt (from npm sourcemap study of `@anthropic-ai/claude-code@2.1.88`).

## Changes

### `clawteam/spawn/prompt.py`
Leader-type agents now receive 3 additional prompt sections (workers remain unchanged):

1. **Synthesis Protocol** — Leaders must understand worker findings before delegating follow-up. Anti-pattern: *"based on your findings, fix it"*.
2. **Concurrency Guidelines** — Read-only tasks parallel, write tasks serial, verification can run alongside implementation on different file areas.
3. **Verification Standards** — *"Proving the code works, not confirming it exists"* — run tests with feature enabled, investigate errors, try edge cases.

### `.agents/skills/clawteam/SKILL.md`
New *Leader Orchestration Guide* section with:
- **Continue-vs-Spawn** decision framework (5-scenario heuristic table)
- **Worker Prompt anti-patterns** with concrete good/bad examples
- **4-phase task workflow** (Research → Synthesis → Implementation → Verification)

## Motivation

ClawTeam has superior infrastructure (multi-backend spawn, P2P transport, git worktree isolation, task dependencies, plan approval) compared to Claude Code's Coordinator. But the \*orchestration discipline\* — how the leader writes prompts, decides when to continue vs spawn, and validates results — was missing from the prompt layer. This PR closes that gap.

## Testing

- `455 passed` — full test suite passes
- Verified leader prompt contains new sections; worker prompt does not
- Only 2 files changed, no infrastructure code touched