### PR TITLE
Add worker lifecycle state and orphan reaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,20 @@ clawteam plan reject <team> <plan-id> <agent> --feedback "Revise X"
 clawteam lifecycle request-shutdown <team> <agent> --reason "done"
 clawteam lifecycle approve-shutdown <team> <request-id> <agent>
 clawteam lifecycle idle <team>
+clawteam orphan-list --team <team>                 # stale running sessions with no live worker
+clawteam orphan-clear --team <team> --dry-run      # preview cleanup
+clawteam orphan-clear --team <team> --execute      # mark stale orphans killed-by-reaper
+clawteam reap --team <team>                        # reap orphans + archive old terminal registry rows
+clawteam reaper install-launchd                    # macOS dry-run: per-user 15-minute LaunchAgent plist
+clawteam reaper install-launchd --execute          # macOS: write per-user plist; bootstrap is explicit
+clawteam reaper bootstrap-launchd --execute        # macOS: load installed per-user LaunchAgent
+clawteam reaper status-launchd                     # macOS/read-only: inspect plist + launchctl state
+clawteam reaper bootout-launchd --execute          # macOS rollback: unload per-user LaunchAgent
+clawteam reaper uninstall-launchd --execute        # macOS rollback: remove per-user plist
+
+# LaunchAgent example: install -> bootstrap; teardown -> bootout -> uninstall
+clawteam reaper install-launchd --execute && clawteam reaper bootstrap-launchd --execute
+clawteam reaper bootout-launchd --execute && clawteam reaper uninstall-launchd --execute
 
 # 🎪 Templates
 clawteam launch <template> --team <name> --goal "Build X"

--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -1530,6 +1530,7 @@ def team_status(
     team: str = typer.Argument(..., help="Team name"),
 ):
     """Show team status and members."""
+    from clawteam.spawn.registry import get_lifecycle_counts
     from clawteam.team.manager import TeamManager
 
     config = TeamManager.get_team(team)
@@ -1543,6 +1544,8 @@ def team_status(
         "leadAgentId": config.lead_agent_id,
         "createdAt": config.created_at,
         "members": [m.model_dump(by_alias=True) for m in config.members],
+        # Decision: ND-363 (team status exposes running vs suspended counts for seat accounting)
+        "workerLifecycle": get_lifecycle_counts(team),
     }
 
     def _human(d):
@@ -1550,6 +1553,15 @@ def team_status(
         if d['description']:
             console.print(f"  {d['description']}")
         console.print(f"  Created: {format_timestamp(d['createdAt'])}")
+        lifecycle = d.get("workerLifecycle", {})
+        if lifecycle:
+            console.print(
+                "  Workers: "
+                f"running={lifecycle.get('running', 0)} "
+                f"suspended={lifecycle.get('suspended', 0)} "
+                f"completed={lifecycle.get('completed', 0)} "
+                f"active_seats={lifecycle.get('active_seats', 0)}"
+            )
         has_user = any(m.get("user") for m in d["members"])
         table = Table(title="Members")
         table.add_column("Name", style="cyan")
@@ -2856,6 +2868,109 @@ def lifecycle_idle(
     )
 
 
+@lifecycle_app.command("state")
+def lifecycle_state(
+    team: str = typer.Option(..., "--team", "-t", help="Team name"),
+    agent: str = typer.Option(..., "--agent", "-n", help="Agent name"),
+):
+    """Show a worker lifecycle state record."""
+    from clawteam.spawn.registry import get_agent_lifecycle
+
+    state = get_agent_lifecycle(team, agent)
+    if state is None:
+        _output({"error": f"No lifecycle state for '{agent}'"}, lambda d: console.print(f"[red]{d['error']}[/red]"))
+        raise typer.Exit(1)
+    _output(state, lambda d: console.print(
+        f"{agent}: [cyan]{d.get('worker_state', '')}[/cyan]"
+        f" transition={d.get('transition', '') or '-'}"
+        f" seat_released={d.get('seat_released', False)}"
+    ))
+
+
+@lifecycle_app.command("suspend")
+def lifecycle_suspend(
+    team: str = typer.Option(..., "--team", "-t", help="Team name"),
+    agent: str = typer.Option(..., "--agent", "-n", help="Agent name"),
+    blocking_condition: str = typer.Option("", "--blocking-condition", help="Human-readable blocking condition"),
+    expected_revive_signal: str = typer.Option("ResumeDispatch", "--expected-revive-signal", help="Expected resume signal contract"),
+    wait_request_id: str = typer.Option("", "--wait-request-id", help="wait_request identifier from the blocking contract"),
+    correlation_id: str = typer.Option("", "--correlation-id", help="MACP/bridge correlation identifier"),
+    target_dispatch_request_id: str = typer.Option("", "--target-dispatch-request-id", help="DispatchRequest identifier to resume"),
+    target_agent_ref: str = typer.Option("", "--target-agent-ref", help="Agent reference expected in ResumeDispatch"),
+):
+    """Suspend a running worker without killing its tmux pane."""
+    from clawteam.spawn.registry import LifecycleStateError, suspend_agent
+
+    try:
+        state = suspend_agent(
+            team,
+            agent,
+            blocking_condition=blocking_condition,
+            expected_revive_signal=expected_revive_signal,
+            wait_request_id=wait_request_id,
+            correlation_id=correlation_id,
+            target_dispatch_request_id=target_dispatch_request_id,
+            target_agent_ref=target_agent_ref,
+        )
+    except LifecycleStateError as e:
+        _output({"error": str(e)}, lambda d: console.print(f"[red]{d['error']}[/red]"))
+        raise typer.Exit(1)
+
+    _output(state, lambda d: console.print(
+        f"[green]OK[/green] Suspended '{agent}' "
+        f"(wait_request_id={d.get('wait_request_id') or '-'})"
+    ))
+
+
+@lifecycle_app.command("resume")
+def lifecycle_resume(
+    team: str = typer.Option(..., "--team", "-t", help="Team name"),
+    agent: str = typer.Option(..., "--agent", "-n", help="Agent name"),
+    wake_reason: str = typer.Option("", "--wake-reason", help="ResumeDispatch wake_reason"),
+    correlation_id: str = typer.Option("", "--correlation-id", help="MACP/bridge correlation identifier"),
+    target_dispatch_request_id: str = typer.Option("", "--target-dispatch-request-id", help="DispatchRequest identifier to resume"),
+    target_agent_ref: str = typer.Option("", "--target-agent-ref", help="Agent reference expected in ResumeDispatch"),
+    resume_dispatch_json: Optional[str] = typer.Option(None, "--resume-dispatch-json", help="ResumeDispatch JSON string or path"),
+):
+    """Resume a suspended worker from a ResumeDispatch-compatible signal."""
+    from clawteam.spawn.registry import LifecycleStateError, resume_agent
+
+    # Decision: ND-363 (bridge-contract integration accepts ResumeDispatch-shaped JSON without hard-coding neurow-bridge as a dependency)
+    if resume_dispatch_json:
+        payload = _load_json_argument(resume_dispatch_json)
+        wake_reason = str(payload.get("wake_reason", wake_reason) or "")
+        correlation_id = str(payload.get("correlation_id", correlation_id) or "")
+        target_dispatch_request_id = str(
+            payload.get("target_dispatch_request_id", target_dispatch_request_id) or ""
+        )
+        target_agent_ref = str(payload.get("target_agent_ref", target_agent_ref) or "")
+
+    try:
+        state = resume_agent(
+            team,
+            agent,
+            wake_reason=wake_reason,
+            correlation_id=correlation_id,
+            target_dispatch_request_id=target_dispatch_request_id,
+            target_agent_ref=target_agent_ref,
+        )
+    except LifecycleStateError as e:
+        _output({"error": str(e)}, lambda d: console.print(f"[red]{d['error']}[/red]"))
+        raise typer.Exit(1)
+
+    _output(state, lambda d: console.print(
+        f"[green]OK[/green] Resumed '{agent}' "
+        f"(wake_reason={d.get('wake_reason') or wake_reason or '-'})"
+    ))
+
+
+def _load_json_argument(value: str) -> dict:
+    path = Path(value).expanduser()
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return json.loads(value)
+
+
 @lifecycle_app.command("on-exit")
 def lifecycle_on_exit(
     team: str = typer.Option(..., "--team", "-t", help="Team name"),
@@ -2865,6 +2980,7 @@ def lifecycle_on_exit(
 
     This is called automatically as a post-exit hook when an agent process terminates.
     """
+    from clawteam.spawn.registry import mark_agent_completed
     from clawteam.spawn.sessions import SessionStore
     from clawteam.team.mailbox import MailboxManager
     from clawteam.team.manager import TeamManager
@@ -2883,6 +2999,7 @@ def lifecycle_on_exit(
     # Without this, session files accumulate indefinitely under
     # ~/.clawteam/sessions/{team}/ after every agent exit.
     SessionStore(team).clear(agent)
+    mark_agent_completed(team, agent, reason="on-exit")
 
     store = TaskStore(team)
     tasks = store.list_tasks()

--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -2971,23 +2971,18 @@ def _load_json_argument(value: str) -> dict:
     return json.loads(value)
 
 
-@lifecycle_app.command("on-exit")
-def lifecycle_on_exit(
-    team: str = typer.Option(..., "--team", "-t", help="Team name"),
-    agent: str = typer.Option(..., "--agent", "-n", help="Agent name"),
-):
-    """Handle agent process exit: clean up session and reset in_progress tasks.
-
-    This is called automatically as a post-exit hook when an agent process terminates.
-    """
-    from clawteam.spawn.registry import mark_agent_completed
-    from clawteam.spawn.sessions import SessionStore
+def _run_agent_exit_cleanup(
+    team: str,
+    agent: str,
+    *,
+    mark_completed: bool,
+    completion_reason: str,
+) -> list:
     from clawteam.team.mailbox import MailboxManager
     from clawteam.team.manager import TeamManager
     from clawteam.team.models import TaskStatus
     from clawteam.team.tasks import TaskStore
 
-    # Write exit journal entry for conductor cross-process notification
     try:
         from clawteam.harness.exit_journal import FileExitJournal
         journal = FileExitJournal(team)
@@ -2995,28 +2990,22 @@ def lifecycle_on_exit(
     except Exception:
         pass
 
-    # Always clean up the agent's session file, regardless of task status.
-    # Without this, session files accumulate indefinitely under
-    # ~/.clawteam/sessions/{team}/ after every agent exit.
-    SessionStore(team).clear(agent)
-    mark_agent_completed(team, agent, reason="on-exit")
+    if mark_completed:
+        from clawteam.spawn.registry import mark_agent_completed
+        mark_agent_completed(team, agent, reason=completion_reason)
 
     store = TaskStore(team)
     tasks = store.list_tasks()
-
-    # Find this agent's in_progress tasks and reset them
     abandoned = [
         t for t in tasks
         if t.owner == agent and t.status == TaskStatus.in_progress
     ]
-
     if not abandoned:
-        return
+        return []
 
     for t in abandoned:
         store.update(t.id, status=TaskStatus.pending)
 
-    # Notify leader
     leader_name = TeamManager.get_leader_name(team)
     if leader_name:
         mailbox = MailboxManager(team)
@@ -3028,7 +3017,6 @@ def lifecycle_on_exit(
                     f"Reset {len(abandoned)} task(s) to pending: {task_subjects}",
         )
 
-    # Emit WorkerExit event
     try:
         from clawteam.events.global_bus import get_event_bus
         from clawteam.events.types import WorkerExit
@@ -3039,10 +3027,30 @@ def lifecycle_on_exit(
     except Exception:
         pass
 
+    return abandoned
+
+
+@lifecycle_app.command("on-exit")
+def lifecycle_on_exit(
+    team: str = typer.Option(..., "--team", "-t", help="Team name"),
+    agent: str = typer.Option(..., "--agent", "-n", help="Agent name"),
+):
+    """Handle agent process exit: clean up session and reset in_progress tasks.
+
+    This is called automatically as a post-exit hook when an agent process terminates.
+    """
+    abandoned = _run_agent_exit_cleanup(
+        team,
+        agent,
+        mark_completed=True,
+        completion_reason="on-exit",
+    )
+
     _output(
         {
             "status": "agent_exited",
             "agent": agent,
+            "abandoned": bool(abandoned),
             "abandoned_tasks": [{"id": t.id, "subject": t.subject} for t in abandoned],
         },
         lambda d: console.print(
@@ -3094,6 +3102,42 @@ def lifecycle_on_crash(
         pass
 
 
+@lifecycle_app.command("parent-killed")
+def lifecycle_parent_killed(
+    team: str = typer.Option(..., "--team", "-t", help="Team name"),
+    agent: str = typer.Option(..., "--agent", "-n", help="Agent name"),
+    signal_name: str = typer.Option("", "--signal", help="Signal or signal-derived exit status"),
+    pid: int = typer.Option(0, "--pid", help="Expected worker parent PID identity"),
+):
+    """Release a worker seat after parent/shell/child signal termination."""
+    from clawteam.spawn.orphans import mark_parent_killed
+
+    state = mark_parent_killed(team, agent, signal_name=signal_name, pid=pid)
+    abandoned = []
+    if state is not None:
+        abandoned = _run_agent_exit_cleanup(
+            team,
+            agent,
+            mark_completed=False,
+            completion_reason="parent-killed",
+        )
+    _output(
+        {
+            "status": "parent_killed" if state is not None else "parent_killed_skipped",
+            "team": team,
+            "agent": agent,
+            "signal": signal_name,
+            "pid": pid,
+            "state": state or {},
+            "abandoned_tasks": [{"id": t.id, "subject": t.subject} for t in abandoned],
+        },
+        lambda d: console.print(
+            f"[yellow]{'Released' if d['status'] == 'parent_killed' else 'Skipped'}[/yellow] "
+            f"'{agent}' after parent-killed signal={signal_name or '-'}"
+        ),
+    )
+
+
 @lifecycle_app.command("check-zombies")
 def lifecycle_check_zombies(
     team: str = typer.Option(..., "--team", "-t", help="Team name"),
@@ -3132,6 +3176,204 @@ def lifecycle_check_zombies(
 
     _output({"team": team, "zombies": zombies}, _fmt)
     raise typer.Exit(1)
+
+
+# ============================================================================
+# Orphan Reaper Commands
+# ============================================================================
+
+reaper_app = typer.Typer(help="Stale worker reaper launchd management")
+app.add_typer(reaper_app, name="reaper")
+
+
+@app.command("orphan-list")
+def orphan_list(
+    team: Optional[str] = typer.Option(None, "--team", "-t", help="Team name (default: all teams)"),
+    max_age_minutes: float = typer.Option(30.0, "--max-age-minutes", help="Stale running threshold"),
+):
+    """List stale running workers with no live backing process."""
+    from clawteam.spawn.orphans import list_orphan_workers
+
+    orphans = list_orphan_workers(team, max_age_minutes=max_age_minutes)
+
+    def _human(items):
+        if not items:
+            console.print("[green]OK[/green] No orphan workers detected")
+            return
+        table = Table(title="Orphan Workers")
+        table.add_column("Team", style="cyan")
+        table.add_column("Agent", style="cyan")
+        table.add_column("Age min", justify="right")
+        table.add_column("Registry")
+        table.add_column("Session")
+        table.add_column("Reason")
+        for item in items:
+            table.add_row(
+                item["team"],
+                item["agent"],
+                str(item["age_minutes"]),
+                item.get("registry_state") or "-",
+                item.get("session_state") or "-",
+                item.get("reason") or "-",
+            )
+        console.print(table)
+
+    _output(orphans, _human)
+
+
+@app.command("orphan-clear")
+def orphan_clear(
+    team: Optional[str] = typer.Option(None, "--team", "-t", help="Team name (default: all teams)"),
+    max_age_minutes: float = typer.Option(30.0, "--max-age-minutes", help="Stale running threshold"),
+    dry_run: bool = typer.Option(True, "--dry-run/--execute", help="Preview by default; use --execute to mutate"),
+):
+    """Mark stale orphan workers killed-by-reaper. Defaults to dry-run."""
+    from clawteam.spawn.orphans import reap_orphan_workers
+
+    result = reap_orphan_workers(team, max_age_minutes=max_age_minutes, dry_run=dry_run)
+    _output(
+        result,
+        lambda d: console.print(
+            f"[green]OK[/green] {'Would reap' if d['dry_run'] else 'Reaped'} "
+            f"{d['reaped_count']} orphan worker(s)"
+        ),
+    )
+
+
+@app.command("reap")
+def reap(
+    team: Optional[str] = typer.Option(None, "--team", "-t", help="Team name (default: all teams)"),
+    max_age_minutes: float = typer.Option(30.0, "--max-age-minutes", help="Stale running threshold"),
+    registry_ttl_days: float = typer.Option(7.0, "--registry-ttl-days", help="Archive released terminal registry rows older than this"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without mutating registry/session state"),
+):
+    """Reap stale orphan workers and safely archive old terminal registry rows."""
+    from clawteam.spawn.orphans import run_reaper
+
+    result = run_reaper(
+        team,
+        max_age_minutes=max_age_minutes,
+        registry_ttl_days=registry_ttl_days,
+        dry_run=dry_run,
+    )
+    _output(
+        result,
+        lambda d: console.print(
+            f"[green]OK[/green] {'Would reap' if d['dry_run'] else 'Reaped'} "
+            f"{d['reap']['reaped_count']} orphan worker(s); "
+            f"registry_archived={sum(item['archived_count'] for item in d['registry_gc'])}"
+        ),
+    )
+
+
+@reaper_app.command("install-launchd")
+def reaper_install_launchd(
+    execute: bool = typer.Option(False, "--execute", help="Write plist. Default is dry-run."),
+    clawteam_bin: Optional[str] = typer.Option(None, "--clawteam-bin", help="Absolute clawteam executable path"),
+    data_dir: Optional[str] = typer.Option(None, "--data-dir", help="CLAWTEAM_DATA_DIR for the scheduled job"),
+    interval_seconds: int = typer.Option(900, "--interval-seconds", help="launchd StartInterval"),
+    max_age_minutes: float = typer.Option(30.0, "--max-age-minutes", help="Stale running threshold"),
+    registry_ttl_days: float = typer.Option(7.0, "--registry-ttl-days", help="Registry archive TTL"),
+):
+    """Generate or install the user LaunchAgent plist for `clawteam reap`."""
+    from clawteam.spawn.orphans import install_launchd_plist
+
+    try:
+        result = install_launchd_plist(
+            execute=execute,
+            clawteam_bin=clawteam_bin,
+            data_dir=data_dir,
+            interval_seconds=interval_seconds,
+            max_age_minutes=max_age_minutes,
+            registry_ttl_days=registry_ttl_days,
+        )
+    except ValueError as exc:
+        _output({"error": str(exc)}, lambda d: console.print(f"[red]{d['error']}[/red]"))
+        raise typer.Exit(1)
+
+    _output(
+        result,
+        lambda d: console.print(
+            f"[{'red' if d['status'] == 'error' else 'green'}]"
+            f"{'ERROR' if d['status'] == 'error' else 'OK'}[/] "
+            f"{d['status']} LaunchAgent plist at {d['path']}"
+        ),
+    )
+    if result["status"] == "error":
+        raise typer.Exit(1)
+
+
+@reaper_app.command("status-launchd")
+def reaper_status_launchd():
+    """Inspect the ClawTeam reaper LaunchAgent without mutating it."""
+    from clawteam.spawn.orphans import launchd_status
+
+    result = launchd_status()
+    _output(
+        result,
+        lambda d: console.print(
+            f"plist_exists={d['plist_exists']} launchctl_loaded={d['launchctl_loaded']}"
+        ),
+    )
+
+
+@reaper_app.command("bootstrap-launchd")
+def reaper_bootstrap_launchd(
+    execute: bool = typer.Option(False, "--execute", help="Run launchctl bootstrap. Default is dry-run."),
+):
+    """Bootstrap the installed ClawTeam reaper LaunchAgent."""
+    from clawteam.spawn.orphans import bootstrap_launchd_plist
+
+    result = bootstrap_launchd_plist(execute=execute)
+    _output(
+        result,
+        lambda d: console.print(
+            f"[{'red' if d['status'] == 'error' else 'green'}]"
+            f"{'ERROR' if d['status'] == 'error' else 'OK'}[/] "
+            f"{d['status']} {' '.join(d['command'])}"
+        ),
+    )
+    if result["status"] == "error":
+        raise typer.Exit(1)
+
+
+@reaper_app.command("bootout-launchd")
+def reaper_bootout_launchd(
+    execute: bool = typer.Option(False, "--execute", help="Run launchctl bootout. Default is dry-run."),
+):
+    """Unload the ClawTeam reaper LaunchAgent."""
+    from clawteam.spawn.orphans import bootout_launchd_plist
+
+    result = bootout_launchd_plist(execute=execute)
+    _output(
+        result,
+        lambda d: console.print(
+            f"[{'red' if d['status'] == 'error' else 'green'}]"
+            f"{'ERROR' if d['status'] == 'error' else 'OK'}[/] "
+            f"{d['status']} {' '.join(d['command'])}"
+        ),
+    )
+    if result["status"] == "error":
+        raise typer.Exit(1)
+
+
+@reaper_app.command("uninstall-launchd")
+def reaper_uninstall_launchd(
+    execute: bool = typer.Option(False, "--execute", help="Remove plist. Default is dry-run."),
+):
+    """Remove the ClawTeam reaper LaunchAgent plist."""
+    from clawteam.spawn.orphans import uninstall_launchd_plist
+
+    result = uninstall_launchd_plist(execute=execute)
+    _output(
+        result,
+        lambda d: console.print(
+            f"[{'red' if d['status'] == 'error' else 'green'}]"
+            f"{'ERROR' if d['status'] == 'error' else 'OK'}[/] {d['status']} {d['path']}"
+        ),
+    )
+    if result["status"] == "error":
+        raise typer.Exit(1)
 
 
 # ============================================================================

--- a/clawteam/spawn/keepalive.py
+++ b/clawteam/spawn/keepalive.py
@@ -61,14 +61,55 @@ def build_keepalive_shell_command(
 ) -> str:
     """Build a POSIX shell command that keeps resumable agents alive."""
     cmd_str = " ".join(shlex.quote(c) for c in initial_command)
+    command_marker = f": {cmd_str}; "
     exit_cmd = shlex.quote(clawteam_bin) if clawteam_bin.startswith("/") else clawteam_bin
     exit_hook = (
         f'CLAWTEAM_EXIT_CODE="$__ct_status" {exit_cmd} lifecycle on-exit '
         f'--team {shlex.quote(team_name)} --agent {shlex.quote(agent_name)}'
     )
+    killed_hook = (
+        f'CLAWTEAM_EXIT_CODE="$__ct_status" {exit_cmd} lifecycle parent-killed '
+        f'--team {shlex.quote(team_name)} --agent {shlex.quote(agent_name)} '
+        '--signal "$__ct_signal" --pid "$$"'
+    )
+    lifecycle_hook = exit_hook
+    signal_prelude = (
+        "set -m 2>/dev/null || true; __ct_child_pid=; "
+        '__ct_run_cmd() { sh -c "exec $1" & __ct_child_pid=$!; '
+        'while kill -0 "$__ct_child_pid" 2>/dev/null; do sleep 0.1; done; '
+        'wait "$__ct_child_pid"; __ct_status=$?; __ct_child_pid=; '
+        'return "$__ct_status"; }; '
+        '__ct_forward_signal() { __ct_signal="$1"; __ct_status="$2"; '
+        'if [ -n "${__ct_child_pid:-}" ]; then '
+        'kill "-$__ct_signal" "-$__ct_child_pid" 2>/dev/null || '
+        'kill "-$__ct_signal" "$__ct_child_pid" 2>/dev/null || true; '
+        'wait "$__ct_child_pid"; __ct_wait_status=$?; __ct_child_pid=; '
+        'if [ "$__ct_wait_status" -ne 127 ]; then __ct_status="$__ct_wait_status"; fi; '
+        "fi; "
+        f"{killed_hook}; "
+        'exit "$__ct_status"; }; '
+        '__ct_forward_control_signal() { __ct_signal="$1"; '
+        'if [ -n "${__ct_child_pid:-}" ]; then '
+        'kill "-$__ct_signal" "-$__ct_child_pid" 2>/dev/null || '
+        'kill "-$__ct_signal" "$__ct_child_pid" 2>/dev/null || true; '
+        "fi; "
+        'if [ "$__ct_signal" = "TSTP" ]; then '
+        "trap - TSTP; kill -TSTP \"$$\"; "
+        "trap '__ct_forward_control_signal TSTP' TSTP; "
+        "fi; }; "
+        "trap '__ct_forward_signal TERM 143' TERM; "
+        "trap '__ct_forward_signal HUP 129' HUP; "
+        "trap '__ct_forward_signal INT 130' INT; "
+        "trap '__ct_forward_control_signal TSTP' TSTP; "
+        "trap '__ct_forward_control_signal CONT' CONT;"
+    )
 
     if not keepalive or not resume_command:
-        return f"{cmd_str}; __ct_status=$?; {exit_hook}; exit $__ct_status"
+        return (
+            f"{signal_prelude} {command_marker}__ct_cmd={shlex.quote(cmd_str)}; "
+            '__ct_run_cmd "$__ct_cmd"; __ct_status=$?; '
+            f"{lifecycle_hook}; exit $__ct_status"
+        )
 
     resume_str = " ".join(shlex.quote(c) for c in resume_command)
     should_keepalive = (
@@ -77,15 +118,17 @@ def build_keepalive_shell_command(
     )
 
     return (
+        f"{signal_prelude} "
+        f"{command_marker}"
         f'__ct_cmd={shlex.quote(cmd_str)}; '
         f'__ct_resume={shlex.quote(resume_str)}; '
         "while true; do "
-        'eval "$__ct_cmd"; '
+        '__ct_run_cmd "$__ct_cmd"; '
         "__ct_status=$?; "
-        f"{exit_hook}; "
         'if [ "$__ct_status" -eq 0 ] && '
         f"{should_keepalive}; "
         'then __ct_cmd="$__ct_resume"; sleep 1; continue; fi; '
+        f"{lifecycle_hook}; "
         "exit $__ct_status; "
         "done"
     )

--- a/clawteam/spawn/orphans.py
+++ b/clawteam/spawn/orphans.py
@@ -1,0 +1,514 @@
+"""Orphan worker detection, reaping, and launchd scheduling helpers."""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from clawteam.fileutil import file_locked
+from clawteam.paths import validate_identifier
+from clawteam.spawn.cli_env import resolve_clawteam_executable
+from clawteam.spawn.registry import (
+    WORKER_STATE_KILLED,
+    WORKER_STATE_KILLED_BY_REAPER,
+    WORKER_STATE_RUNNING,
+    _registry_identity,
+    _session_identity,
+    evict_registry_entries,
+    get_registry,
+    is_agent_alive,
+    mark_agent_terminal_if_current,
+    mark_agent_terminal_if_registry_fields,
+)
+from clawteam.spawn.sessions import SessionStore
+from clawteam.team.models import get_data_dir
+
+LAUNCHD_LABEL = "com.clawteam.reaper"
+
+
+def list_orphan_workers(
+    team_name: str | None = None,
+    *,
+    max_age_minutes: float = 30.0,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Return stale running workers with no live backing process."""
+    now = now or datetime.now(timezone.utc)
+    orphans: list[dict[str, Any]] = []
+    for team in _iter_team_names(team_name):
+        registry = get_registry(team)
+        session_map = {session.agent_name: session for session in SessionStore(team).list_sessions()}
+        for agent_name in sorted(set(registry) | set(session_map)):
+            info = registry.get(agent_name)
+            session = session_map.get(agent_name)
+            if not _joined_running_unreleased(info, session):
+                continue
+
+            last_lifecycle_at = _latest_lifecycle_at(info, session)
+            if last_lifecycle_at is None:
+                continue
+            age_minutes = (now - last_lifecycle_at).total_seconds() / 60.0
+            if age_minutes < max_age_minutes:
+                continue
+
+            alive = _joined_alive(team, agent_name, info)
+            if alive is True:
+                continue
+            if alive is None:
+                continue
+
+            registry_state = str((info or {}).get("worker_state", ""))
+            session_state = str((session.state if session else {}).get("state", ""))
+            orphans.append({
+                "team": team,
+                "agent": agent_name,
+                "age_minutes": round(age_minutes, 2),
+                "last_lifecycle_at": last_lifecycle_at.isoformat(),
+                "registry_present": info is not None,
+                "session_present": session is not None,
+                "registry_state": registry_state,
+                "session_state": session_state,
+                "registry_seat_released": bool((info or {}).get("seat_released", False)),
+                "session_seat_released": bool((session.state if session else {}).get("seat_released", False)),
+                "registry_identity": _registry_identity(info) if info is not None else None,
+                "session_identity": _session_identity(session) if session is not None else None,
+                "alive": alive,
+                "reason": "stale-running-no-live-backing-process",
+            })
+    return orphans
+
+
+def reap_orphan_workers(
+    team_name: str | None = None,
+    *,
+    max_age_minutes: float = 30.0,
+    dry_run: bool = False,
+    reason: str = "stale-running-no-live-backing-process",
+) -> dict[str, Any]:
+    """Terminalize stale orphan workers across registry and session surfaces."""
+    reaped_at = datetime.now(timezone.utc).isoformat()
+    orphans = list_orphan_workers(team_name, max_age_minutes=max_age_minutes)
+    reaped: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    if not dry_run:
+        for orphan in orphans:
+            state = mark_agent_terminal_if_current(
+                orphan["team"],
+                orphan["agent"],
+                state=WORKER_STATE_KILLED_BY_REAPER,
+                reason=WORKER_STATE_KILLED_BY_REAPER,
+                expected_registry_identity=orphan.get("registry_identity"),
+                expected_session_identity=orphan.get("session_identity"),
+                extra={
+                    "reap_reason": reason,
+                    "reaped_at": reaped_at,
+                },
+            )
+            if state is None:
+                skipped.append({
+                    "team": orphan["team"],
+                    "agent": orphan["agent"],
+                    "reason": "identity-changed-or-live",
+                })
+            else:
+                reaped.append({
+                    "team": orphan["team"],
+                    "agent": orphan["agent"],
+                    "state": state,
+                })
+    return {
+        "dry_run": dry_run,
+        "max_age_minutes": max_age_minutes,
+        "candidate_count": len(orphans),
+        "reaped_count": len(orphans) if dry_run else len(reaped),
+        "orphans": orphans,
+        "reaped": reaped,
+        "skipped": skipped,
+    }
+
+
+def run_reaper(
+    team_name: str | None = None,
+    *,
+    max_age_minutes: float = 30.0,
+    registry_ttl_days: float = 7.0,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Run orphan reaping and safe registry archive GC."""
+    if dry_run:
+        return _run_reaper_unlocked(
+            team_name,
+            max_age_minutes=max_age_minutes,
+            registry_ttl_days=registry_ttl_days,
+            dry_run=True,
+        )
+    with file_locked(_reaper_lock_path()):
+        return _run_reaper_unlocked(
+            team_name,
+            max_age_minutes=max_age_minutes,
+            registry_ttl_days=registry_ttl_days,
+            dry_run=False,
+        )
+
+
+def _run_reaper_unlocked(
+    team_name: str | None = None,
+    *,
+    max_age_minutes: float,
+    registry_ttl_days: float,
+    dry_run: bool,
+) -> dict[str, Any]:
+    reap_result = reap_orphan_workers(team_name, max_age_minutes=max_age_minutes, dry_run=dry_run)
+    gc_results = [
+        evict_registry_entries(team, ttl_days=registry_ttl_days, dry_run=dry_run)
+        for team in _iter_team_names(team_name)
+    ]
+    return {
+        "dry_run": dry_run,
+        "max_age_minutes": max_age_minutes,
+        "registry_ttl_days": registry_ttl_days,
+        "reap": reap_result,
+        "registry_gc": gc_results,
+    }
+
+
+def mark_parent_killed(
+    team_name: str,
+    agent_name: str,
+    *,
+    signal_name: str = "",
+    pid: int = 0,
+) -> dict | None:
+    """Best-effort terminalization for parent/worker signal exits."""
+    return mark_agent_terminal_if_registry_fields(
+        team_name,
+        agent_name,
+        state=WORKER_STATE_KILLED,
+        reason="parent-killed",
+        expected_registry_fields={"pid": pid},
+        extra={"kill_signal": signal_name},
+    )
+
+
+def build_launchd_plist(
+    *,
+    clawteam_bin: str,
+    data_dir: str,
+    interval_seconds: int = 900,
+    max_age_minutes: float = 30.0,
+    registry_ttl_days: float = 7.0,
+) -> dict[str, Any]:
+    """Build the user LaunchAgent plist for the ClawTeam reaper."""
+    bin_path = Path(clawteam_bin).expanduser()
+    data_path = Path(data_dir).expanduser()
+    if not bin_path.is_absolute():
+        raise ValueError("LaunchAgent plist requires an absolute clawteam executable path")
+    if not data_path.is_absolute():
+        raise ValueError("LaunchAgent plist requires an absolute CLAWTEAM_DATA_DIR path")
+    logs_dir = data_path / "logs"
+    return {
+        "Label": LAUNCHD_LABEL,
+        "ProgramArguments": [
+            str(bin_path),
+            "reap",
+            "--max-age-minutes",
+            str(max_age_minutes),
+            "--registry-ttl-days",
+            str(registry_ttl_days),
+        ],
+        "StartInterval": interval_seconds,
+        "EnvironmentVariables": {
+            "CLAWTEAM_DATA_DIR": str(data_path),
+        },
+        "StandardOutPath": str(logs_dir / "reaper.out.log"),
+        "StandardErrorPath": str(logs_dir / "reaper.err.log"),
+        "RunAtLoad": False,
+    }
+
+
+def install_launchd_plist(
+    *,
+    execute: bool = False,
+    clawteam_bin: str | None = None,
+    data_dir: str | None = None,
+    interval_seconds: int = 900,
+    max_age_minutes: float = 30.0,
+    registry_ttl_days: float = 7.0,
+) -> dict[str, Any]:
+    """Write the LaunchAgent plist when ``execute`` is true; dry-run otherwise."""
+    resolved_bin = str(Path(clawteam_bin or resolve_clawteam_executable()).expanduser())
+    resolved_data_dir = str(Path(data_dir).expanduser()) if data_dir else str(get_data_dir())
+    plist = build_launchd_plist(
+        clawteam_bin=resolved_bin,
+        data_dir=resolved_data_dir,
+        interval_seconds=interval_seconds,
+        max_age_minutes=max_age_minutes,
+        registry_ttl_days=registry_ttl_days,
+    )
+    path = _launchd_plist_path()
+    plist_bytes = plistlib.dumps(plist, sort_keys=True)
+    if execute and sys.platform != "darwin":
+        return _launchd_platform_error(path=path, command=[])
+    if execute:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        (Path(resolved_data_dir) / "logs").mkdir(parents=True, exist_ok=True)
+        path.write_bytes(plist_bytes)
+    return {
+        "status": "installed" if execute else "dry-run",
+        "label": LAUNCHD_LABEL,
+        "path": str(path),
+        "plist": plist,
+    }
+
+
+def launchd_status() -> dict[str, Any]:
+    """Return LaunchAgent file and launchctl status without mutating state."""
+    path = _launchd_plist_path()
+    if sys.platform != "darwin":
+        return {
+            "label": LAUNCHD_LABEL,
+            "path": str(path),
+            "plist_exists": path.exists(),
+            "launchctl_loaded": False,
+            "launchctl_stdout": "",
+            "launchctl_stderr": "launchctl unavailable: launchd is macOS-only",
+        }
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", f"gui/{os.getuid()}/{LAUNCHD_LABEL}"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        launchctl_loaded = result.returncode == 0
+        stdout = result.stdout.strip()
+        stderr = result.stderr.strip()
+    except FileNotFoundError:
+        launchctl_loaded = False
+        stdout = ""
+        stderr = "launchctl not found"
+    return {
+        "label": LAUNCHD_LABEL,
+        "path": str(path),
+        "plist_exists": path.exists(),
+        "launchctl_loaded": launchctl_loaded,
+        "launchctl_stdout": stdout,
+        "launchctl_stderr": stderr,
+    }
+
+
+def bootstrap_launchd_plist(*, execute: bool = False) -> dict[str, Any]:
+    """Bootstrap the installed LaunchAgent when ``execute`` is true."""
+    path = _launchd_plist_path()
+    command = ["launchctl", "bootstrap", f"gui/{os.getuid()}", str(path)]
+    if not execute:
+        return {
+            "status": "dry-run",
+            "label": LAUNCHD_LABEL,
+            "path": str(path),
+            "command": command,
+        }
+    if sys.platform != "darwin":
+        return _launchd_platform_error(path=path, command=command)
+    try:
+        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    except FileNotFoundError as exc:
+        return {
+            "status": "error",
+            "label": LAUNCHD_LABEL,
+            "path": str(path),
+            "command": command,
+            "returncode": -1,
+            "stdout": "",
+            "stderr": str(exc),
+        }
+    return {
+        "status": "bootstrapped" if result.returncode == 0 else "error",
+        "label": LAUNCHD_LABEL,
+        "path": str(path),
+        "command": command,
+        "returncode": result.returncode,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def bootout_launchd_plist(*, execute: bool = False) -> dict[str, Any]:
+    """Unload the LaunchAgent when ``execute`` is true."""
+    path = _launchd_plist_path()
+    command = ["launchctl", "bootout", f"gui/{os.getuid()}/{LAUNCHD_LABEL}"]
+    if not execute:
+        return {
+            "status": "dry-run",
+            "label": LAUNCHD_LABEL,
+            "path": str(path),
+            "command": command,
+        }
+    if sys.platform != "darwin":
+        return _launchd_platform_error(path=path, command=command)
+    try:
+        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    except FileNotFoundError as exc:
+        return {
+            "status": "error",
+            "label": LAUNCHD_LABEL,
+            "path": str(path),
+            "command": command,
+            "returncode": -1,
+            "stdout": "",
+            "stderr": str(exc),
+        }
+    return {
+        "status": "unloaded" if result.returncode == 0 else "error",
+        "label": LAUNCHD_LABEL,
+        "path": str(path),
+        "command": command,
+        "returncode": result.returncode,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def uninstall_launchd_plist(*, execute: bool = False) -> dict[str, Any]:
+    """Remove the LaunchAgent plist when ``execute`` is true; dry-run otherwise."""
+    path = _launchd_plist_path()
+    existed = path.exists()
+    if execute and sys.platform != "darwin":
+        return _launchd_platform_error(path=path, command=[])
+    if execute and path.exists():
+        path.unlink()
+    return {
+        "status": "removed" if execute else "dry-run",
+        "label": LAUNCHD_LABEL,
+        "path": str(path),
+        "plist_existed": existed,
+    }
+
+
+def _iter_team_names(team_name: str | None) -> list[str]:
+    if team_name:
+        return [validate_identifier(team_name, "team name")]
+
+    root = get_data_dir()
+    names: set[str] = set()
+    for parent_name in ("sessions", "teams"):
+        parent = root / parent_name
+        if not parent.exists():
+            continue
+        for child in parent.iterdir():
+            if child.is_dir():
+                try:
+                    names.add(validate_identifier(child.name, "team name"))
+                except ValueError:
+                    continue
+    return sorted(names)
+
+
+def _joined_running_unreleased(info: dict | None, session) -> bool:
+    states: list[str] = []
+    unreleased = False
+    if info is not None:
+        if info.get("transition"):
+            return False
+        states.append(str(info.get("worker_state") or WORKER_STATE_RUNNING))
+        unreleased = unreleased or not bool(info.get("seat_released", False))
+    if session is not None:
+        if session.state.get("transition"):
+            return False
+        states.append(str(session.state.get("state") or ""))
+        unreleased = unreleased or not bool(session.state.get("seat_released", False))
+    return unreleased and WORKER_STATE_RUNNING in states
+
+
+def _latest_lifecycle_at(info: dict | None, session) -> datetime | None:
+    lifecycle_candidates: list[datetime | None] = []
+    if info is not None:
+        lifecycle_candidates.append(_parse_time(info.get("last_lifecycle_at")))
+    if session is not None:
+        lifecycle_candidates.append(_parse_time(session.state.get("last_lifecycle_at")))
+    valid = [candidate for candidate in lifecycle_candidates if candidate is not None]
+    if valid:
+        return max(valid)
+
+    fallback_candidates: list[datetime | None] = []
+    if info is not None:
+        fallback_candidates.append(_parse_unix_time(info.get("spawned_at")))
+    if session is not None:
+        fallback_candidates.append(_parse_time(session.saved_at))
+    valid = [candidate for candidate in fallback_candidates if candidate is not None]
+    if not valid:
+        return None
+    return max(valid)
+
+
+def _joined_alive(team_name: str, agent_name: str, info: dict | None) -> bool | None:
+    if info is not None:
+        alive = is_agent_alive(team_name, agent_name)
+        if alive is True:
+            return True
+        if alive is False:
+            return False
+        return None
+    if _tmux_default_target_alive(team_name, agent_name):
+        return True
+    return None
+
+
+def _tmux_default_target_alive(team_name: str, agent_name: str) -> bool:
+    if not shutil.which("tmux"):
+        return False
+    target = f"clawteam-{team_name}:{agent_name}"
+    result = subprocess.run(
+        ["tmux", "list-panes", "-t", target, "-F", "#{pane_dead}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False
+    return any(line.strip() == "0" for line in result.stdout.splitlines())
+
+
+def _parse_time(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _parse_unix_time(value: Any) -> datetime | None:
+    try:
+        return datetime.fromtimestamp(float(value), timezone.utc)
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _launchd_plist_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+
+
+def _launchd_platform_error(*, path: Path, command: list[str]) -> dict[str, Any]:
+    return {
+        "status": "error",
+        "label": LAUNCHD_LABEL,
+        "path": str(path),
+        "command": command,
+        "returncode": -1,
+        "stdout": "",
+        "stderr": "launchd LaunchAgent management is macOS-only",
+    }
+
+
+def _reaper_lock_path() -> Path:
+    return get_data_dir() / "locks" / LAUNCHD_LABEL

--- a/clawteam/spawn/registry.py
+++ b/clawteam/spawn/registry.py
@@ -8,11 +8,25 @@ import shutil
 import signal
 import subprocess
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 from clawteam.fileutil import atomic_write_text, file_locked
 from clawteam.paths import ensure_within_root, validate_identifier
 from clawteam.team.models import get_data_dir
+
+WORKER_STATE_RUNNING = "running"
+WORKER_STATE_SUSPENDED = "suspended"
+WORKER_STATE_COMPLETED = "completed"
+WORKER_STATES = {WORKER_STATE_RUNNING, WORKER_STATE_SUSPENDED, WORKER_STATE_COMPLETED}
+
+
+class LifecycleStateError(RuntimeError):
+    """Raised when a lifecycle transition is invalid for the current worker state."""
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _registry_path(team_name: str) -> Path:
@@ -28,6 +42,7 @@ def register_agent(
     agent_name: str,
     backend: str,
     tmux_target: str = "",
+    tmux_pane_id: str = "",
     block_id: str = "",
     pid: int = 0,
     command: list[str] | None = None,
@@ -36,20 +51,65 @@ def register_agent(
     path = _registry_path(team_name)
     with file_locked(path):
         registry = _load(path)
+        existing = registry.get(agent_name, {})
         registry[agent_name] = {
             "backend": backend,
             "tmux_target": tmux_target,
+            "tmux_pane_id": tmux_pane_id,
             "block_id": block_id,
             "pid": pid,
             "command": command or [],
             "spawned_at": time.time(),
+            # Decision: ND-363 (spawn registers workers as running in the explicit lifecycle state machine)
+            "worker_state": WORKER_STATE_RUNNING,
+            "transition": "",
+            "seat_released": False,
+            "suspended_at": "",
+            "resumed_at": "",
+            "completed_at": "",
+            "blocking_condition": "",
+            "expected_revive_signal": "",
+            "wait_request_id": "",
+            "correlation_id": "",
+            "target_dispatch_request_id": "",
+            "target_agent_ref": "",
+            "wake_reason": "",
+            "lifecycle_generation": int(existing.get("lifecycle_generation", 0)) + 1,
+            "last_lifecycle_event": "spawn",
+            "last_lifecycle_error": "",
+            "last_lifecycle_at": _now_iso(),
         }
         _save(path, registry)
+        _persist_session_lifecycle(team_name, agent_name, registry[agent_name])
 
 
 def get_registry(team_name: str) -> dict[str, dict]:
     """Return the full spawn registry for a team."""
     return _load(_registry_path(team_name))
+
+
+def get_agent_lifecycle(team_name: str, agent_name: str) -> dict | None:
+    """Return the persisted worker lifecycle record for an agent."""
+    info = get_registry(team_name).get(agent_name)
+    if not info:
+        return None
+    return _lifecycle_view(info)
+
+
+def get_lifecycle_counts(team_name: str) -> dict[str, int]:
+    """Return running/suspended/completed counts for capacity reporting."""
+    counts = {
+        WORKER_STATE_RUNNING: 0,
+        WORKER_STATE_SUSPENDED: 0,
+        WORKER_STATE_COMPLETED: 0,
+    }
+    for info in get_registry(team_name).values():
+        state = _normal_worker_state(info)
+        if state in counts:
+            counts[state] += 1
+    counts["active_seats"] = counts[WORKER_STATE_RUNNING]
+    counts["released_seats"] = counts[WORKER_STATE_SUSPENDED] + counts[WORKER_STATE_COMPLETED]
+    return counts
 
 
 def is_agent_alive(team_name: str, agent_name: str) -> bool | None:
@@ -66,6 +126,9 @@ def is_agent_alive(team_name: str, agent_name: str) -> bool | None:
     if backend == "tmux":
         alive = _tmux_pane_alive(info.get("tmux_target", ""))
         if alive is False:
+            pane_id = info.get("tmux_pane_id", "")
+            if pane_id and _tmux_pane_alive(pane_id) is True:
+                return True
             # Tmux target may be invalid (e.g. after tile operation);
             # fall back to PID check
             pid = info.get("pid", 0)
@@ -162,10 +225,201 @@ def stop_agent(team_name: str, agent_name: str, timeout_seconds: float = 3.0) ->
     while time.time() < deadline:
         alive = is_agent_alive(team_name, agent_name)
         if alive is False or alive is None:
+            mark_agent_completed(team_name, agent_name, reason="stop")
             return True
         time.sleep(0.1)
 
-    return is_agent_alive(team_name, agent_name) in (False, None)
+    stopped = is_agent_alive(team_name, agent_name) in (False, None)
+    if stopped:
+        mark_agent_completed(team_name, agent_name, reason="stop")
+    return stopped
+
+
+def suspend_agent(
+    team_name: str,
+    agent_name: str,
+    *,
+    blocking_condition: str = "",
+    expected_revive_signal: str = "ResumeDispatch",
+    wait_request_id: str = "",
+    correlation_id: str = "",
+    target_dispatch_request_id: str = "",
+    target_agent_ref: str = "",
+) -> dict:
+    """Transition a running worker to suspended while preserving its tmux pane."""
+    path = _registry_path(team_name)
+    with file_locked(path):
+        registry = _load(path)
+        info = _require_agent(registry, agent_name)
+        state = _normal_worker_state(info)
+        transition = info.get("transition", "")
+        if transition:
+            raise LifecycleStateError(f"Agent '{agent_name}' is already transitioning: {transition}")
+        if state == WORKER_STATE_COMPLETED:
+            raise LifecycleStateError(f"Agent '{agent_name}' is completed and cannot be suspended")
+        if state == WORKER_STATE_SUSPENDED:
+            if _same_suspend_identity(info, wait_request_id, correlation_id, target_dispatch_request_id):
+                return _lifecycle_view(info)
+            raise LifecycleStateError(f"Agent '{agent_name}' is already suspended for a different wait signal")
+
+        # Decision: ND-363 (persist suspending before tmux side effect for crash recovery)
+        info.update({
+            "transition": "suspending",
+            "blocking_condition": blocking_condition,
+            "expected_revive_signal": expected_revive_signal or "ResumeDispatch",
+            "wait_request_id": wait_request_id,
+            "correlation_id": correlation_id,
+            "target_dispatch_request_id": target_dispatch_request_id,
+            "target_agent_ref": target_agent_ref,
+            "last_lifecycle_event": "suspending",
+            "last_lifecycle_error": "",
+            "last_lifecycle_at": _now_iso(),
+            "lifecycle_generation": int(info.get("lifecycle_generation", 0)) + 1,
+        })
+        registry[agent_name] = info
+        _save(path, registry)
+        _persist_session_lifecycle(team_name, agent_name, info)
+
+    try:
+        _suspend_process(info)
+    except Exception as exc:
+        _record_transition_failure(team_name, agent_name, "suspending", str(exc))
+        raise
+
+    with file_locked(path):
+        registry = _load(path)
+        info = _require_agent(registry, agent_name)
+        # Decision: ND-363 (suspended workers release capacity seats without being marked dead)
+        info.update({
+            "worker_state": WORKER_STATE_SUSPENDED,
+            "transition": "",
+            "seat_released": True,
+            "suspended_at": _now_iso(),
+            "resumed_at": "",
+            "completed_at": "",
+            "last_lifecycle_event": "suspended",
+            "last_lifecycle_error": "",
+            "last_lifecycle_at": _now_iso(),
+            "lifecycle_generation": int(info.get("lifecycle_generation", 0)) + 1,
+        })
+        registry[agent_name] = info
+        _save(path, registry)
+        _persist_session_lifecycle(team_name, agent_name, info)
+        return _lifecycle_view(info)
+
+
+def resume_agent(
+    team_name: str,
+    agent_name: str,
+    *,
+    wake_reason: str = "",
+    correlation_id: str = "",
+    target_dispatch_request_id: str = "",
+    target_agent_ref: str = "",
+) -> dict:
+    """Transition a suspended worker back to running."""
+    path = _registry_path(team_name)
+    with file_locked(path):
+        registry = _load(path)
+        info = _require_agent(registry, agent_name)
+        state = _normal_worker_state(info)
+        transition = info.get("transition", "")
+        if transition:
+            raise LifecycleStateError(f"Agent '{agent_name}' is already transitioning: {transition}")
+        if state == WORKER_STATE_COMPLETED:
+            raise LifecycleStateError(f"Agent '{agent_name}' is completed and cannot be resumed")
+        if state == WORKER_STATE_RUNNING:
+            return _lifecycle_view(info)
+        _validate_resume_identity(info, correlation_id, target_dispatch_request_id, target_agent_ref)
+
+        # Decision: ND-363 (persist resuming before tmux fg so late daemon resumes are auditable)
+        info.update({
+            "transition": "resuming",
+            "wake_reason": wake_reason,
+            "last_lifecycle_event": "resuming",
+            "last_lifecycle_error": "",
+            "last_lifecycle_at": _now_iso(),
+            "lifecycle_generation": int(info.get("lifecycle_generation", 0)) + 1,
+        })
+        registry[agent_name] = info
+        _save(path, registry)
+        _persist_session_lifecycle(team_name, agent_name, info)
+
+    try:
+        _resume_process(info)
+    except Exception as exc:
+        _record_transition_failure(team_name, agent_name, "resuming", str(exc))
+        raise
+
+    with file_locked(path):
+        registry = _load(path)
+        info = _require_agent(registry, agent_name)
+        # Decision: ND-363 (resume reacquires the capacity seat and clears blocking metadata)
+        info.update({
+            "worker_state": WORKER_STATE_RUNNING,
+            "transition": "",
+            "seat_released": False,
+            "resumed_at": _now_iso(),
+            "blocking_condition": "",
+            "expected_revive_signal": "",
+            "wait_request_id": "",
+            "correlation_id": "",
+            "target_dispatch_request_id": "",
+            "target_agent_ref": "",
+            "last_lifecycle_event": "resumed",
+            "last_lifecycle_error": "",
+            "last_lifecycle_at": _now_iso(),
+            "lifecycle_generation": int(info.get("lifecycle_generation", 0)) + 1,
+        })
+        registry[agent_name] = info
+        _save(path, registry)
+        _persist_session_lifecycle(team_name, agent_name, info)
+        return _lifecycle_view(info)
+
+
+def mark_agent_completed(team_name: str, agent_name: str, *, reason: str = "completed") -> dict | None:
+    """Mark a worker lifecycle terminal without deleting its registry entry."""
+    path = _registry_path(team_name)
+    with file_locked(path):
+        registry = _load(path)
+        info = registry.get(agent_name)
+        if not info:
+            return None
+        # Decision: ND-363 (completed is terminal for late suspend/resume signals)
+        info.update({
+            "worker_state": WORKER_STATE_COMPLETED,
+            "transition": "",
+            "seat_released": True,
+            "completed_at": _now_iso(),
+            "last_lifecycle_event": reason,
+            "last_lifecycle_error": "",
+            "last_lifecycle_at": _now_iso(),
+            "lifecycle_generation": int(info.get("lifecycle_generation", 0)) + 1,
+        })
+        registry[agent_name] = info
+        _save(path, registry)
+        _persist_session_lifecycle(team_name, agent_name, info)
+        return _lifecycle_view(info)
+
+
+def _record_transition_failure(team_name: str, agent_name: str, transition: str, error: str) -> None:
+    path = _registry_path(team_name)
+    with file_locked(path):
+        registry = _load(path)
+        info = registry.get(agent_name)
+        if not info:
+            return
+        # Decision: ND-363 (failed side effects clear transient markers for retryable recovery)
+        info.update({
+            "transition": "",
+            "last_lifecycle_event": f"{transition}_failed",
+            "last_lifecycle_error": error,
+            "last_lifecycle_at": _now_iso(),
+            "lifecycle_generation": int(info.get("lifecycle_generation", 0)) + 1,
+        })
+        registry[agent_name] = info
+        _save(path, registry)
+        _persist_session_lifecycle(team_name, agent_name, info)
 
 
 def _tmux_pane_alive(target: str) -> bool:
@@ -190,6 +444,152 @@ def _tmux_pane_alive(target: str) -> bool:
         if len(parts) >= 2 and parts[1] in ("bash", "zsh", "sh", "fish"):
             return False
     return True
+
+
+def _suspend_process(info: dict) -> None:
+    backend = info.get("backend", "")
+    if backend == "tmux":
+        target = info.get("tmux_target", "")
+        if not target:
+            raise LifecycleStateError("Cannot suspend tmux worker without tmux_target")
+        # Decision: ND-363 (tmux suspend uses job-control C-z so the pane survives)
+        result = subprocess.run(
+            ["tmux", "send-keys", "-t", target, "C-z"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise LifecycleStateError(f"tmux suspend failed: {result.stderr.strip()}")
+        return
+    if backend == "subprocess":
+        pid = info.get("pid", 0)
+        if pid:
+            os.kill(pid, signal.SIGTSTP)
+            return
+    raise LifecycleStateError(f"Backend '{backend}' does not support suspend")
+
+
+def _resume_process(info: dict) -> None:
+    backend = info.get("backend", "")
+    if backend == "tmux":
+        target = info.get("tmux_target", "")
+        if not target:
+            raise LifecycleStateError("Cannot resume tmux worker without tmux_target")
+        # Decision: ND-363 (tmux resume uses shell job-control fg to continue the stopped foreground job)
+        result = subprocess.run(
+            ["tmux", "send-keys", "-t", target, "fg", "Enter"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise LifecycleStateError(f"tmux resume failed: {result.stderr.strip()}")
+        return
+    if backend == "subprocess":
+        pid = info.get("pid", 0)
+        if pid:
+            os.kill(pid, signal.SIGCONT)
+            return
+    raise LifecycleStateError(f"Backend '{backend}' does not support resume")
+
+
+def _require_agent(registry: dict, agent_name: str) -> dict:
+    info = registry.get(agent_name)
+    if not info:
+        raise LifecycleStateError(f"No registry entry for agent '{agent_name}'")
+    return info
+
+
+def _normal_worker_state(info: dict) -> str:
+    state = info.get("worker_state") or WORKER_STATE_RUNNING
+    if state not in WORKER_STATES:
+        return WORKER_STATE_RUNNING
+    return state
+
+
+def _same_suspend_identity(
+    info: dict,
+    wait_request_id: str,
+    correlation_id: str,
+    target_dispatch_request_id: str,
+) -> bool:
+    checks = [
+        ("wait_request_id", wait_request_id),
+        ("correlation_id", correlation_id),
+        ("target_dispatch_request_id", target_dispatch_request_id),
+    ]
+    for key, expected in checks:
+        if expected and info.get(key, "") != expected:
+            return False
+    return True
+
+
+def _validate_resume_identity(
+    info: dict,
+    correlation_id: str,
+    target_dispatch_request_id: str,
+    target_agent_ref: str,
+) -> None:
+    # Decision: ND-363 (ResumeDispatch-style fields must match the suspended worker record)
+    expected = {
+        "correlation_id": correlation_id,
+        "target_dispatch_request_id": target_dispatch_request_id,
+        "target_agent_ref": target_agent_ref,
+    }
+    for key, value in expected.items():
+        if value and info.get(key, "") and info.get(key, "") != value:
+            raise LifecycleStateError(
+                f"Resume signal mismatch for {key}: expected {info.get(key, '')!r}, got {value!r}"
+            )
+
+
+def _lifecycle_view(info: dict) -> dict:
+    keys = [
+        "worker_state",
+        "transition",
+        "seat_released",
+        "suspended_at",
+        "resumed_at",
+        "completed_at",
+        "blocking_condition",
+        "expected_revive_signal",
+        "wait_request_id",
+        "correlation_id",
+        "target_dispatch_request_id",
+        "target_agent_ref",
+        "wake_reason",
+        "lifecycle_generation",
+        "last_lifecycle_event",
+        "last_lifecycle_error",
+        "last_lifecycle_at",
+    ]
+    return {key: info.get(key, "") for key in keys}
+
+
+def _persist_session_lifecycle(team_name: str, agent_name: str, info: dict) -> None:
+    from clawteam.spawn.sessions import SessionStore
+
+    store = SessionStore(team_name)
+    store.merge_state(agent_name, {
+        "state": _normal_worker_state(info),
+        "transition": info.get("transition", ""),
+        "seat_released": bool(info.get("seat_released", False)),
+        "suspended_at": info.get("suspended_at", ""),
+        "resumed_at": info.get("resumed_at", ""),
+        "completed_at": info.get("completed_at", ""),
+        "blocking_condition": info.get("blocking_condition", ""),
+        "expected_revive_signal": info.get("expected_revive_signal", ""),
+        "wait_request_id": info.get("wait_request_id", ""),
+        "correlation_id": info.get("correlation_id", ""),
+        "target_dispatch_request_id": info.get("target_dispatch_request_id", ""),
+        "target_agent_ref": info.get("target_agent_ref", ""),
+        "wake_reason": info.get("wake_reason", ""),
+        "lifecycle_generation": info.get("lifecycle_generation", 0),
+        "last_lifecycle_event": info.get("last_lifecycle_event", ""),
+        "last_lifecycle_error": info.get("last_lifecycle_error", ""),
+        "last_lifecycle_at": info.get("last_lifecycle_at", ""),
+    })
 
 
 def _pid_alive(pid: int) -> bool:

--- a/clawteam/spawn/registry.py
+++ b/clawteam/spawn/registry.py
@@ -10,6 +10,7 @@ import subprocess
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from clawteam.fileutil import atomic_write_text, file_locked
 from clawteam.paths import ensure_within_root, validate_identifier
@@ -18,7 +19,20 @@ from clawteam.team.models import get_data_dir
 WORKER_STATE_RUNNING = "running"
 WORKER_STATE_SUSPENDED = "suspended"
 WORKER_STATE_COMPLETED = "completed"
-WORKER_STATES = {WORKER_STATE_RUNNING, WORKER_STATE_SUSPENDED, WORKER_STATE_COMPLETED}
+WORKER_STATE_KILLED = "killed"
+WORKER_STATE_KILLED_BY_REAPER = "killed-by-reaper"
+WORKER_STATES = {
+    WORKER_STATE_RUNNING,
+    WORKER_STATE_SUSPENDED,
+    WORKER_STATE_COMPLETED,
+    WORKER_STATE_KILLED,
+    WORKER_STATE_KILLED_BY_REAPER,
+}
+TERMINAL_WORKER_STATES = {
+    WORKER_STATE_COMPLETED,
+    WORKER_STATE_KILLED,
+    WORKER_STATE_KILLED_BY_REAPER,
+}
 
 
 class LifecycleStateError(RuntimeError):
@@ -34,6 +48,14 @@ def _registry_path(team_name: str) -> Path:
         get_data_dir() / "teams",
         validate_identifier(team_name, "team name"),
         "spawn_registry.json",
+    )
+
+
+def _registry_archive_path(team_name: str) -> Path:
+    return ensure_within_root(
+        get_data_dir() / "teams",
+        validate_identifier(team_name, "team name"),
+        "spawn_registry.archive.jsonl",
     )
 
 
@@ -98,17 +120,20 @@ def get_agent_lifecycle(team_name: str, agent_name: str) -> dict | None:
 
 def get_lifecycle_counts(team_name: str) -> dict[str, int]:
     """Return running/suspended/completed counts for capacity reporting."""
-    counts = {
-        WORKER_STATE_RUNNING: 0,
-        WORKER_STATE_SUSPENDED: 0,
-        WORKER_STATE_COMPLETED: 0,
-    }
-    for info in get_registry(team_name).values():
+    counts = {state: 0 for state in sorted(WORKER_STATES)}
+    registry = get_registry(team_name)
+    for info in registry.values():
         state = _normal_worker_state(info)
         if state in counts:
             counts[state] += 1
-    counts["active_seats"] = counts[WORKER_STATE_RUNNING]
-    counts["released_seats"] = counts[WORKER_STATE_SUSPENDED] + counts[WORKER_STATE_COMPLETED]
+    counts["active_seats"] = sum(
+        1
+        for info in registry.values()
+        if not _seat_released(info) and _normal_worker_state(info) not in TERMINAL_WORKER_STATES
+    )
+    counts["released_seats"] = sum(
+        1 for info in registry.values() if _seat_released(info)
+    )
     return counts
 
 
@@ -122,6 +147,11 @@ def is_agent_alive(team_name: str, agent_name: str) -> bool | None:
     if not info:
         return None
 
+    return _agent_info_alive(info)
+
+
+def _agent_info_alive(info: dict) -> bool | None:
+    """Check liveness for an already-loaded registry row."""
     backend = info.get("backend", "")
     if backend == "tmux":
         alive = _tmux_pane_alive(info.get("tmux_target", ""))
@@ -255,8 +285,8 @@ def suspend_agent(
         transition = info.get("transition", "")
         if transition:
             raise LifecycleStateError(f"Agent '{agent_name}' is already transitioning: {transition}")
-        if state == WORKER_STATE_COMPLETED:
-            raise LifecycleStateError(f"Agent '{agent_name}' is completed and cannot be suspended")
+        if state in TERMINAL_WORKER_STATES:
+            raise LifecycleStateError(f"Agent '{agent_name}' is terminal ({state}) and cannot be suspended")
         if state == WORKER_STATE_SUSPENDED:
             if _same_suspend_identity(info, wait_request_id, correlation_id, target_dispatch_request_id):
                 return _lifecycle_view(info)
@@ -326,8 +356,8 @@ def resume_agent(
         transition = info.get("transition", "")
         if transition:
             raise LifecycleStateError(f"Agent '{agent_name}' is already transitioning: {transition}")
-        if state == WORKER_STATE_COMPLETED:
-            raise LifecycleStateError(f"Agent '{agent_name}' is completed and cannot be resumed")
+        if state in TERMINAL_WORKER_STATES:
+            raise LifecycleStateError(f"Agent '{agent_name}' is terminal ({state}) and cannot be resumed")
         if state == WORKER_STATE_RUNNING:
             return _lifecycle_view(info)
         _validate_resume_identity(info, correlation_id, target_dispatch_request_id, target_agent_ref)
@@ -379,27 +409,295 @@ def resume_agent(
 
 def mark_agent_completed(team_name: str, agent_name: str, *, reason: str = "completed") -> dict | None:
     """Mark a worker lifecycle terminal without deleting its registry entry."""
+    return mark_agent_terminal(
+        team_name,
+        agent_name,
+        state=WORKER_STATE_COMPLETED,
+        reason=reason,
+    )
+
+
+def mark_agent_terminal(
+    team_name: str,
+    agent_name: str,
+    *,
+    state: str,
+    reason: str,
+    extra: dict[str, Any] | None = None,
+) -> dict | None:
+    """Mark a worker terminal and persist matching session audit state.
+
+    The registry row is updated when it exists. A session audit record is always
+    written so session-only orphan records can be terminalized by the reaper.
+    """
+    if state not in TERMINAL_WORKER_STATES:
+        raise LifecycleStateError(f"Worker state '{state}' is not terminal")
+
     path = _registry_path(team_name)
+    now = _now_iso()
+    extra = dict(extra or {})
     with file_locked(path):
         registry = _load(path)
         info = registry.get(agent_name)
-        if not info:
-            return None
-        # Decision: ND-363 (completed is terminal for late suspend/resume signals)
-        info.update({
-            "worker_state": WORKER_STATE_COMPLETED,
+        if info:
+            # Decision: ND-425 (all terminal states release seats and are non-resumable)
+            info.update({
+                "worker_state": state,
+                "transition": "",
+                "seat_released": True,
+                "completed_at": now,
+                "last_lifecycle_event": reason,
+                "last_lifecycle_error": "",
+                "last_lifecycle_at": now,
+                "lifecycle_generation": int(info.get("lifecycle_generation", 0)) + 1,
+            })
+            info.update(extra)
+            registry[agent_name] = info
+            _save(path, registry)
+            _persist_session_lifecycle(team_name, agent_name, info)
+            return _lifecycle_view(info)
+
+        info = {
+            "backend": "",
+            "tmux_target": "",
+            "tmux_pane_id": "",
+            "block_id": "",
+            "pid": 0,
+            "command": [],
+            "spawned_at": 0,
+            "worker_state": state,
             "transition": "",
             "seat_released": True,
-            "completed_at": _now_iso(),
+            "suspended_at": "",
+            "resumed_at": "",
+            "completed_at": now,
+            "blocking_condition": "",
+            "expected_revive_signal": "",
+            "wait_request_id": "",
+            "correlation_id": "",
+            "target_dispatch_request_id": "",
+            "target_agent_ref": "",
+            "wake_reason": "",
+            "lifecycle_generation": 1,
             "last_lifecycle_event": reason,
             "last_lifecycle_error": "",
-            "last_lifecycle_at": _now_iso(),
+            "last_lifecycle_at": now,
+        }
+        info.update(extra)
+        _persist_session_lifecycle(team_name, agent_name, info)
+        return _lifecycle_view(info)
+
+
+def mark_agent_terminal_if_current(
+    team_name: str,
+    agent_name: str,
+    *,
+    state: str,
+    reason: str,
+    expected_registry_identity: dict[str, Any] | None,
+    expected_session_identity: dict[str, Any] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict | None:
+    """Terminalize only if the registry/session still match an orphan snapshot."""
+    if state not in TERMINAL_WORKER_STATES:
+        raise LifecycleStateError(f"Worker state '{state}' is not terminal")
+
+    path = _registry_path(team_name)
+    now = _now_iso()
+    extra = dict(extra or {})
+    with file_locked(path):
+        registry = _load(path)
+        info = registry.get(agent_name)
+        if expected_registry_identity is None:
+            if info is not None:
+                return None
+        else:
+            if info is None or _registry_identity(info) != expected_registry_identity:
+                return None
+            if (
+                _normal_worker_state(info) != WORKER_STATE_RUNNING
+                or _seat_released(info)
+                or info.get("transition")
+            ):
+                return None
+            if _agent_info_alive(info) is not False:
+                return None
+
+            current_info = registry.get(agent_name)
+            if current_info is None or _registry_identity(current_info) != expected_registry_identity:
+                return None
+            info = current_info
+            info.update({
+                "worker_state": state,
+                "transition": "",
+                "seat_released": True,
+                "completed_at": now,
+                "last_lifecycle_event": reason,
+                "last_lifecycle_error": "",
+                "last_lifecycle_at": now,
+                "lifecycle_generation": int(info.get("lifecycle_generation", 0)) + 1,
+            })
+            info.update(extra)
+            registry[agent_name] = info
+            _save(path, registry)
+            _persist_session_lifecycle(team_name, agent_name, info)
+            return _lifecycle_view(info)
+
+        if not _session_identity_matches(team_name, agent_name, expected_session_identity):
+            return None
+
+        info = {
+            "backend": "",
+            "tmux_target": "",
+            "tmux_pane_id": "",
+            "block_id": "",
+            "pid": 0,
+            "command": [],
+            "spawned_at": 0,
+            "worker_state": state,
+            "transition": "",
+            "seat_released": True,
+            "suspended_at": "",
+            "resumed_at": "",
+            "completed_at": now,
+            "blocking_condition": "",
+            "expected_revive_signal": "",
+            "wait_request_id": "",
+            "correlation_id": "",
+            "target_dispatch_request_id": "",
+            "target_agent_ref": "",
+            "wake_reason": "",
+            "lifecycle_generation": 1,
+            "last_lifecycle_event": reason,
+            "last_lifecycle_error": "",
+            "last_lifecycle_at": now,
+        }
+        info.update(extra)
+        _persist_session_lifecycle(team_name, agent_name, info)
+        return _lifecycle_view(info)
+
+
+def mark_agent_terminal_if_registry_fields(
+    team_name: str,
+    agent_name: str,
+    *,
+    state: str,
+    reason: str,
+    expected_registry_fields: dict[str, Any],
+    extra: dict[str, Any] | None = None,
+) -> dict | None:
+    """Terminalize only if selected registry identity fields still match."""
+    if state not in TERMINAL_WORKER_STATES:
+        raise LifecycleStateError(f"Worker state '{state}' is not terminal")
+    expected_registry_fields = {
+        key: value
+        for key, value in expected_registry_fields.items()
+        if value not in ("", None)
+    }
+    if not expected_registry_fields:
+        return None
+
+    path = _registry_path(team_name)
+    now = _now_iso()
+    extra = dict(extra or {})
+    with file_locked(path):
+        registry = _load(path)
+        info = registry.get(agent_name)
+        if info is None:
+            return None
+        for key, expected in expected_registry_fields.items():
+            if info.get(key, "") != expected:
+                return None
+        if (
+            _normal_worker_state(info) != WORKER_STATE_RUNNING
+            or _seat_released(info)
+            or info.get("transition")
+        ):
+            return None
+
+        info.update({
+            "worker_state": state,
+            "transition": "",
+            "seat_released": True,
+            "completed_at": now,
+            "last_lifecycle_event": reason,
+            "last_lifecycle_error": "",
+            "last_lifecycle_at": now,
             "lifecycle_generation": int(info.get("lifecycle_generation", 0)) + 1,
         })
+        info.update(extra)
         registry[agent_name] = info
         _save(path, registry)
         _persist_session_lifecycle(team_name, agent_name, info)
         return _lifecycle_view(info)
+
+
+def evict_registry_entries(
+    team_name: str,
+    *,
+    ttl_days: float = 7.0,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Archive released terminal registry entries older than ``ttl_days``.
+
+    Running, alive, and suspended workers are deliberately retained even when
+    their ``spawned_at`` timestamp is old. Stale non-terminal rows must be
+    terminalized by the orphan reaper before GC can remove them from the hot
+    registry.
+    """
+    path = _registry_path(team_name)
+    archive_path = _registry_archive_path(team_name)
+    cutoff_seconds = ttl_days * 86400
+    now = time.time()
+    with file_locked(path):
+        registry = _load(path)
+        retained: dict[str, dict] = {}
+        archived: list[dict[str, Any]] = []
+        skipped: list[dict[str, str]] = []
+        for agent_name, info in registry.items():
+            state = _normal_worker_state(info)
+            try:
+                age_seconds = (
+                    _terminal_age_seconds(info, now)
+                    if state in TERMINAL_WORKER_STATES
+                    else _spawn_age_seconds(info, now)
+                )
+            except (TypeError, ValueError, OSError):
+                retained[agent_name] = info
+                skipped.append({"agent": agent_name, "reason": "missing-or-invalid-terminal-age"})
+                continue
+
+            if age_seconds < cutoff_seconds:
+                retained[agent_name] = info
+                continue
+            if state not in TERMINAL_WORKER_STATES or not _seat_released(info):
+                retained[agent_name] = info
+                skipped.append({"agent": agent_name, "reason": "not-terminal-released"})
+                continue
+
+            archived.append({
+                "team": team_name,
+                "agent": agent_name,
+                "archived_at": _now_iso(),
+                "record": info,
+            })
+
+        if not dry_run and archived:
+            archive_path.parent.mkdir(parents=True, exist_ok=True)
+            with archive_path.open("a", encoding="utf-8") as fh:
+                for entry in archived:
+                    fh.write(json.dumps(entry, sort_keys=True) + "\n")
+            _save(path, retained)
+
+    return {
+        "team": team_name,
+        "dry_run": dry_run,
+        "ttl_days": ttl_days,
+        "archived_count": len(archived),
+        "archive_path": str(archive_path),
+        "archived": [{"agent": entry["agent"], "state": entry["record"].get("worker_state", "")} for entry in archived],
+        "skipped": skipped,
+    }
 
 
 def _record_transition_failure(team_name: str, agent_name: str, transition: str, error: str) -> None:
@@ -508,6 +806,30 @@ def _normal_worker_state(info: dict) -> str:
     return state
 
 
+def _seat_released(info: dict) -> bool:
+    return bool(info.get("seat_released", False))
+
+
+def _registry_identity(info: dict) -> dict[str, Any]:
+    keys = [
+        "backend",
+        "tmux_target",
+        "tmux_pane_id",
+        "block_id",
+        "pid",
+        "spawned_at",
+        "worker_state",
+        "transition",
+        "seat_released",
+        "lifecycle_generation",
+        "last_lifecycle_at",
+    ]
+    return {
+        key: bool(info.get(key, False)) if key == "seat_released" else info.get(key, "")
+        for key in keys
+    }
+
+
 def _same_suspend_identity(
     info: dict,
     wait_request_id: str,
@@ -563,6 +885,9 @@ def _lifecycle_view(info: dict) -> dict:
         "last_lifecycle_event",
         "last_lifecycle_error",
         "last_lifecycle_at",
+        "reap_reason",
+        "reaped_at",
+        "kill_signal",
     ]
     return {key: info.get(key, "") for key in keys}
 
@@ -589,7 +914,49 @@ def _persist_session_lifecycle(team_name: str, agent_name: str, info: dict) -> N
         "last_lifecycle_event": info.get("last_lifecycle_event", ""),
         "last_lifecycle_error": info.get("last_lifecycle_error", ""),
         "last_lifecycle_at": info.get("last_lifecycle_at", ""),
+        "reap_reason": info.get("reap_reason", ""),
+        "reaped_at": info.get("reaped_at", ""),
+        "kill_signal": info.get("kill_signal", ""),
     })
+
+
+def _session_identity_matches(
+    team_name: str,
+    agent_name: str,
+    expected_session_identity: dict[str, Any] | None,
+) -> bool:
+    if expected_session_identity is None:
+        return False
+    from clawteam.spawn.sessions import SessionStore
+
+    session = SessionStore(team_name).load(agent_name)
+    if session is None:
+        return False
+    return _session_identity(session) == expected_session_identity
+
+
+def _session_identity(session) -> dict[str, Any]:
+    return {
+        "saved_at": session.saved_at,
+        "state": session.state.get("state", ""),
+        "seat_released": bool(session.state.get("seat_released", False)),
+        "last_lifecycle_at": session.state.get("last_lifecycle_at", ""),
+        "lifecycle_generation": session.state.get("lifecycle_generation", ""),
+    }
+
+
+def _terminal_age_seconds(info: dict, now: float) -> float:
+    terminal_at = info.get("reaped_at") or info.get("completed_at")
+    if not terminal_at:
+        return _spawn_age_seconds(info, now)
+    parsed = datetime.fromisoformat(str(terminal_at).replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return now - parsed.timestamp()
+
+
+def _spawn_age_seconds(info: dict, now: float) -> float:
+    return now - float(info.get("spawned_at"))
 
 
 def _pid_alive(pid: int) -> bool:

--- a/clawteam/spawn/sessions.py
+++ b/clawteam/spawn/sessions.py
@@ -82,6 +82,20 @@ class SessionStore:
         except Exception:
             return None
 
+    def merge_state(self, agent_name: str, state: dict[str, Any]) -> SessionState:
+        """Merge lifecycle state into a saved session without clobbering resume fields."""
+        validate_identifier(agent_name, "agent name")
+        existing = self.load(agent_name)
+        merged = dict(existing.state) if existing else {}
+        merged.update(state)
+        # Decision: ND-363 (lifecycle persistence must preserve session_id/last_task_id across suspend writes)
+        return self.save(
+            agent_name=agent_name,
+            session_id=existing.session_id if existing else "",
+            last_task_id=existing.last_task_id if existing else "",
+            state=merged,
+        )
+
     def clear(self, agent_name: str) -> bool:
         validate_identifier(agent_name, "agent name")
         path = _sessions_root(self.team_name) / f"{agent_name}.json"

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -278,14 +278,18 @@ class TmuxBackend(SpawnBackend):
 
         # Capture pane PID for robust liveness checking (survives tile operations)
         pane_pid = 0
+        pane_id = ""
         pid_result = subprocess.run(
-            ["tmux", "list-panes", "-t", target, "-F", "#{pane_pid}"],
+            ["tmux", "list-panes", "-t", target, "-F", "#{pane_id} #{pane_pid}"],
             capture_output=True, text=True,
         )
         if pid_result.returncode == 0 and pid_result.stdout.strip():
+            parts = pid_result.stdout.strip().splitlines()[0].split()
+            if parts:
+                pane_id = parts[0]
             try:
-                pane_pid = int(pid_result.stdout.strip().splitlines()[0])
-            except ValueError:
+                pane_pid = int(parts[1] if len(parts) > 1 else "0")
+            except (ValueError, IndexError):
                 pass
 
         # Persist spawn info for liveness checking
@@ -295,6 +299,7 @@ class TmuxBackend(SpawnBackend):
             agent_name=agent_name,
             backend="tmux",
             tmux_target=target,
+            tmux_pane_id=pane_id,
             pid=pane_pid,
             command=list(final_command),
         )

--- a/tests/test_orphan_reaper.py
+++ b/tests/test_orphan_reaper.py
@@ -1,0 +1,594 @@
+"""ND-425 orphan worker cleanup tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+
+import pytest
+from typer.testing import CliRunner
+
+from clawteam.cli.commands import app
+from clawteam.spawn import registry as spawn_registry
+from clawteam.spawn.keepalive import build_keepalive_shell_command
+from clawteam.spawn.orphans import (
+    build_launchd_plist,
+    list_orphan_workers,
+    reap_orphan_workers,
+    run_reaper,
+)
+from clawteam.spawn.registry import (
+    WORKER_STATE_KILLED,
+    WORKER_STATE_KILLED_BY_REAPER,
+    WORKER_STATE_RUNNING,
+    WORKER_STATE_SUSPENDED,
+    _load,
+    _save,
+    evict_registry_entries,
+    get_agent_lifecycle,
+    get_registry,
+    mark_agent_completed,
+    register_agent,
+)
+from clawteam.spawn.sessions import SessionStore
+from clawteam.team.models import TaskStatus
+from clawteam.team.tasks import TaskStore
+
+OLD_ISO = "2026-05-06T19:00:18.888526+00:00"
+NOW = datetime(2026, 5, 6, 20, 0, tzinfo=timezone.utc)
+
+
+def _seed_running_session(team: str, agent: str, *, last_lifecycle_at: str = OLD_ISO) -> None:
+    SessionStore(team).save(
+        agent,
+        state={
+            "state": "running",
+            "transition": "",
+            "seat_released": False,
+            "completed_at": "",
+            "last_lifecycle_event": "spawn",
+            "last_lifecycle_error": "",
+            "last_lifecycle_at": last_lifecycle_at,
+        },
+    )
+
+
+def _age_registry(
+    team: str,
+    agent: str,
+    isolated_data_dir,
+    *,
+    spawned_at: float = 0,
+    completed_at: str | None = None,
+) -> None:
+    path = isolated_data_dir / "teams" / team / "spawn_registry.json"
+    registry = _load(path)
+    registry[agent]["spawned_at"] = spawned_at
+    registry[agent]["last_lifecycle_at"] = OLD_ISO
+    if completed_at is not None:
+        registry[agent]["completed_at"] = completed_at
+    _save(path, registry)
+
+
+def test_orphan_reaper_terminalizes_registry_and_session(team_name, isolated_data_dir):
+    agent = "abstract-239b5169ba51"
+    register_agent(team_name, agent, backend="subprocess", pid=999999999)
+    _age_registry(team_name, agent, isolated_data_dir)
+    _seed_running_session(team_name, agent)
+
+    orphans = list_orphan_workers(team_name, max_age_minutes=30, now=NOW)
+    assert [item["agent"] for item in orphans] == [agent]
+    assert orphans[0]["registry_present"] is True
+    assert orphans[0]["session_present"] is True
+
+    result = reap_orphan_workers(team_name, max_age_minutes=30, dry_run=False)
+
+    lifecycle = get_agent_lifecycle(team_name, agent)
+    session = SessionStore(team_name).load(agent)
+    assert result["reaped_count"] == 1
+    assert lifecycle["worker_state"] == WORKER_STATE_KILLED_BY_REAPER
+    assert lifecycle["seat_released"] is True
+    assert lifecycle["reap_reason"] == "stale-running-no-live-backing-process"
+    assert session is not None
+    assert session.state["state"] == WORKER_STATE_KILLED_BY_REAPER
+    assert session.state["seat_released"] is True
+
+
+def test_orphan_reaper_skips_session_only_empirical_shape_without_identity(team_name):
+    agent = "abstract-25e239eef4c7"
+    _seed_running_session(team_name, agent, last_lifecycle_at="2026-05-06T16:32:07.452792+00:00")
+
+    orphans = list_orphan_workers(team_name, max_age_minutes=30, now=NOW)
+    assert orphans == []
+
+    result = reap_orphan_workers(team_name, max_age_minutes=30, dry_run=False)
+
+    session = SessionStore(team_name).load(agent)
+    assert session is not None
+    assert result["candidate_count"] == 0
+    assert session.state["state"] == WORKER_STATE_RUNNING
+    assert session.state["seat_released"] is False
+    assert get_registry(team_name) == {}
+
+
+def test_registry_gc_archives_only_released_terminal_entries(
+    team_name,
+    isolated_data_dir,
+    monkeypatch,
+):
+    monkeypatch.setattr(spawn_registry.time, "time", lambda: 10_000_000)
+    register_agent(team_name, "alive-old", backend="subprocess", pid=999999999)
+    _age_registry(team_name, "alive-old", isolated_data_dir, spawned_at=1)
+    register_agent(team_name, "suspended-old", backend="subprocess", pid=999999999)
+    _age_registry(team_name, "suspended-old", isolated_data_dir, spawned_at=1)
+    path = isolated_data_dir / "teams" / team_name / "spawn_registry.json"
+    registry = _load(path)
+    registry["suspended-old"]["worker_state"] = WORKER_STATE_SUSPENDED
+    registry["suspended-old"]["seat_released"] = True
+    _save(path, registry)
+    register_agent(team_name, "terminal-old", backend="subprocess", pid=999999999)
+    mark_agent_completed(team_name, "terminal-old", reason="test")
+    _age_registry(
+        team_name,
+        "terminal-old",
+        isolated_data_dir,
+        spawned_at=1,
+        completed_at="1970-01-01T00:00:00+00:00",
+    )
+
+    result = evict_registry_entries(team_name, ttl_days=7, dry_run=False)
+
+    registry = get_registry(team_name)
+    archive_path = isolated_data_dir / "teams" / team_name / "spawn_registry.archive.jsonl"
+    assert result["archived_count"] == 1
+    assert "terminal-old" not in registry
+    assert "alive-old" in registry
+    assert "suspended-old" in registry
+    archived = [json.loads(line) for line in archive_path.read_text().splitlines()]
+    assert archived[0]["agent"] == "terminal-old"
+
+
+def test_reap_runs_orphan_reap_and_safe_registry_gc(team_name, isolated_data_dir, monkeypatch):
+    monkeypatch.setattr(spawn_registry.time, "time", lambda: 10_000_000)
+    register_agent(team_name, "orphan", backend="subprocess", pid=999999999)
+    _age_registry(team_name, "orphan", isolated_data_dir, spawned_at=1)
+    _seed_running_session(team_name, "orphan")
+
+    first = run_reaper(team_name, max_age_minutes=30, registry_ttl_days=7, dry_run=False)
+    second = run_reaper(team_name, max_age_minutes=30, registry_ttl_days=7, dry_run=False)
+
+    assert first["reap"]["reaped_count"] == 1
+    assert second["reap"]["reaped_count"] == 0
+    assert first["registry_gc"][0]["archived_count"] == 0
+    assert second["registry_gc"][0]["archived_count"] == 0
+    assert get_registry(team_name)["orphan"]["worker_state"] == WORKER_STATE_KILLED_BY_REAPER
+
+
+def test_reaper_skips_orphan_snapshot_after_same_name_respawn(
+    team_name,
+    isolated_data_dir,
+    monkeypatch,
+):
+    register_agent(team_name, "orphan", backend="subprocess", pid=999999999)
+    _age_registry(team_name, "orphan", isolated_data_dir, spawned_at=1)
+    _seed_running_session(team_name, "orphan")
+    stale_snapshot = list_orphan_workers(team_name, max_age_minutes=30, now=NOW)
+    register_agent(team_name, "orphan", backend="subprocess", pid=os.getpid())
+    monkeypatch.setattr(
+        "clawteam.spawn.orphans.list_orphan_workers",
+        lambda *_args, **_kwargs: stale_snapshot,
+    )
+
+    result = reap_orphan_workers(team_name, max_age_minutes=30, dry_run=False)
+
+    lifecycle = get_agent_lifecycle(team_name, "orphan")
+    assert result["reaped_count"] == 0
+    assert result["skipped"] == [
+        {"team": team_name, "agent": "orphan", "reason": "identity-changed-or-live"}
+    ]
+    assert lifecycle["worker_state"] == WORKER_STATE_RUNNING
+    assert lifecycle["seat_released"] is False
+
+
+def test_reaper_skips_unverifiable_registry_liveness(team_name, isolated_data_dir):
+    register_agent(team_name, "unknown", backend="mystery", pid=0)
+    _age_registry(team_name, "unknown", isolated_data_dir, spawned_at=1)
+    _seed_running_session(team_name, "unknown")
+
+    result = reap_orphan_workers(team_name, max_age_minutes=30, dry_run=False)
+
+    lifecycle = get_agent_lifecycle(team_name, "unknown")
+    assert result["candidate_count"] == 0
+    assert result["reaped_count"] == 0
+    assert result["skipped"] == []
+    assert lifecycle["worker_state"] == WORKER_STATE_RUNNING
+    assert lifecycle["seat_released"] is False
+
+
+def test_reaper_skips_mid_transition_registry_rows(team_name, isolated_data_dir):
+    register_agent(team_name, "transitioning", backend="subprocess", pid=999999999)
+    _age_registry(team_name, "transitioning", isolated_data_dir, spawned_at=1)
+    path = isolated_data_dir / "teams" / team_name / "spawn_registry.json"
+    registry = _load(path)
+    registry["transitioning"]["transition"] = "suspending"
+    _save(path, registry)
+    _seed_running_session(team_name, "transitioning")
+
+    result = reap_orphan_workers(team_name, max_age_minutes=30, dry_run=False)
+
+    lifecycle = get_agent_lifecycle(team_name, "transitioning")
+    assert result["candidate_count"] == 0
+    assert lifecycle["worker_state"] == WORKER_STATE_RUNNING
+    assert lifecycle["transition"] == "suspending"
+
+
+def test_reap_dry_run_does_not_create_reaper_lock(team_name, isolated_data_dir):
+    run_reaper(team_name, max_age_minutes=30, registry_ttl_days=7, dry_run=True)
+
+    assert not (isolated_data_dir / "locks").exists()
+
+
+def test_orphan_clear_defaults_to_dry_run_and_execute_mutates(team_name, isolated_data_dir):
+    register_agent(team_name, "orphan", backend="subprocess", pid=999999999)
+    _age_registry(team_name, "orphan", isolated_data_dir)
+    _seed_running_session(team_name, "orphan")
+    runner = CliRunner()
+
+    dry = runner.invoke(
+        app,
+        ["--json", "orphan-clear", "--team", team_name, "--max-age-minutes", "30"],
+    )
+    after_dry = get_agent_lifecycle(team_name, "orphan")
+    execute = runner.invoke(
+        app,
+        ["--json", "orphan-clear", "--team", team_name, "--max-age-minutes", "30", "--execute"],
+    )
+
+    assert dry.exit_code == 0
+    assert json.loads(dry.output)["dry_run"] is True
+    assert after_dry["worker_state"] == WORKER_STATE_RUNNING
+    assert execute.exit_code == 0
+    assert json.loads(execute.output)["dry_run"] is False
+    assert get_agent_lifecycle(team_name, "orphan")["worker_state"] == WORKER_STATE_KILLED_BY_REAPER
+
+
+def test_launchd_plist_uses_absolute_executable_and_fifteen_minute_interval(tmp_path):
+    plist = build_launchd_plist(
+        clawteam_bin="/usr/local/bin/clawteam",
+        data_dir=str(tmp_path / ".clawteam"),
+        interval_seconds=900,
+    )
+
+    assert plist["Label"] == "com.clawteam.reaper"
+    assert plist["StartInterval"] == 900
+    assert plist["ProgramArguments"][:2] == ["/usr/local/bin/clawteam", "reap"]
+    assert plist["EnvironmentVariables"]["CLAWTEAM_DATA_DIR"] == str(tmp_path / ".clawteam")
+
+
+def test_launchd_plist_rejects_relative_paths(tmp_path):
+    with pytest.raises(ValueError, match="absolute clawteam executable"):
+        build_launchd_plist(
+            clawteam_bin="clawteam",
+            data_dir=str(tmp_path / ".clawteam"),
+        )
+
+    with pytest.raises(ValueError, match="absolute CLAWTEAM_DATA_DIR"):
+        build_launchd_plist(
+            clawteam_bin="/usr/local/bin/clawteam",
+            data_dir=".clawteam",
+        )
+
+
+def test_reaper_install_launchd_is_dry_run_by_default(tmp_path):
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "reaper",
+            "install-launchd",
+            "--clawteam-bin",
+            "/usr/local/bin/clawteam",
+            "--data-dir",
+            str(tmp_path / ".clawteam"),
+        ],
+        env={"HOME": str(tmp_path)},
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "dry-run"
+    assert not (tmp_path / "Library" / "LaunchAgents" / "com.clawteam.reaper.plist").exists()
+
+
+def test_reaper_bootstrap_launchd_is_dry_run_by_default(tmp_path):
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        ["--json", "reaper", "bootstrap-launchd"],
+        env={"HOME": str(tmp_path)},
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "dry-run"
+    assert payload["command"][0:2] == ["launchctl", "bootstrap"]
+
+
+def test_reaper_bootstrap_launchd_failure_exits_nonzero(monkeypatch, tmp_path):
+    runner = CliRunner()
+
+    def fail_run(*args, **kwargs):
+        return subprocess.CompletedProcess(args[0], 1, stdout="", stderr="boom")
+
+    monkeypatch.setattr("clawteam.spawn.orphans.subprocess.run", fail_run)
+
+    result = runner.invoke(
+        app,
+        ["--json", "reaper", "bootstrap-launchd", "--execute"],
+        env={"HOME": str(tmp_path)},
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 1
+    assert payload["status"] == "error"
+    assert payload["stderr"] == "boom"
+
+
+def test_reaper_bootout_launchd_missing_launchctl_exits_nonzero(monkeypatch, tmp_path):
+    runner = CliRunner()
+
+    def missing_run(*args, **kwargs):
+        raise FileNotFoundError("launchctl missing")
+
+    monkeypatch.setattr("clawteam.spawn.orphans.subprocess.run", missing_run)
+
+    result = runner.invoke(
+        app,
+        ["--json", "reaper", "bootout-launchd", "--execute"],
+        env={"HOME": str(tmp_path)},
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 1
+    assert payload["status"] == "error"
+    assert payload["returncode"] == -1
+    assert "launchctl missing" in payload["stderr"]
+
+
+def test_launchd_execute_fails_without_side_effects_on_non_macos(monkeypatch, tmp_path):
+    runner = CliRunner()
+    monkeypatch.setattr("clawteam.spawn.orphans.sys.platform", "linux")
+
+    install = runner.invoke(
+        app,
+        [
+            "--json",
+            "reaper",
+            "install-launchd",
+            "--execute",
+            "--clawteam-bin",
+            "/usr/local/bin/clawteam",
+            "--data-dir",
+            str(tmp_path / ".clawteam"),
+        ],
+        env={"HOME": str(tmp_path)},
+    )
+    bootstrap = runner.invoke(
+        app,
+        ["--json", "reaper", "bootstrap-launchd", "--execute"],
+        env={"HOME": str(tmp_path)},
+    )
+    uninstall = runner.invoke(
+        app,
+        ["--json", "reaper", "uninstall-launchd", "--execute"],
+        env={"HOME": str(tmp_path)},
+    )
+
+    assert install.exit_code == 1
+    assert bootstrap.exit_code == 1
+    assert uninstall.exit_code == 1
+    assert json.loads(install.output)["status"] == "error"
+    assert json.loads(bootstrap.output)["status"] == "error"
+    assert json.loads(uninstall.output)["status"] == "error"
+    assert not (tmp_path / "Library" / "LaunchAgents" / "com.clawteam.reaper.plist").exists()
+
+
+def test_lifecycle_on_exit_always_emits_json(team_name):
+    register_agent(team_name, "worker", backend="subprocess", pid=999999999)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        ["--json", "lifecycle", "on-exit", "--team", team_name, "--agent", "worker"],
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "agent_exited"
+    assert payload["abandoned"] is False
+    assert payload["abandoned_tasks"] == []
+
+
+def test_parent_killed_requires_pid_identity(team_name):
+    register_agent(team_name, "worker", backend="subprocess", pid=111111)
+    runner = CliRunner()
+
+    skipped = runner.invoke(
+        app,
+        [
+            "--json",
+            "lifecycle",
+            "parent-killed",
+            "--team",
+            team_name,
+            "--agent",
+            "worker",
+            "--signal",
+            "TERM",
+            "--pid",
+            "222222",
+        ],
+    )
+    released = runner.invoke(
+        app,
+        [
+            "--json",
+            "lifecycle",
+            "parent-killed",
+            "--team",
+            team_name,
+            "--agent",
+            "worker",
+            "--signal",
+            "TERM",
+            "--pid",
+            "111111",
+        ],
+    )
+
+    assert skipped.exit_code == 0
+    assert json.loads(skipped.output)["status"] == "parent_killed_skipped"
+    assert released.exit_code == 0
+    assert json.loads(released.output)["status"] == "parent_killed"
+    assert get_agent_lifecycle(team_name, "worker")["worker_state"] == WORKER_STATE_KILLED
+
+
+def test_parent_killed_resets_in_progress_tasks(team_name):
+    register_agent(team_name, "worker", backend="subprocess", pid=111111)
+    store = TaskStore(team_name)
+    task = store.create("finish work", owner="worker")
+    store.update(task.id, status=TaskStatus.in_progress)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "lifecycle",
+            "parent-killed",
+            "--team",
+            team_name,
+            "--agent",
+            "worker",
+            "--signal",
+            "TERM",
+            "--pid",
+            "111111",
+        ],
+    )
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["status"] == "parent_killed"
+    assert payload["abandoned_tasks"] == [{"id": task.id, "subject": "finish work"}]
+    assert store.get(task.id).status == TaskStatus.pending
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only signal test")
+def test_keepalive_treats_high_exit_code_as_normal_exit(tmp_path):
+    log = tmp_path / "calls.log"
+    stub = tmp_path / "clawteam"
+    stub.write_text(f"#!/bin/sh\necho \"$@\" >> {log}\nexit 0\n", encoding="utf-8")
+    stub.chmod(0o755)
+    command = build_keepalive_shell_command(
+        ["sh", "-c", "exit 143"],
+        resume_command=[],
+        clawteam_bin=str(stub),
+        team_name="demo",
+        agent_name="worker",
+        keepalive=False,
+    )
+
+    result = subprocess.run(command, shell=True)
+
+    assert result.returncode == 143
+    logged = log.read_text()
+    assert "lifecycle on-exit --team demo --agent worker" in logged
+    assert "lifecycle parent-killed" not in logged
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only signal test")
+def test_keepalive_forwards_parent_signal_to_child(tmp_path):
+    log = tmp_path / "calls.log"
+    stub = tmp_path / "clawteam"
+    child = tmp_path / "child.sh"
+    stub.write_text(f"#!/bin/sh\necho \"clawteam $@\" >> {log}\nexit 0\n", encoding="utf-8")
+    child.write_text(
+        "#!/bin/sh\n"
+        f"trap 'echo child-term >> {log}; exit 143' TERM\n"
+        f"echo child-ready >> {log}\n"
+        "sleep 30\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    child.chmod(0o755)
+    command = build_keepalive_shell_command(
+        [str(child)],
+        resume_command=[],
+        clawteam_bin=str(stub),
+        team_name="demo",
+        agent_name="worker",
+        keepalive=False,
+    )
+
+    proc = subprocess.Popen(command, shell=True)
+    for _ in range(50):
+        if log.exists() and "child-ready" in log.read_text():
+            break
+        subprocess.run(["sleep", "0.05"], check=False)
+    proc.terminate()
+    proc.wait(timeout=5)
+
+    logged = log.read_text()
+    assert "child-term" in logged
+    assert "lifecycle parent-killed --team demo --agent worker --signal TERM" in logged
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only signal test")
+def test_keepalive_installs_suspend_resume_forwarders(tmp_path):
+    stub = tmp_path / "clawteam"
+    child = tmp_path / "child.sh"
+    stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    child.write_text("#!/bin/sh\nsleep 1\n", encoding="utf-8")
+    stub.chmod(0o755)
+    child.chmod(0o755)
+
+    command = build_keepalive_shell_command(
+        [str(child)],
+        resume_command=[],
+        clawteam_bin=str(stub),
+        team_name="demo",
+        agent_name="worker",
+        keepalive=False,
+    )
+
+    assert "trap '__ct_forward_control_signal TSTP' TSTP" in command
+    assert "trap '__ct_forward_control_signal CONT' CONT" in command
+    assert 'kill -TSTP "$$"' in command
+    assert "lifecycle parent-killed" in command
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only signal test")
+def test_keepalive_marks_normal_exit_on_exit(tmp_path):
+    log = tmp_path / "calls.log"
+    stub = tmp_path / "clawteam"
+    stub.write_text(f"#!/bin/sh\necho \"$@\" >> {log}\nexit 0\n", encoding="utf-8")
+    stub.chmod(0o755)
+    command = build_keepalive_shell_command(
+        ["sh", "-c", "exit 0"],
+        resume_command=[],
+        clawteam_bin=str(stub),
+        team_name="demo",
+        agent_name="worker",
+        keepalive=False,
+    )
+
+    result = subprocess.run(command, shell=True)
+
+    assert result.returncode == 0
+    assert "lifecycle on-exit --team demo --agent worker" in log.read_text()

--- a/tests/test_suspend_lifecycle.py
+++ b/tests/test_suspend_lifecycle.py
@@ -1,0 +1,252 @@
+"""ND-363 worker suspend lifecycle tests."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import time
+
+import pytest
+from typer.testing import CliRunner
+
+from clawteam.cli.commands import app
+from clawteam.spawn import registry as spawn_registry
+from clawteam.spawn.registry import (
+    LifecycleStateError,
+    get_agent_lifecycle,
+    get_lifecycle_counts,
+    is_agent_alive,
+    mark_agent_completed,
+    register_agent,
+    resume_agent,
+    suspend_agent,
+)
+from clawteam.spawn.sessions import SessionStore
+from clawteam.team.manager import TeamManager
+
+
+def test_register_agent_starts_running_and_persists_session(team_name):
+    register_agent(team_name, "worker", backend="tmux", tmux_target="ct:worker", pid=123)
+
+    lifecycle = get_agent_lifecycle(team_name, "worker")
+    session = SessionStore(team_name).load("worker")
+
+    assert lifecycle["worker_state"] == "running"
+    assert lifecycle["seat_released"] is False
+    assert session is not None
+    assert session.state["state"] == "running"
+
+
+def test_suspend_changes_running_to_suspended_and_releases_seat(team_name, monkeypatch):
+    register_agent(team_name, "worker", backend="tmux", tmux_target="ct:worker", pid=123)
+    monkeypatch.setattr(spawn_registry, "_suspend_process", lambda _info: None)
+
+    lifecycle = suspend_agent(
+        team_name,
+        "worker",
+        blocking_condition="coordctl-lock:glass_floor.py",
+        expected_revive_signal="ResumeDispatch",
+        wait_request_id="wait-1",
+        correlation_id="corr-1",
+        target_dispatch_request_id="ND-363",
+        target_agent_ref="worker",
+    )
+
+    assert lifecycle["worker_state"] == "suspended"
+    assert lifecycle["seat_released"] is True
+    assert lifecycle["wait_request_id"] == "wait-1"
+    assert get_lifecycle_counts(team_name)["suspended"] == 1
+
+
+def test_duplicate_suspend_with_same_wait_id_is_idempotent(team_name, monkeypatch):
+    register_agent(team_name, "worker", backend="tmux", tmux_target="ct:worker", pid=123)
+    calls: list[str] = []
+    monkeypatch.setattr(spawn_registry, "_suspend_process", lambda _info: calls.append("suspend"))
+
+    first = suspend_agent(team_name, "worker", wait_request_id="wait-1", correlation_id="corr-1")
+    second = suspend_agent(team_name, "worker", wait_request_id="wait-1", correlation_id="corr-1")
+
+    assert first["worker_state"] == "suspended"
+    assert second["worker_state"] == "suspended"
+    assert calls == ["suspend"]
+
+
+def test_suspend_with_different_wait_id_conflicts_when_already_suspended(team_name, monkeypatch):
+    register_agent(team_name, "worker", backend="tmux", tmux_target="ct:worker", pid=123)
+    monkeypatch.setattr(spawn_registry, "_suspend_process", lambda _info: None)
+    suspend_agent(team_name, "worker", wait_request_id="wait-1")
+
+    with pytest.raises(LifecycleStateError):
+        suspend_agent(team_name, "worker", wait_request_id="wait-2")
+
+
+def test_resume_with_matching_resume_dispatch_fields_reacquires_seat(team_name, monkeypatch):
+    register_agent(team_name, "worker", backend="tmux", tmux_target="ct:worker", pid=123)
+    monkeypatch.setattr(spawn_registry, "_suspend_process", lambda _info: None)
+    monkeypatch.setattr(spawn_registry, "_resume_process", lambda _info: None)
+    suspend_agent(
+        team_name,
+        "worker",
+        wait_request_id="wait-1",
+        correlation_id="corr-1",
+        target_dispatch_request_id="ND-363",
+        target_agent_ref="worker",
+    )
+
+    lifecycle = resume_agent(
+        team_name,
+        "worker",
+        wake_reason="coord_resolved",
+        correlation_id="corr-1",
+        target_dispatch_request_id="ND-363",
+        target_agent_ref="worker",
+    )
+
+    assert lifecycle["worker_state"] == "running"
+    assert lifecycle["seat_released"] is False
+    assert lifecycle["wait_request_id"] == ""
+    assert get_lifecycle_counts(team_name)["active_seats"] == 1
+
+
+def test_resume_with_wrong_correlation_rejects(team_name, monkeypatch):
+    register_agent(team_name, "worker", backend="tmux", tmux_target="ct:worker", pid=123)
+    monkeypatch.setattr(spawn_registry, "_suspend_process", lambda _info: None)
+    suspend_agent(team_name, "worker", correlation_id="corr-1")
+
+    with pytest.raises(LifecycleStateError):
+        resume_agent(team_name, "worker", correlation_id="corr-2")
+
+
+def test_completed_is_terminal_for_suspend_and_resume(team_name, monkeypatch):
+    register_agent(team_name, "worker", backend="tmux", tmux_target="ct:worker", pid=123)
+    monkeypatch.setattr(spawn_registry, "_suspend_process", lambda _info: None)
+    mark_agent_completed(team_name, "worker", reason="test")
+
+    with pytest.raises(LifecycleStateError):
+        suspend_agent(team_name, "worker")
+    with pytest.raises(LifecycleStateError):
+        resume_agent(team_name, "worker")
+
+
+def test_transition_failure_clears_transient_marker_for_retry(team_name, monkeypatch):
+    register_agent(team_name, "worker", backend="tmux", tmux_target="missing", pid=123)
+
+    def fail(_info):
+        raise LifecycleStateError("tmux failed")
+
+    monkeypatch.setattr(spawn_registry, "_suspend_process", fail)
+
+    with pytest.raises(LifecycleStateError):
+        suspend_agent(team_name, "worker")
+
+    lifecycle = get_agent_lifecycle(team_name, "worker")
+    assert lifecycle["worker_state"] == "running"
+    assert lifecycle["transition"] == ""
+    assert lifecycle["last_lifecycle_event"] == "suspending_failed"
+
+
+def test_session_merge_state_preserves_resume_fields(team_name):
+    store = SessionStore(team_name)
+    store.save("worker", session_id="sess-1", last_task_id="task-1", state={"custom": "keep"})
+
+    merged = store.merge_state("worker", {"state": "suspended"})
+
+    assert merged.session_id == "sess-1"
+    assert merged.last_task_id == "task-1"
+    assert merged.state["custom"] == "keep"
+    assert merged.state["state"] == "suspended"
+
+
+def test_cli_resume_accepts_resume_dispatch_json(team_name, monkeypatch):
+    TeamManager.create_team(name=team_name, leader_name="leader", leader_id="leader001")
+    register_agent(team_name, "worker", backend="tmux", tmux_target="ct:worker", pid=123)
+    monkeypatch.setattr(spawn_registry, "_suspend_process", lambda _info: None)
+    monkeypatch.setattr(spawn_registry, "_resume_process", lambda _info: None)
+    suspend_agent(
+        team_name,
+        "worker",
+        correlation_id="corr-1",
+        target_dispatch_request_id="ND-363",
+        target_agent_ref="worker",
+    )
+    resume_dispatch = {
+        "target_dispatch_request_id": "ND-363",
+        "target_agent_ref": "worker",
+        "wake_reason": "coord_resolved",
+        "dispatched_at": "2026-05-04T22:00:00Z",
+        "correlation_id": "corr-1",
+    }
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "--json",
+            "lifecycle",
+            "resume",
+            "--team",
+            team_name,
+            "--agent",
+            "worker",
+            "--resume-dispatch-json",
+            json.dumps(resume_dispatch),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["worker_state"] == "running"
+
+
+def test_team_status_reports_running_and_suspended_counts(team_name, monkeypatch):
+    TeamManager.create_team(name=team_name, leader_name="leader", leader_id="leader001")
+    register_agent(team_name, "worker-a", backend="tmux", tmux_target="ct:a", pid=123)
+    register_agent(team_name, "worker-b", backend="tmux", tmux_target="ct:b", pid=456)
+    monkeypatch.setattr(spawn_registry, "_suspend_process", lambda _info: None)
+    suspend_agent(team_name, "worker-b", wait_request_id="wait-1")
+
+    result = CliRunner().invoke(app, ["--json", "team", "status", team_name])
+    payload = json.loads(result.output)
+
+    assert result.exit_code == 0
+    assert payload["workerLifecycle"]["running"] == 1
+    assert payload["workerLifecycle"]["suspended"] == 1
+    assert payload["workerLifecycle"]["active_seats"] == 1
+
+
+def test_tmux_suspend_keeps_pane_listed_and_resume_reactivates(team_name):
+    if not shutil.which("tmux"):
+        pytest.skip("tmux is not installed")
+
+    session = f"nd363-pytest-{int(time.time() * 1000)}"
+    target = f"{session}:worker"
+    subprocess.run(["tmux", "new-session", "-d", "-s", session, "-n", "worker", "bash"], check=True)
+    try:
+        subprocess.run(["tmux", "send-keys", "-t", target, "sleep 1000", "Enter"], check=True)
+        time.sleep(0.5)
+        pane_pid = subprocess.check_output(
+            ["tmux", "list-panes", "-t", target, "-F", "#{pane_id} #{pane_pid}"],
+            text=True,
+        ).split()
+        register_agent(
+            team_name,
+            "worker",
+            backend="tmux",
+            tmux_target=target,
+            tmux_pane_id=pane_pid[0],
+            pid=int(pane_pid[1]),
+        )
+
+        suspended = suspend_agent(team_name, "worker", wait_request_id="wait-1")
+        pane_count = subprocess.check_output(
+            ["tmux", "list-panes", "-t", target, "-F", "#{pane_id}"],
+            text=True,
+        ).strip().splitlines()
+        alive_while_suspended = is_agent_alive(team_name, "worker")
+        resumed = resume_agent(team_name, "worker")
+
+        assert suspended["worker_state"] == "suspended"
+        assert pane_count
+        assert alive_while_suspended is True
+        assert resumed["worker_state"] == "running"
+    finally:
+        subprocess.run(["tmux", "kill-session", "-t", session], check=False)


### PR DESCRIPTION
## Summary
- add explicit worker lifecycle suspend/completed state foundation
- add ND-425 orphan worker cleanup: `killed` / `killed-by-reaper`, identity-guarded orphan reaper, safe registry archive GC, and operator commands
- add keepalive signal forwarding, parent-killed cleanup, and macOS per-user LaunchAgent helpers

## Verification
- `uv run --extra dev ruff check .`
- `uv run --extra dev pytest tests/ -q` → 609 passed, 2 existing multiprocessing fork warnings
- `python3 -m compileall clawteam tests`
- `uv run --extra dev clawteam --json reap --team neurow-build --dry-run` → 6 candidates, no mutation
- LaunchAgent install dry-run/status read-only checks
- CodeRabbit local review final pass: `findings=0`
