### PR TITLE
fix: leader agent exits before workers complete in template launch

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -4055,6 +4055,7 @@ def launch_team(
             env=a_env or None,
             cwd=cwd,
             skip_permissions=skip_permissions,
+            is_leader=(agent.name == tmpl.leader.name),
         )
         spawned.append({"name": agent.name, "id": a_id, "type": agent.type, "result": result})
 

--- a/clawteam/spawn/base.py
+++ b/clawteam/spawn/base.py
@@ -21,6 +21,7 @@ class SpawnBackend(ABC):
         cwd: str | None = None,
         skip_permissions: bool = False,
         system_prompt: str | None = None,
+        is_leader: bool = False,
     ) -> str:
         """Spawn a new agent process. Returns a status message."""
 

--- a/clawteam/spawn/subprocess_backend.py
+++ b/clawteam/spawn/subprocess_backend.py
@@ -31,6 +31,7 @@ class SubprocessBackend(SpawnBackend):
         cwd: str | None = None,
         skip_permissions: bool = False,
         system_prompt: str | None = None,
+        is_leader: bool = False,
     ) -> str:
         spawn_env = os.environ.copy()
         clawteam_bin = resolve_clawteam_executable()
@@ -41,7 +42,7 @@ class SubprocessBackend(SpawnBackend):
             "CLAWTEAM_AGENT_NAME": agent_name,
             "CLAWTEAM_AGENT_TYPE": agent_type,
             "CLAWTEAM_TEAM_NAME": team_name,
-            "CLAWTEAM_AGENT_LEADER": "0",
+            "CLAWTEAM_AGENT_LEADER": "1" if is_leader else "0",
         })
         # Propagate user if set
         user = os.environ.get("CLAWTEAM_USER", "")

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -52,6 +52,7 @@ class TmuxBackend(SpawnBackend):
         cwd: str | None = None,
         skip_permissions: bool = False,
         system_prompt: str | None = None,
+        is_leader: bool = False,
     ) -> str:
         if not shutil.which("tmux"):
             return "Error: tmux not installed"
@@ -69,7 +70,7 @@ class TmuxBackend(SpawnBackend):
             "CLAWTEAM_AGENT_NAME": agent_name,
             "CLAWTEAM_AGENT_TYPE": agent_type,
             "CLAWTEAM_TEAM_NAME": team_name,
-            "CLAWTEAM_AGENT_LEADER": "0",
+            "CLAWTEAM_AGENT_LEADER": "1" if is_leader else "0",
         })
         if cwd:
             env_vars["CLAWTEAM_WORKSPACE_DIR"] = cwd
@@ -143,6 +144,14 @@ class TmuxBackend(SpawnBackend):
         if launch.returncode != 0:
             stderr = launch.stderr.decode() if isinstance(launch.stderr, bytes) else launch.stderr
             return f"Error: failed to launch tmux session: {(stderr or '').strip()}"
+
+        # Keep leader pane alive even if the agent process exits, so it can be
+        # re-activated or inspected later.
+        if is_leader:
+            subprocess.run(
+                ["tmux", "set-option", "-t", target, "remain-on-exit", "on"],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            )
 
         # Set tmux native hooks for reliable lifecycle management
         _exit_hook_cmd = (

--- a/clawteam/spawn/wsh_backend.py
+++ b/clawteam/spawn/wsh_backend.py
@@ -224,6 +224,7 @@ class WshBackend(SpawnBackend):
         cwd: str | None = None,
         skip_permissions: bool = False,
         system_prompt: str | None = None,
+        is_leader: bool = False,
     ) -> str:
         """Spawn a new agent in a TideTerm block."""
         wsh_bin = _find_wsh()
@@ -243,7 +244,7 @@ class WshBackend(SpawnBackend):
                 "CLAWTEAM_AGENT_NAME": agent_name,
                 "CLAWTEAM_AGENT_TYPE": agent_type,
                 "CLAWTEAM_TEAM_NAME": team_name,
-                "CLAWTEAM_AGENT_LEADER": "0",
+                "CLAWTEAM_AGENT_LEADER": "1" if is_leader else "0",
             }
         )
         if cwd:

--- a/clawteam/templates/code-review.toml
+++ b/clawteam/templates/code-review.toml
@@ -9,15 +9,26 @@ name = "lead-reviewer"
 type = "lead-reviewer"
 task = """You are the Lead Reviewer coordinating a multi-perspective code review.
 Your goal: {goal}
+Team: {team_name}
+
+CRITICAL: Do NOT try to synthesize immediately. You MUST wait for ALL reviewers to finish.
 
 Workflow:
-1. Assign review tasks to each specialist via `clawteam task create {team_name} "Review [aspect]" -o [reviewer]`
-2. Send the code context to each reviewer via `clawteam inbox send {team_name} [reviewer] "Please review ..."`
-3. Monitor progress via `clawteam board show {team_name}`
-4. Collect all review feedback via `clawteam inbox receive {team_name}`
-5. Synthesize findings into a unified review: critical issues, suggestions, and approval recommendation
+1. Check the task board: `clawteam board show {team_name}`
+2. If any reviewer task is still IN_PROGRESS, WAIT for them by running:
+   `sleep 45 && clawteam board show {team_name}`
+   Repeat this check until ALL reviewer tasks show "completed".
+3. Once all reviewers are done, collect their findings:
+   `clawteam inbox receive {team_name}`
+4. Synthesize all findings into a unified review report with:
+   - Critical issues (must fix before merge)
+   - Warnings (should fix)
+   - Suggestions (nice to have)
+   - Overall approval recommendation
+5. Mark your task completed:
+   `clawteam task update {team_name} --status completed`
 
-Wait for ALL reviewers before writing the final summary."""
+IMPORTANT: Use the polling loop (step 2) to wait. Do NOT proceed to synthesis until every reviewer task is completed."""
 
 [[template.agents]]
 name = "security-reviewer"

--- a/clawteam/templates/hedge-fund.toml
+++ b/clawteam/templates/hedge-fund.toml
@@ -9,16 +9,22 @@ name = "portfolio-manager"
 type = "portfolio-manager"
 task = """You are the Portfolio Manager and team leader of an AI hedge fund.
 Your goal: {goal}
+Team: {team_name}
+
+CRITICAL: Do NOT make investment decisions immediately. You MUST wait for ALL analysts to report.
 
 Workflow:
 1. Create analysis tasks for each analyst via `clawteam task create {team_name} "Analyze [tickers]" -o [analyst]`
 2. Send task instructions to each analyst via `clawteam inbox send {team_name} [analyst] "Analyze ..."`
 3. Monitor progress via `clawteam board show {team_name}`
-4. Wait for risk-manager's consolidated risk report via `clawteam inbox receive {team_name}`
-5. Make final investment decisions based on all analyst signals + risk assessment
-6. Output a final report with: ticker, action (buy/sell/hold), quantity, confidence, reasoning
+4. If any analyst task is still IN_PROGRESS, WAIT by running:
+   `sleep 45 && clawteam board show {team_name}`
+   Repeat until ALL tasks show "completed".
+5. Collect all reports: `clawteam inbox receive {team_name}`
+6. Make final investment decisions based on all analyst signals + risk assessment
+7. Output a final report with: ticker, action (buy/sell/hold), quantity, confidence, reasoning
 
-You must wait for ALL analysts to report before making decisions."""
+IMPORTANT: Use the polling loop (step 4) to wait. Do NOT decide until every analyst is done."""
 
 [[template.agents]]
 name = "buffett-analyst"

--- a/clawteam/templates/research-paper.toml
+++ b/clawteam/templates/research-paper.toml
@@ -9,17 +9,24 @@ name = "principal-investigator"
 type = "principal-investigator"
 task = """You are the Principal Investigator leading a research paper effort.
 Your goal: {goal}
+Team: {team_name}
+
+CRITICAL: Do NOT write the final synthesis immediately. You MUST wait for ALL team members to complete their sections.
 
 Workflow:
 1. Break the research topic into sub-tasks and assign to team members
 2. Create tasks: `clawteam task create {team_name} "[task]" -o [researcher]`
 3. Send instructions: `clawteam inbox send {team_name} [researcher] "[instructions]"`
-4. Wait for all team members to complete their sections
-5. Synthesize findings into a coherent paper with: abstract, introduction, related work,
+4. Monitor progress via `clawteam board show {team_name}`
+5. If any task is still IN_PROGRESS, WAIT by running:
+   `sleep 45 && clawteam board show {team_name}`
+   Repeat until ALL tasks show "completed".
+6. Collect all sections: `clawteam inbox receive {team_name}`
+7. Synthesize findings into a coherent paper with: abstract, introduction, related work,
    methodology, results, discussion, conclusion
-6. Ensure proper citations and consistent writing style throughout
+8. Ensure proper citations and consistent writing style throughout
 
-Wait for ALL members before writing the final synthesis."""
+IMPORTANT: Use the polling loop (step 5) to wait. Do NOT synthesize until every member is done."""
 
 [[template.agents]]
 name = "literature-surveyor"

--- a/clawteam/templates/software-dev.toml
+++ b/clawteam/templates/software-dev.toml
@@ -9,6 +9,7 @@ name = "tech-lead"
 type = "tech-lead"
 task = """You are the Technical Lead and team coordinator for a software development project.
 Your goal: {goal}
+Team: {team_name}
 
 Your responsibilities:
 1. Break down the project into manageable tasks using `clawteam task create {team_name} "Task description" -o [assignee]`
@@ -21,11 +22,15 @@ Your responsibilities:
 Workflow:
 1. Create initial task breakdown with dependencies
 2. Spawn worker agents for parallel workstreams
-3. Monitor task completion and unblock dependencies
-4. Review and integrate completed work
-5. Report final status to user
+3. Monitor task completion: `clawteam board show {team_name}`
+4. When tasks complete, check for updates: `clawteam inbox receive {team_name}`
+5. If tasks are still IN_PROGRESS, WAIT by running:
+   `sleep 45 && clawteam board show {team_name}`
+   Repeat until all development tasks are done.
+6. Review and integrate completed work
+7. Merge worktrees and report final status
 
-Use `clawteam inbox receive {team_name}` to get updates from team members."""
+IMPORTANT: Use the polling loop (step 5) to wait for workers. Do not finalize until all tasks are done."""
 
 [[template.agents]]
 name = "backend-dev"

--- a/clawteam/templates/strategy-room.toml
+++ b/clawteam/templates/strategy-room.toml
@@ -9,21 +9,27 @@ name = "strategy-lead"
 type = "strategy-lead"
 task = """You are the Strategy Lead coordinating a cross-functional strategy room.
 Your goal: {goal}
+Team: {team_name}
+
+CRITICAL: Do NOT finalize the recommendation until all specialists have reported.
 
 Workflow:
 1. Frame the decision or planning problem clearly
 2. Create focused tasks for each specialist via `clawteam task create {team_name} "[task]" -o [member]`
 3. Send context and instructions via `clawteam inbox send {team_name} [member] "[instructions]"`
 4. Monitor progress via `clawteam board show {team_name}`
-5. Wait for the decision-editor's strategy memo
-6. Produce a final recommendation with:
+5. If any task is still IN_PROGRESS, WAIT by running:
+   `sleep 45 && clawteam board show {team_name}`
+   Repeat until ALL tasks show "completed".
+6. Collect all reports: `clawteam inbox receive {team_name}`
+7. Produce a final recommendation with:
    - recommended path
    - rejected alternatives
    - key risks
    - execution sequence
    - next steps
 
-You must not finalize the recommendation until the decision-editor has delivered the memo."""
+IMPORTANT: Use the polling loop (step 5) to wait. Do NOT finalize until every member has reported."""
 
 [[template.agents]]
 name = "systems-analyst"


### PR DESCRIPTION
When using `clawteam launch`, the leader agent's Claude session would finish and exit before workers sent their results, causing the tmux window to be destroyed and making the leader unable to synthesize findings.

Changes:
- Add `is_leader` parameter to SpawnBackend.spawn() across all backends
- Set CLAWTEAM_AGENT_LEADER=1 for leader agents (was hardcoded to 0)
- Enable tmux remain-on-exit for leader panes to persist after process exit
- Update all 5 template leader prompts with explicit polling instructions (sleep + board show loop) to wait for workers before synthesizing