### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,6 +5,12 @@
       "source": "anthropics/skills",
       "sourceType": "github",
       "computedHash": "063a0e6448123cd359ad0044cc46b0e490cc7964d45ef4bb9fd842bd2ffbca67"
+    },
+    "mmx-cli": {
+      "source": "MiniMax-AI/cli",
+      "sourceType": "github",
+      "path": "skill/",
+      "computedHash": "54adc09c298ca1fd11457a8cb6a9eaf558a4d0758570dfb43e82f3002ec32c16"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to `skills-lock.json` so the mmx-cli skill is discoverable and installable out of the box
- The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard format
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**6 lines changed, 1 file.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (MiniMax-Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The `SKILL.md` includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`) for clean integration with ClawTeam's agent spawn system.

## Test plan

- `skills-lock.json` validates as valid JSON
- No existing functionality changed
- Agents spawned with the mmx-cli skill can invoke `mmx text chat`, `mmx image generate`, etc.