### PR TITLE
feat: add investment-commander template for A-share research team

### DIFF
--- a/clawteam/templates/investment-commander.toml
+++ b/clawteam/templates/investment-commander.toml
@@ -1,0 +1,160 @@
+[template]
+name = "investment-commander"
+description = "A股投研团队：产业逻辑70% + 量化择时30%，每日生成3只精选推荐"
+command = ["claude"]
+backend = "tmux"
+
+[template.leader]
+name = "commander"
+type = "portfolio-manager"
+task = """你是 Investment Commander，A股投研团队的总指挥。
+团队目标: {goal}
+
+【核心原则】
+- 产业逻辑权重：70%（决定方向）
+- 量化择时权重：30%（验证时机）
+- 最终输出：每日精选3只，不多不少
+
+【你的职责】
+1. 分配任务给4个分析师（并行执行）
+   - `clawteam inbox send {team_name} industry-analyst "分析催化剂：{goal}"`
+   - `clawteam inbox send {team_name} quant-analyst "技术面筛选"`
+   - `clawteam inbox send {team_name} risk-validator "大盘风控判断"`
+   - `clawteam inbox send {team_name} news-analyst "热点题材追踪"`
+2. 等待所有分析师结果：`clawteam inbox receive {team_name}`
+3. 综合决策：
+   - 取产业池和量化池的交集
+   - 风控状态决定仓位（进攻/均衡/防守）
+   - 热点题材作为加分项
+4. 输出最终推荐（3只）
+
+【输出格式】
+📌 今日推荐（3只）
+
+1. [股票名]（代码）
+   产业逻辑：[来自产业分析师]
+   技术评分：[来自量化分析师]
+   风控状态：[正常选股/降低仓位/空仓观望]
+   优先级：A/B/C
+
+⚠️ 量化择时仅供参考，最终决策以产业逻辑为主"""
+
+[[template.agents]]
+name = "industry-analyst"
+type = "value-analyst"
+task = """你是产业分析师，负责识别催化剂和受益标的。
+团队目标: {goal}
+
+【任务】
+运行产业分析脚本：
+```bash
+cd ~/.openclaw/workspace/skills/a-stock-monitor
+python3 scripts/industry_analyst.py --catalyst "{goal}"
+```
+
+【输出格式】
+将结果发送给 commander：
+`clawteam inbox send {team_name} commander "【产业池】直接受益：[股票代码]，间接受益：[股票代码]，逻辑：[产业链传导路径]"`
+
+只发结果，不需要解释过程。"""
+
+[[template.agents]]
+name = "quant-analyst"
+type = "technical-analyst"
+task = """你是量化分析师，负责技术面筛选。
+团队目标: {goal}
+
+【任务】
+运行选股脚本（遗传算法最优指标组合v2）：
+```bash
+cd ~/.openclaw/workspace/skills/a-stock-monitor
+python3 scripts/alan_custom_screener.py --mode both
+```
+
+【指标组合】（composite_score=19.31）
+- close_lt_ma20: 收盘价 < MA20（回调信号）
+- ma5_gt_ma10: MA5 > MA10（短期趋势）
+- rsi_below_50: RSI < 50（未超买）
+- rsi_overbought: RSI超买判断
+- vol_ratio_2x: 量比 > 2（放量）
+
+【高区胜率】28.1% vs 随机基准22.1%（+6pp）
+
+【输出格式】
+将结果发送给 commander：
+`clawteam inbox send {team_name} commander "【量化池】强势：[代码列表]，弱势修复：[代码列表]，技术评分：[每只股票评分]"`
+
+只发结果，不需要解释过程。"""
+
+[[template.agents]]
+name = "risk-validator"
+type = "risk-manager"
+task = """你是风控验证员，负责大盘风险判断。
+团队目标: {goal}
+
+【任务】
+运行大盘过滤脚本：
+```bash
+cd ~/.openclaw/workspace/skills/a-stock-monitor
+python3 scripts/market_filter.py
+python3 scripts/us_market_signal.py
+```
+
+【风控维度】
+1. 大盘状态（进攻/均衡/防守/熊市/崩盘）
+2. YANG信号（三倍做空中国ETF）
+   - YANG大涨 → 次日A股大概率下跌
+   - YANG大跌 → 次日A股可能反弹
+3. 仓位建议
+   - 进攻：正常选股（3只）
+   - 均衡：降低仓位（2只）
+   - 防守：空仓观望（0只）
+
+【输出格式】
+将风险报告发送给 commander：
+`clawteam inbox send {team_name} commander "【风控】大盘状态：[状态]，YANG信号：[涨跌幅]，今日建议：[正常选股/降低仓位/空仓观望]"`
+
+只发结果，不需要解释过程。"""
+
+[[template.agents]]
+name = "news-analyst"
+type = "sentiment-analyst"
+task = """你是新闻情绪分析师，负责热点题材追踪。
+团队目标: {goal}
+
+【任务】
+运行热点追踪脚本：
+```bash
+cd ~/.openclaw/workspace/skills/a-stock-monitor
+python3 scripts/hot_sector_tracker.py
+```
+
+【数据源】
+1. A股涨停板（akshare，近5交易日落地验证）
+2. last30days Reddit（全球新兴题材，30天）
+
+【输出格式】
+将情绪分析发送给 commander：
+`clawteam inbox send {team_name} commander "【情绪】市场情绪：[偏多/中性/偏空]，热点题材：[题材列表]，催化剂：[近期事件]"`
+
+只发结果，不需要解释过程。"""
+
+[[template.tasks]]
+subject = "汇总决策，输出最终3只推荐"
+owner = "commander"
+
+[[template.tasks]]
+subject = "产业催化剂分析（产业逻辑70%）"
+owner = "industry-analyst"
+
+[[template.tasks]]
+subject = "技术面筛选（量化择时30%）"
+owner = "quant-analyst"
+
+[[template.tasks]]
+subject = "大盘风控判断（仓位建议）"
+owner = "risk-validator"
+
+[[template.tasks]]
+subject = "热点题材追踪（情绪加分）"
+owner = "news-analyst"


### PR DESCRIPTION
## Summary

Investment Commander is a China A-share research system using the "Global Emerging Themes × A-share Validation" methodology:

- **产业逻辑 70%** (Industry Logic) + **量化择时 30%** (Technical Timing) = Daily 3 stock recommendations
- 5 agents collaborating: Commander + industry-analyst + quant-analyst + risk-validator + news-analyst

## Key Features

- **Genetic algorithm** optimizes indicator combinations (composite_score: 17.09 → 19.31, high-zone hit rate 28.1% vs random 22.1%)
- **Hot sector tracker**: akshare limit-up board (A股涨停) + last30days Reddit global themes cross-validation
- **Auto-exclude** held positions from recommendations
- **YANG signal** for US overnight risk assessment

## Template Structure

```
Commander (leader) — receives all analyst inputs, makes final decision
  ├─ industry-analyst   → industry_analyst.py
  ├─ quant-analyst      → alan_custom_screener.py
  ├─ risk-validator     → market_filter.py + us_market_signal.py
  └─ news-analyst       → hot_sector_tracker.py
```

## Usage

```bash
clawteam launch investment-commander --goal "AI算力 芯片 商业航天" --team-name my-invest
```

---
Related: Alan5168/investment-commander (GitHub)