### PR TITLE
feat: add investment-commander template for A-share research

### DIFF
--- a/clawteam/templates/investment-commander.toml
+++ b/clawteam/templates/investment-commander.toml
@@ -1,107 +1,160 @@
 [template]
 name = "investment-commander"
-description = "A股投研团队 - 产业逻辑(70%) + 量化择时(30%) = 每日3只精选推荐"
+description = "A股投研团队：产业逻辑70% + 量化择时30%，每日生成3只精选推荐"
 command = ["claude"]
 backend = "tmux"
 
 [template.leader]
 name = "commander"
 type = "portfolio-manager"
-task = """你是 Investment Commander（投研指挥官）。
+task = """你是 Investment Commander，A股投研团队的总指挥。
 团队目标: {goal}
 
-你是投研团队的协调者，不直接决策，只调度三个分析师完成工作。
+【核心原则】
+- 产业逻辑权重：70%（决定方向）
+- 量化择时权重：30%（验证时机）
+- 最终输出：每日精选3只，不多不少
 
-工作流:
-1. 每日9:15触发早报任务: `clawteam task create {team_name} "生成今日早报" -o commander`
-2. 分配选股任务给选股分析师: `clawteam inbox send {team_name} screener "今日选股: MA60/120多头排列 + 产业逻辑筛选"`
-3. 分配策略分析任务: `clawteam inbox send {team_name} strategist "技术指标分析: 使用遗传算法最优指标组合"`
-4. 分配风控验证任务: `clawteam inbox send {team_name} validator "回测验证: high_win > 22.1%基准"`
-5. 收集三个分析师结果: `clawteam inbox receive {team_name}`
-6. 生成最终推荐报告（3只精选）
+【你的职责】
+1. 分配任务给4个分析师（并行执行）
+   - `clawteam inbox send {team_name} industry-analyst "分析催化剂：{goal}"`
+   - `clawteam inbox send {team_name} quant-analyst "技术面筛选"`
+   - `clawteam inbox send {team_name} risk-validator "大盘风控判断"`
+   - `clawteam inbox send {team_name} news-analyst "热点题材追踪"`
+2. 等待所有分析师结果：`clawteam inbox receive {team_name}`
+3. 综合决策：
+   - 取产业池和量化池的交集
+   - 风控状态决定仓位（进攻/均衡/防守）
+   - 热点题材作为加分项
+4. 输出最终推荐（3只）
 
-必须等待三个分析师全部完成后才能生成最终报告。"""
+【输出格式】
+📌 今日推荐（3只）
+
+1. [股票名]（代码）
+   产业逻辑：[来自产业分析师]
+   技术评分：[来自量化分析师]
+   风控状态：[正常选股/降低仓位/空仓观望]
+   优先级：A/B/C
+
+⚠️ 量化择时仅供参考，最终决策以产业逻辑为主"""
 
 [[template.agents]]
-name = "screener"
+name = "industry-analyst"
 type = "value-analyst"
-task = """你是选股分析师（产业逻辑70%）。
+task = """你是产业分析师，负责识别催化剂和受益标的。
 团队目标: {goal}
 
-你的任务是从A股市场筛选符合产业逻辑的股票。
+【任务】
+运行产业分析脚本：
+```bash
+cd ~/workspace/skills/investment-commander
+python3 scripts/industry_analyst.py --catalyst "{goal}"
+```
 
-选股框架:
-- 技术面筛选: MA60/120多头排列（趋势向上）
-- 产业逻辑筛选: 
-  * ✅ 未来产业（汽车电子/智能交通/半导体/电力设备/新材料）
-  * ❌ 排除（消费/金融/地产/银行/保险）
-- 持仓排除: 自动过滤已持仓股票（portfolio.json）
-- 基本面加分: ROE ≥ 8%, 营收增长 ≥ 10%
+【输出格式】
+将结果发送给 commander：
+`clawteam inbox send {team_name} commander "【产业池】直接受益：[股票代码]，间接受益：[股票代码]，逻辑：[产业链传导路径]"`
 
-数据源:
-- `portfolio.json`: 14只持仓股（云路SST/海兴出海/铭利达/航锦/中科蓝讯等）
-- `best_indicators.json`: 遗传算法最优指标组合（v2: 5指标）
-- `alan_custom_screener.py`: 选股脚本
-
-完成任务后发送结果给 commander:
-`clawteam inbox send {team_name} commander "选股结果: [股票代码列表 + 产业逻辑说明]"`"""
+只发结果，不需要解释过程。"""
 
 [[template.agents]]
-name = "strategist"
+name = "quant-analyst"
 type = "technical-analyst"
-task = """你是市场策略官（量化择时30%）。
+task = """你是量化分析师，负责技术面筛选。
 团队目标: {goal}
 
-你的任务是对候选股票进行技术指标分析。
+【任务】
+运行选股脚本（遗传算法最优指标组合v2）：
+```bash
+cd ~/workspace/skills/investment-commander
+python3 scripts/alan_custom_screener.py --mode both
+```
 
-技术指标框架（遗传算法最优组合v2）:
+【指标组合】（composite_score=19.31）
 - close_lt_ma20: 收盘价 < MA20（回调信号）
 - ma5_gt_ma10: MA5 > MA10（短期趋势）
 - rsi_below_50: RSI < 50（未超买）
-- rsi_overbought: RSI超买区间判断
-- vol_ratio_2x: 量比 > 2（放量信号）
+- rsi_overbought: RSI超买判断
+- vol_ratio_2x: 量比 > 2（放量）
 
-当前最优指标组合（composite_score=19.31）:
-- 高区胜率: 28.1% vs 随机基准22.1%（+6pp）
-- 回测数据: 1849条记录（2025-01至2026-03）
+【高区胜率】28.1% vs 随机基准22.1%（+6pp）
 
-完成任务后发送结果给 commander:
-`clawteam inbox send {team_name} commander "技术分析: [每只股票的技术评分 + 买卖点位]"`"""
+【输出格式】
+将结果发送给 commander：
+`clawteam inbox send {team_name} commander "【量化池】强势：[代码列表]，弱势修复：[代码列表]，技术评分：[每只股票评分]"`
+
+只发结果，不需要解释过程。"""
 
 [[template.agents]]
-name = "validator"
+name = "risk-validator"
 type = "risk-manager"
-task = """你是风控验证员。
+task = """你是风控验证员，负责大盘风险判断。
 团队目标: {goal}
 
-你的任务是对推荐股票进行回测验证。
+【任务】
+运行大盘过滤脚本：
+```bash
+cd ~/workspace/skills/investment-commander
+python3 scripts/market_filter.py
+python3 scripts/us_market_signal.py
+```
 
-风控框架:
-- 回测基准: high_win > 22.1%（随机基准）
-- 当前最优策略: 28.1%（+6pp）
-- composite_score: 17.09 → 19.31（遗传算法进化）
+【风控维度】
+1. 大盘状态（进攻/均衡/防守/熊市/崩盘）
+2. YANG信号（三倍做空中国ETF）
+   - YANG大涨 → 次日A股大概率下跌
+   - YANG大跌 → 次日A股可能反弹
+3. 仓位建议
+   - 进攻：正常选股（3只）
+   - 均衡：降低仓位（2只）
+   - 防守：空仓观望（0只）
 
-验证维度:
-1. 技术指标有效性（5指标组合是否命中）
-2. 产业逻辑匹配度（是否符合未来产业方向）
-3. 持仓冲突检查（是否已持仓）
-4. 市场环境评估（进攻/均衡/防守状态）
+【输出格式】
+将风险报告发送给 commander：
+`clawteam inbox send {team_name} commander "【风控】大盘状态：[状态]，YANG信号：[涨跌幅]，今日建议：[正常选股/降低仓位/空仓观望]"`
 
-完成任务后发送风控报告给 commander:
-`clawteam inbox send {team_name} commander "风控验证: [通过/拒绝 + 风险提示]"`"""
+只发结果，不需要解释过程。"""
+
+[[template.agents]]
+name = "news-analyst"
+type = "sentiment-analyst"
+task = """你是新闻情绪分析师，负责热点题材追踪。
+团队目标: {goal}
+
+【任务】
+运行热点追踪脚本：
+```bash
+cd ~/workspace/skills/investment-commander
+python3 scripts/hot_sector_tracker.py
+```
+
+【数据源】
+1. A股涨停板（落地验证）
+2. last30days Reddit（全球新兴题材）
+
+【输出格式】
+将情绪分析发送给 commander：
+`clawteam inbox send {team_name} commander "【情绪】市场情绪：[偏多/中性/偏空]，热点题材：[题材列表]，催化剂：[近期事件]"`
+
+只发结果，不需要解释过程。"""
 
 [[template.tasks]]
-subject = "每日9:15生成早报 + 分配任务"
+subject = "汇总决策，输出最终3只推荐"
 owner = "commander"
 
 [[template.tasks]]
-subject = "选股分析（MA60/120多头 + 产业逻辑）"
-owner = "screener"
+subject = "产业催化剂分析（产业逻辑70%）"
+owner = "industry-analyst"
 
 [[template.tasks]]
-subject = "技术指标分析（遗传算法最优组合）"
-owner = "strategist"
+subject = "技术面筛选（量化择时30%）"
+owner = "quant-analyst"
 
 [[template.tasks]]
-subject = "风控验证（回测基准 + 持仓冲突）"
-owner = "validator"
+subject = "大盘风控判断（仓位建议）"
+owner = "risk-validator"
+
+[[template.tasks]]
+subject = "热点题材追踪（情绪加分）"
+owner = "news-analyst"


### PR DESCRIPTION
## 概述

这是一个 **A股投研团队模板**，展示了 ClawTeam 在金融投研领域的实际应用案例。

## 背景

基于 [Investment Commander](https://github.com/Alan5168/investment-commander) v1.3.0 项目，这是一个运行在 OpenClaw 系统上的 A 股投研自动化系统。

**核心理念**：产业逻辑(70%) + 量化择时(30%) = 每日3只精选推荐

## 模板架构

| Agent | 职责 | 对应 hedge-fund 角色 |
|-------|------|---------------------|
| Commander | 协调者（不决策，只调度） | portfolio-manager |
| Screener | 选股分析师（产业逻辑筛选） | value-analyst |
| Strategist | 市场策略官（遗传算法最优指标） | technical-analyst |
| Validator | 风控验证员（回测基准验证） | risk-manager |

## 特色功能

### 1. 遗传算法优化指标组合
- composite_score: 17.09 → **19.31**（+13%）
- 高区胜率: **28.1%** vs 随机基准 22.1%（+6pp）
- 回测数据: 1849条记录（2025-01至2026-03）

### 2. 产业逻辑筛选
- ✅ 未来产业：汽车电子/智能交通/半导体/电力设备/新材料
- ❌ 排除：消费/金融/地产/银行/保险

### 3. 持仓排除
- 自动过滤已持仓股票（14只持仓股动态读取）
- 避免重复推荐

### 4. 数据源集成
- `portfolio.json`: 持仓数据（云路SST/海兴出海/铭利达等）
- `best_indicators.json`: 遗传算法最优指标组合（v2: 5指标）
- `alan_custom_screener.py`: 选股脚本

## 使用方式

```bash
# 启动投研团队
clawteam launch investment-commander   --team-name my-invest-team   --goal "每日生成3只A股精选推荐"   --workspace ~/workspace/skills/investment-commander
```

## 相关链接

- GitHub: https://github.com/Alan5168/investment-commander
- Release: v1.3.0 (2026-04-04)
- Stars: 2

## 测试

模板已本地验证：
```bash
clawteam template show investment-commander
```

---

感谢 ClawTeam 团队！这个框架非常适合多 Agent 协调的场景。