### PR TITLE
fix: prevent profile doctor from silently wiping Claude state on bad JSON

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -1046,19 +1046,32 @@ def profile_doctor(
 
     claude_state_path = Path.home() / ".claude.json"
     before_exists = claude_state_path.exists()
-    data: dict[str, object]
+    data: dict[str, object] = {}
+    corrupted = False
     if before_exists:
+        raw = claude_state_path.read_text(encoding="utf-8")
         try:
-            data = json.loads(claude_state_path.read_text(encoding="utf-8"))
-            if not isinstance(data, dict):
-                data = {}
-        except Exception:
-            data = {}
-    else:
-        data = {}
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                data = parsed
+            else:
+                corrupted = True
+        except (json.JSONDecodeError, ValueError):
+            corrupted = True
+
+        if corrupted:
+            backup_path = claude_state_path.with_suffix(".json.bak")
+            backup_path.write_text(raw, encoding="utf-8")
+            console.print(
+                f"[yellow]Warning:[/yellow] {claude_state_path} contained invalid data; "
+                f"backed up to {backup_path}"
+            )
 
     data["hasCompletedOnboarding"] = True
-    claude_state_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    from clawteam.fileutil import atomic_write_text
+
+    atomic_write_text(claude_state_path, json.dumps(data, indent=2))
 
     result = {
         "client": "claude",

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -171,6 +171,48 @@ def test_profile_doctor_claude_updates_existing_state_file(tmp_path):
     assert state["hasCompletedOnboarding"] is True
 
 
+def test_profile_doctor_claude_backs_up_corrupted_state_file(tmp_path):
+    runner = CliRunner()
+    env = {
+        "HOME": str(tmp_path),
+        "CLAWTEAM_DATA_DIR": str(tmp_path / ".clawteam"),
+    }
+    state_path = Path(tmp_path) / ".claude.json"
+    state_path.write_text("NOT VALID JSON {{{", encoding="utf-8")
+
+    result = runner.invoke(app, ["profile", "doctor", "claude"], env=env)
+
+    assert result.exit_code == 0
+    normalized = " ".join(result.output.split())
+    assert "invalid data" in normalized
+    assert ".bak" in normalized
+    backup_path = Path(tmp_path) / ".claude.json.bak"
+    assert backup_path.read_text(encoding="utf-8") == "NOT VALID JSON {{{"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["hasCompletedOnboarding"] is True
+
+
+def test_profile_doctor_claude_backs_up_non_dict_state_file(tmp_path):
+    runner = CliRunner()
+    env = {
+        "HOME": str(tmp_path),
+        "CLAWTEAM_DATA_DIR": str(tmp_path / ".clawteam"),
+    }
+    state_path = Path(tmp_path) / ".claude.json"
+    state_path.write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+
+    result = runner.invoke(app, ["profile", "doctor", "claude"], env=env)
+
+    assert result.exit_code == 0
+    normalized = " ".join(result.output.split())
+    assert "invalid data" in normalized
+    assert ".bak" in normalized
+    backup_path = Path(tmp_path) / ".claude.json.bak"
+    assert json.loads(backup_path.read_text(encoding="utf-8")) == ["not", "a", "dict"]
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["hasCompletedOnboarding"] is True
+
+
 def test_profile_wizard_generates_profile_from_preset(monkeypatch, tmp_path):
     runner = CliRunner()
     env = {


### PR DESCRIPTION
## Summary

- **Data loss bug**: `clawteam profile doctor claude` silently destroyed all existing Claude state (`~/.claude.json`) when the file contained invalid JSON or a non-dict value. The bare `except Exception: data = {}` handler replaced the entire file with `{"hasCompletedOnboarding": true}`, discarding API keys, preferences, and other saved state.
- **Fix**: Corrupted/non-dict state files are now backed up to `.claude.json.bak` before being replaced, and the user receives a clear warning. Valid dict state is preserved and merged as before.
- **Safety**: The write itself now uses `atomic_write_text` from `clawteam.fileutil` to prevent partial writes.

## Changes

| File | What changed |
|---|---|
| `clawteam/cli/commands.py` | Replace bare `except Exception: data = {}` with explicit `json.JSONDecodeError` handling, backup-before-wipe, and atomic write |
| `tests/test_profiles.py` | Add 2 tests: corrupted JSON backup + non-dict JSON backup |

## Test plan

- [x] `uv run pytest tests/test_profiles.py -v` — 10/10 passed
- [x] `uv run pytest -q` — full suite 547 passed, 0 failures
- [x] `uv run ruff check` — all checks passed


Made with [Cursor](https://cursor.com)