### PR TITLE
docs: add Qwen Code, pi, Gemini CLI, OpenCode to supported agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,10 @@ All examples below assume the corresponding CLI already runs standalone on your 
 | [Codex](https://openai.com/codex) | `clawteam spawn tmux codex --team ...` | ✅ Full support |
 | [OpenClaw](https://github.com/nicepkg/OpenClaw) | `clawteam spawn tmux openclaw --team ...` | ✅ Full support |
 | [nanobot](https://github.com/HKUDS/nanobot) | `clawteam spawn tmux nanobot --team ...` | ✅ Full support |
+| [Qwen Code](https://github.com/QwenLM/qwen-code) | `clawteam spawn tmux qwen-code --team ...` | 🔮 Experimental |
+| [pi](https://github.com/mariozechner/pi-coding-agent) | `clawteam spawn tmux pi --team ...` | 🔮 Experimental |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `clawteam spawn tmux gemini --team ...` | 🔮 Experimental |
+| [OpenCode](https://github.com/opencode-ai/opencode) | `clawteam spawn tmux opencode --team ...` | 🔮 Experimental |
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | 🔮 Experimental |
 | Custom scripts | `clawteam spawn subprocess python --team ...` | ✅ Full support |
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -402,6 +402,10 @@ clawteam spawn subprocess <your-agent> --team my-team --agent-name test --task "
 | [Codex](https://openai.com/codex) | `clawteam spawn tmux codex --team ...` | ✅ 完全支持 |
 | [OpenClaw](https://github.com/nicepkg/OpenClaw) | `clawteam spawn tmux openclaw --team ...` | ✅ 完全支持 |
 | [nanobot](https://github.com/HKUDS/nanobot) | `clawteam spawn tmux nanobot --team ...` | ✅ 完全支持 |
+| [Qwen Code](https://github.com/QwenLM/qwen-code) | `clawteam spawn tmux qwen-code --team ...` | 🔮 实验性 |
+| [pi](https://github.com/mariozechner/pi-coding-agent) | `clawteam spawn tmux pi --team ...` | 🔮 实验性 |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `clawteam spawn tmux gemini --team ...` | 🔮 实验性 |
+| [OpenCode](https://github.com/opencode-ai/opencode) | `clawteam spawn tmux opencode --team ...` | 🔮 实验性 |
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | 🔮 实验性 |
 | 自定义脚本 | `clawteam spawn subprocess python --team ...` | ✅ 完全支持 |
 

--- a/README_KR.md
+++ b/README_KR.md
@@ -391,6 +391,10 @@ ClawTeam은 셸 명령을 실행할 수 있는 **어떤 CLI 에이전트**와도
 | [Codex](https://openai.com/codex) | `clawteam spawn tmux codex --team ...` | ✅ 완전 지원 |
 | [OpenClaw](https://github.com/nicepkg/OpenClaw) | `clawteam spawn tmux openclaw --team ...` | ✅ 완전 지원 |
 | [nanobot](https://github.com/HKUDS/nanobot) | `clawteam spawn tmux nanobot --team ...` | ✅ 완전 지원 |
+| [Qwen Code](https://github.com/QwenLM/qwen-code) | `clawteam spawn tmux qwen-code --team ...` | 🔮 실험적 |
+| [pi](https://github.com/mariozechner/pi-coding-agent) | `clawteam spawn tmux pi --team ...` | 🔮 실험적 |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `clawteam spawn tmux gemini --team ...` | 🔮 실험적 |
+| [OpenCode](https://github.com/opencode-ai/opencode) | `clawteam spawn tmux opencode --team ...` | 🔮 실험적 |
 | [Cursor](https://cursor.com) | `clawteam spawn subprocess cursor --team ...` | 🔮 실험적 |
 | Custom scripts | `clawteam spawn subprocess python --team ...` | ✅ 완전 지원 |
 


### PR DESCRIPTION
## Summary

Adds 4 newly supported coding agents to the Supported Agents table across all READMEs (EN/CN/KR), addressing issue #111.

### New agents (all 🔮 Experimental)
| Agent | Adapter support |
|-------|----------------|
| [Qwen Code](https://github.com/QwenLM/qwen-code) | tmux spawn |
| [pi](https://github.com/mariozechner/pi-coding-agent) | tmux spawn |
| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | tmux spawn |
| [OpenCode](https://github.com/opencode-ai/opencode) | tmux spawn |

### Changes
- **README.md**: 4 new rows in agent table + spawn command examples
- **README_CN.md**: 4 new rows (status: 🔮 实验性)
- **README_KR.md**: 4 new rows (status: 🔮 실험적)

Closes #111