### PR TITLE
perf: avoid Pydantic serialization round-trip and cache timezone config

### DIFF
--- a/clawteam/board/collector.py
+++ b/clawteam/board/collector.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 from clawteam.team.mailbox import MailboxManager
 from clawteam.team.manager import TeamManager
 from clawteam.team.tasks import TaskStore
@@ -100,7 +98,7 @@ class BoardCollector:
             "blocked": [],
         }
         for t in all_tasks:
-            td = json.loads(t.model_dump_json(by_alias=True, exclude_none=True))
+            td = t.model_dump(mode="json", by_alias=True, exclude_none=True)
             grouped[t.status.value].append(td)
 
         summary = {
@@ -120,7 +118,7 @@ class BoardCollector:
         try:
             events = mailbox.get_event_log(limit=200)
             for msg in events:
-                payload = json.loads(msg.model_dump_json(by_alias=True, exclude_none=True))
+                payload = msg.model_dump(mode="json", by_alias=True, exclude_none=True)
                 from_info = member_aliases.get(payload.get("from") or "")
                 to_info = member_aliases.get(payload.get("to") or "")
                 if from_info:

--- a/clawteam/timefmt.py
+++ b/clawteam/timefmt.py
@@ -2,10 +2,29 @@
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from clawteam.config import load_config
+from clawteam.config import config_path, load_config
+
+_tz_cache: tuple[float, str] | None = None
+
+
+def _get_timezone() -> str:
+    """Return the configured display timezone, cached by config file mtime."""
+    global _tz_cache
+    try:
+        mtime = os.path.getmtime(config_path())
+    except OSError:
+        mtime = 0.0
+
+    if _tz_cache is not None and _tz_cache[0] == mtime:
+        return _tz_cache[1]
+
+    tz_name = (load_config().timezone or "UTC").strip() or "UTC"
+    _tz_cache = (mtime, tz_name)
+    return tz_name
 
 
 def _parse_timestamp(value: str) -> datetime | None:
@@ -35,7 +54,7 @@ def format_timestamp(value: str | None) -> str:
     if dt is None:
         return str(value)[:19]
 
-    tz_name = (load_config().timezone or "UTC").strip() or "UTC"
+    tz_name = _get_timezone()
     if tz_name.upper() == "UTC":
         return dt.astimezone(timezone.utc).isoformat()[:19]
 


### PR DESCRIPTION
## Summary

- **`collector.py`**: Replace `json.loads(model.model_dump_json(...))` with `model.model_dump(mode="json", ...)` for tasks and event messages. This eliminates a redundant serialize→string→parse→dict cycle on every task and every message when building the board snapshot.
- **`timefmt.py`**: Cache the configured timezone by `config.json` file mtime so `format_timestamp()` only hits disk once per config change instead of on every call. The board renderer formats dozens of timestamps per refresh; this removes repeated `load_config()` I/O from the hot path while still picking up config edits immediately.

## Changes

| File | What changed |
|---|---|
| `clawteam/board/collector.py` | `json.loads(t.model_dump_json(...))` → `t.model_dump(mode="json", ...)` (2 call sites: tasks + messages) |
| `clawteam/timefmt.py` | Added `_get_timezone()` with mtime-based cache; `format_timestamp()` delegates to it |

## Test plan

- [x] `uv run pytest tests/test_board.py tests/test_timefmt.py -v` — 17/17 passed
- [x] `uv run pytest -q` — full suite 545 passed, 0 failures
- [x] `uv run ruff check` — all checks passed


Made with [Cursor](https://cursor.com)