### PR TITLE
fix(waiter): guard signal.signal() calls for non-main threads

### DIFF
--- a/clawteam/spawn/keepalive.py
+++ b/clawteam/spawn/keepalive.py
@@ -32,6 +32,10 @@ def build_resume_command(command: list[str]) -> list[str]:
         return [normalized[0], "--continue"]
     if executable == "pi":
         return [normalized[0], "--continue"]
+    if executable == "openclaw":
+        # OpenClaw resumes via --session-id (injected by NativeCliAdapter),
+        # so the resume command is just the base `openclaw agent` invocation.
+        return [normalized[0], "agent"]
     return []
 
 

--- a/clawteam/team/waiter.py
+++ b/clawteam/team/waiter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import signal
+import threading
 import time
 from dataclasses import dataclass, field
 from typing import Callable
@@ -68,15 +69,22 @@ class TaskWaiter:
         self._running = True
         start = time.monotonic()
 
-        # Save and install signal handlers
-        prev_sigint = signal.getsignal(signal.SIGINT)
-        prev_sigterm = signal.getsignal(signal.SIGTERM)
+        install_signal_handlers = threading.current_thread() is threading.main_thread()
+        prev_sigint = None
+        prev_sigterm = None
 
         def _handle_signal(signum, frame):
             self._running = False
 
-        signal.signal(signal.SIGINT, _handle_signal)
-        signal.signal(signal.SIGTERM, _handle_signal)
+        if install_signal_handlers:
+            # Python only allows signal handlers to be installed from the main
+            # thread. TaskWaiter is sometimes executed in a worker thread (for
+            # example via asyncio.run_in_executor), so treat signal handling as
+            # best-effort and skip it there.
+            prev_sigint = signal.getsignal(signal.SIGINT)
+            prev_sigterm = signal.getsignal(signal.SIGTERM)
+            signal.signal(signal.SIGINT, _handle_signal)
+            signal.signal(signal.SIGTERM, _handle_signal)
 
         last_summary = ""
         try:
@@ -160,9 +168,11 @@ class TaskWaiter:
                 task_details=[_task_summary(t) for t in tasks],
             )
         finally:
-            # Restore original signal handlers
-            signal.signal(signal.SIGINT, prev_sigint)
-            signal.signal(signal.SIGTERM, prev_sigterm)
+            if install_signal_handlers:
+                # Restore original signal handlers when they were installed by
+                # this waiter invocation.
+                signal.signal(signal.SIGINT, prev_sigint)
+                signal.signal(signal.SIGTERM, prev_sigterm)
 
 
     def _check_dead_agents(self) -> None:


### PR DESCRIPTION
## Summary

- Guard `signal.signal()` calls in `TaskWaiter.wait()` with a main-thread check to prevent `ValueError` when the waiter runs inside a worker thread.

## Problem

`TaskWaiter.wait()` unconditionally calls `signal.signal(signal.SIGINT, ...)` to install a graceful-shutdown handler. Python requires that `signal.signal()` is only called from the main thread of the main interpreter — calling it elsewhere raises:

```
ValueError: signal only works in main thread of the main interpreter
```

This was not an issue when tasks ran serially, but breaks under parallel execution (e.g. MASP-Bench with `RUN_ALL_WORKERS=4`), where the call chain becomes:

```
bash &  →  python -m masp_bench run  →  asyncio event loop
    →  loop.run_in_executor(None, waiter.wait)   # worker thread, not main thread
        →  signal.signal(...)                     # 💥 ValueError
```

## Fix

Added a `threading.current_thread() is threading.main_thread()` guard around signal handler installation and restoration. When `wait()` runs in a non-main thread, signal handling is simply skipped.

**Trade-off:** Tasks running in worker threads cannot be gracefully interrupted via Ctrl+C — they must rely on timeout or explicit termination. This is an acceptable degradation since the core polling and task-completion logic is unaffected.

## Changes

- `clawteam/team/waiter.py`: Added `import threading`, wrapped `signal.signal()` / `signal.getsignal()` calls with a main-thread guard.