### PR TITLE
feat(keepalive): support openclaw resume

### DIFF
--- a/clawteam/spawn/keepalive.py
+++ b/clawteam/spawn/keepalive.py
@@ -32,6 +32,10 @@ def build_resume_command(command: list[str]) -> list[str]:
         return [normalized[0], "--continue"]
     if executable == "pi":
         return [normalized[0], "--continue"]
+    if executable == "openclaw":
+        # OpenClaw resumes via --session-id (injected by NativeCliAdapter),
+        # so the resume command is just the base `openclaw agent` invocation.
+        return [normalized[0], "agent"]
     return []
 
 


### PR DESCRIPTION
## Summary

- Add `openclaw` to the set of recognized executables in `build_resume_command()` so the keepalive loop can restart an OpenClaw agent after a clean exit.
- Unlike other CLIs that pass an explicit `--continue` or `--resume` flag, OpenClaw restores its session via `--session-id`, which is already injected by `NativeCliAdapter` at spawn time. Therefore the resume command only needs the base `openclaw agent` invocation.

## Motivation

When an OpenClaw agent process exits cleanly while keepalive is enabled, `build_resume_command()` previously returned an empty list (the catch-all `return []`), which meant the keepalive shell wrapper would not attempt a restart. This patch closes that gap and brings OpenClaw in line with the other supported CLIs (Claude, Codex, Gemini, Kimi, Qwen, OpenCode, Pi).

## Changes

- `clawteam/spawn/keepalive.py`: Added an `openclaw` branch that returns `[normalized[0], "agent"]` as the resume command.

