### PR TITLE
fix: tmux spawn fails in root environments and with large env

### DIFF
--- a/clawteam/spawn/adapters.py
+++ b/clawteam/spawn/adapters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -35,7 +36,11 @@ class NativeCliAdapter:
         post_launch_prompt = None
 
         if skip_permissions:
-            if is_claude_command(normalized_command):
+            # Claude Code rejects --dangerously-skip-permissions when running
+            # as root/sudo.  Detect this and silently omit the flag so spawned
+            # agents can still start.
+            _is_root = os.getuid() == 0
+            if is_claude_command(normalized_command) and not _is_root:
                 final_command.append("--dangerously-skip-permissions")
             elif is_codex_command(normalized_command):
                 final_command.append("--dangerously-bypass-approvals-and-sandbox")

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -106,7 +106,20 @@ class TmuxBackend(SpawnBackend):
         # WSL includes names like `PROGRAMFILES(X86)`, which would abort the
         # shell before the pane becomes observable.
         export_vars = {k: v for k, v in env_vars.items() if _SHELL_ENV_KEY_RE.fullmatch(k)}
-        export_str = "; ".join(f"export {k}={shlex.quote(v)}" for k, v in export_vars.items())
+
+        # Write env vars to a temp file and source it to avoid exceeding
+        # tmux's command-length limit (~16k chars).  The file is deliberately
+        # NOT deleted here — the sourcing shell needs it at startup.  A
+        # self-cleanup line inside the file removes it after it has been read.
+        env_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".env.sh", delete=False, prefix="clawteam-env-"
+        )
+        for k, v in export_vars.items():
+            env_file.write(f"export {k}={shlex.quote(v)}\n")
+        # Self-cleanup: remove the env file after sourcing
+        env_file.write(f"rm -f {shlex.quote(env_file.name)}\n")
+        env_file.close()
+        env_source_cmd = f". {shlex.quote(env_file.name)}"
 
         cmd_str = " ".join(shlex.quote(c) for c in final_command)
         exit_cmd = shlex.quote(clawteam_bin) if os.path.isabs(clawteam_bin) else "clawteam"
@@ -114,9 +127,9 @@ class TmuxBackend(SpawnBackend):
         # don't refuse to start when the leader is itself a claude session.
         unset_clause = "unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION 2>/dev/null; "
         if cwd:
-            full_cmd = f"{unset_clause}{export_str}; cd {shlex.quote(cwd)} && {cmd_str}"
+            full_cmd = f"{unset_clause}{env_source_cmd}; cd {shlex.quote(cwd)} && {cmd_str}"
         else:
-            full_cmd = f"{unset_clause}{export_str}; {cmd_str}"
+            full_cmd = f"{unset_clause}{env_source_cmd}; {cmd_str}"
 
         # Check if tmux session exists
         check = subprocess.run(

--- a/tests/test_spawn_backends.py
+++ b/tests/test_spawn_backends.py
@@ -188,12 +188,22 @@ def test_tmux_backend_exports_spawn_path_for_agent_commands(monkeypatch, tmp_pat
 
     new_session = next(call for call in run_calls if call[:3] == ["tmux", "new-session", "-d"])
     full_cmd = new_session[-1]
-    assert f"export PATH={clawteam_bin.parent}:/usr/bin:/bin" in full_cmd
-    assert f"export CLAWTEAM_BIN={clawteam_bin}" in full_cmd
-    assert "export CLAWTEAM_DATA_DIR=/tmp/oh-data" in full_cmd
-    assert "export GOOGLE_CLOUD_PROJECT=demo-project" in full_cmd
+    # Env vars are now written to a temp file and sourced, not inlined
+    import re as _re
+    env_file_match = _re.search(r"\. '?(/tmp/clawteam-env-[^';\s]+\.env\.sh)'?", full_cmd)
+    assert env_file_match, f"env source command not found in: {full_cmd}"
+    env_file_path = env_file_match.group(1)
+    env_file_content = open(env_file_path).read()
+    # PATH should contain the clawteam bin directory
+    assert any(str(clawteam_bin.parent) in line for line in env_file_content.splitlines() if line.startswith("export PATH="))
+    assert any(str(clawteam_bin) in line for line in env_file_content.splitlines() if line.startswith("export CLAWTEAM_BIN="))
+    assert any("/tmp/oh-data" in line for line in env_file_content.splitlines() if line.startswith("export CLAWTEAM_DATA_DIR="))
+    assert any("demo-project" in line for line in env_file_content.splitlines() if line.startswith("export GOOGLE_CLOUD_PROJECT="))
     assert "cd /tmp/demo &&" in full_cmd
-    assert "PROGRAMFILES(X86)" not in full_cmd
+    assert "PROGRAMFILES(X86)" not in env_file_content
+    # Cleanup env file
+    import os as _os
+    _os.unlink(env_file_path)
     # Exit hook is now set via tmux set-hook (not inline in command string)
     set_hook_calls = [c for c in run_calls if c[:2] == ["tmux", "set-hook"]]
     assert any("pane-exited" in c for c in set_hook_calls), "pane-exited hook not set"


### PR DESCRIPTION
## Summary
- **tmux command too long**: All env vars (~23KB) were inlined in the `tmux new-session` command, exceeding tmux's ~16K command-length limit. Now writes env vars to a self-cleaning temp `.env.sh` file and sources it instead (~166 chars).
- **root skip-permissions**: Claude Code rejects `--dangerously-skip-permissions` when running as root/sudo (common in pod/container environments). Detect `uid == 0` and omit the flag so spawned agents can start.

## Test plan
- [x] All 40 existing tests in `test_spawn_backends.py` pass
- [x] Verified tmux session creates successfully in root pod environment
- [x] Verified spawned claude agents start and complete tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)