### PR TITLE
fix(spawn): add pi to profile model flag resolution

### DIFF
--- a/clawteam/spawn/profiles.py
+++ b/clawteam/spawn/profiles.py
@@ -154,7 +154,7 @@ def _command_has_model_arg(command: list[str]) -> bool:
 
 
 def _model_flag(agent: str) -> str | None:
-    if agent in {"claude", "claude-code", "codex", "codex-cli", "gemini", "kimi"}:
+    if agent in {"claude", "claude-code", "codex", "codex-cli", "gemini", "kimi", "pi"}:
         return "--model"
     return None
 
@@ -168,6 +168,8 @@ def _base_url_env_var(agent: str) -> str | None:
         return "GOOGLE_GEMINI_BASE_URL"
     if agent == "kimi":
         return "KIMI_BASE_URL"
+    if agent == "pi":
+        return None  # pi resolves base URL from --provider or env
     return None
 
 
@@ -180,4 +182,6 @@ def _api_key_target_env(agent: str) -> str | None:
         return "GEMINI_API_KEY"
     if agent == "kimi":
         return "KIMI_API_KEY"
+    if agent == "pi":
+        return None  # pi resolves API key from --api-key or provider-specific env vars
     return None

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -158,6 +158,53 @@ def test_profile_doctor_claude_updates_existing_state_file(tmp_path):
     assert state["hasCompletedOnboarding"] is True
 
 
+def test_apply_profile_pi_model_flag_is_injected():
+    """Pi profiles should receive --model from profile.model."""
+    profile = AgentProfile(
+        agent="pi",
+        model="anthropic/claude-sonnet-4.6",
+    )
+
+    command, env, agent = apply_profile(profile)
+
+    assert agent == "pi"
+    assert command == ["pi", "--model", "anthropic/claude-sonnet-4.6"]
+    assert env == {}
+
+
+def test_apply_profile_pi_model_not_duplicated_when_already_present():
+    """If --model is already in the command, profile.model should not add another."""
+    profile = AgentProfile(
+        agent="pi",
+        model="anthropic/claude-sonnet-4.6",
+        command=["pi", "--model", "google/gemini-2.5-pro"],
+    )
+
+    command, env, agent = apply_profile(profile)
+
+    assert agent == "pi"
+    assert command == ["pi", "--model", "google/gemini-2.5-pro"]
+
+
+def test_apply_profile_pi_no_base_url_or_api_key_env_injection(monkeypatch):
+    """Pi resolves base URL and API keys from --provider or provider-specific env."""
+    monkeypatch.setenv("MY_API_KEY", "test-key")
+    profile = AgentProfile(
+        agent="pi",
+        model="google/gemini-2.5-pro",
+        api_key_env="MY_API_KEY",
+    )
+
+    command, env, agent = apply_profile(profile)
+
+    assert agent == "pi"
+    assert command == ["pi", "--model", "google/gemini-2.5-pro"]
+    # Pi has no built-in base_url_env or api_key_target_env mapping,
+    # so the profile's api_key_env should NOT produce an automatic injection.
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+    assert "OPENAI_API_KEY" not in env
+
+
 def test_profile_wizard_generates_profile_from_preset(monkeypatch, tmp_path):
     runner = CliRunner()
     env = {


### PR DESCRIPTION
## Summary

When a profile specifies `--agent pi --model X`, the model is silently ignored because `_model_flag()` in `profiles.py` did not include `"pi"` in its agent set.

## Changes

- **`clawteam/spawn/profiles.py`** — Add `"pi"` to `_model_flag()` so `--model` is appended from `profile.model`. Add explicit `return None` entries for pi in `_base_url_env_var()` and `_api_key_target_env()` (pi resolves these via `--provider` and provider-specific env vars, not a single base-url/api-key env).
- **`tests/test_profiles.py`** — Add 3 new tests:
  - `test_apply_profile_pi_model_flag_is_injected` — verifies `--model` is appended
  - `test_apply_profile_pi_model_not_duplicated_when_already_present` — verifies no double `--model`
  - `test_apply_profile_pi_no_base_url_or_api_key_env_injection` — verifies pi does not auto-inject env vars

## Test Results

All 445 tests pass (2 skipped due to missing `mcp` module, unrelated to this change):

```
tests/test_adapters.py ...................                                [  4%]
tests/test_board.py ..............                                       [  7%]
tests/test_cli_commands.py ................                              [ 11%]
tests/test_config.py ..............                                      [ 14%]
tests/test_context.py ..                                                 [ 14%]
tests/test_costs.py ...........                                          [ 17%]
tests/test_fileutil.py ..........                                        [ 19%]
tests/test_gource.py .....                                               [ 20%]
tests/test_identity.py ...............                                   [ 23%]
tests/test_inbox_routing.py ..                                           [ 24%]
tests/test_lifecycle.py .......                                          [ 25%]
tests/test_mailbox.py ..............................                     [ 32%]
tests/test_manager.py .............................                      [ 39%]
tests/test_models.py ..................                                  [ 43%]
tests/test_plan_storage.py .....                                         [ 44%]
tests/test_presets.py ........                                           [ 46%]
tests/test_profiles.py ...........                                       [ 47%]  ← was 8, now 11
tests/test_prompt.py .........                                           [ 49%]
tests/test_registry.py ......................                            [ 54%]
tests/test_runtime_routing.py ..........                                 [ 57%]
tests/test_snapshots.py .....................                            [ 61%]
tests/test_spawn_backends.py .......................................     [ 70%]
tests/test_spawn_cli.py .................                                [ 74%]
tests/test_store.py ..................                                   [ 78%]
tests/test_task_store_locking.py .                                       [ 78%]
tests/test_tasks.py ............................................         [ 88%]
tests/test_templates.py .........................                        [ 94%]
tests/test_timefmt.py ...                                                [ 94%]
tests/test_waiter.py ...................                                 [ 99%]
tests/test_workspace_manager.py .                                        [ 99%]
tests/test_wsh_backend.py ...                                            [100%]

======================= 445 passed in 143.36s ========================
```

## Usage Example

```bash
# Create a profile for Pi with a specific model
clawteam profile set pi-anthropic \
  --agent pi \
  --model "anthropic/claude-sonnet-4.6"

# Spawn an agent — --model is now correctly appended
clawteam spawn tmux --profile pi-anthropic --team myteam --task "Implement feature X"
# Results in: pi --model anthropic/claude-sonnet-4.6 -p "..."
```
