### PR TITLE
Add session resume and leader watcher core

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -1162,6 +1162,7 @@ def team_spawn_team(
 ):
     """Create a new team and register the leader (spawnTeam)."""
     from clawteam.identity import AgentIdentity
+    from clawteam.spawn.session_capture import save_current_agent_session
     from clawteam.team.manager import TeamManager
 
     identity = AgentIdentity.from_env()
@@ -1182,11 +1183,15 @@ def team_spawn_team(
             "leadAgentId": leader_id,
             "leaderName": leader_name,
         }
+        session_id = save_current_agent_session(name, leader_name)
+        if session_id:
+            result["sessionId"] = session_id
         if identity.user:
             result["user"] = identity.user
         _output(result, lambda d: (
             console.print(f"[green]OK[/green] Team '{name}' created"),
             console.print(f"  Leader: {leader_name} (id: {leader_id})"),
+            console.print(f"  Session: {d['sessionId']}") if d.get("sessionId") else None,
         ))
     except ValueError as e:
         if _json_output:
@@ -1571,6 +1576,53 @@ def team_status(
         console.print(table)
 
     _output(data, _human)
+
+
+@team_app.command("watch")
+def team_watch(
+    team: str = typer.Argument(..., help="Team name"),
+    leader: Optional[str] = typer.Option(None, "--leader", "-l", help="Leader agent name (default: from team config)"),
+    interval: float = typer.Option(60.0, "--interval", "-i", help="Polling fallback interval in seconds"),
+    heartbeat_interval: float = typer.Option(
+        300.0,
+        "--heartbeat-interval",
+        help="Periodic reminder interval in seconds even when state is unchanged",
+    ),
+    redis_mode: str = typer.Option(
+        "auto",
+        "--redis",
+        help="Redis wakeup mode: auto, off, or redis://host:port/db",
+    ),
+):
+    """Watch team state and periodically wake the leader agent."""
+    from clawteam.team.leader_watcher import LeaderWatcher
+    from clawteam.team.manager import TeamManager
+
+    config = TeamManager.get_team(team)
+    if not config:
+        _output({"error": f"Team '{team}' not found"}, lambda d: console.print(f"[red]{d['error']}[/red]"))
+        raise typer.Exit(1)
+
+    leader_name = leader or TeamManager.get_leader_name(team)
+    if not leader_name:
+        _output({"error": f"No leader found for team '{team}'"}, lambda d: console.print(f"[red]{d['error']}[/red]"))
+        raise typer.Exit(1)
+
+    watcher = LeaderWatcher(
+        team_name=team,
+        leader_name=leader_name,
+        interval=interval,
+        heartbeat_interval=heartbeat_interval,
+        redis_mode=redis_mode,
+        json_output=_json_output,
+        verbose=not _json_output,
+    )
+    if not _json_output:
+        console.print(
+            f"Watching team '[cyan]{team}[/cyan]' for leader '[cyan]{leader_name}[/cyan]' "
+            f"(interval: {interval}s, heartbeat: {heartbeat_interval}s, redis: {redis_mode})."
+        )
+    watcher.run()
 
 
 @team_app.command("snapshot")
@@ -2572,9 +2624,11 @@ app.add_typer(session_app, name="session")
 @session_app.command("save")
 def session_save(
     team: str = typer.Argument(..., help="Team name"),
-    session_id: str = typer.Option("", "--session-id", "-s", help="Claude Code session ID"),
+    session_id: str = typer.Option("", "--session-id", "-s", help="Native client session ID"),
     last_task: str = typer.Option("", "--last-task", help="Last task ID worked on"),
     agent: Optional[str] = typer.Option(None, "--agent", "-a", help="Agent name (default: from env)"),
+    client: str = typer.Option("", "--client", help="Client name such as claude, codex, gemini"),
+    cwd: str = typer.Option("", "--cwd", help="Workspace directory for this session"),
 ):
     """Save agent session for later resume."""
     from clawteam.identity import AgentIdentity
@@ -2586,6 +2640,12 @@ def session_save(
         agent_name=agent_name,
         session_id=session_id,
         last_task_id=last_task,
+        state={
+            "client": client,
+            "source": "manual",
+            "cwd": cwd,
+            "confidence": "exact" if session_id else "",
+        },
     )
     data = _dump(session)
     _output(data, lambda d: console.print(f"[green]OK[/green] Session saved for '{agent_name}'"))
@@ -2606,9 +2666,13 @@ def session_show(
             _output({"error": f"No session for '{agent}'"}, lambda d: console.print(f"[dim]{d['error']}[/dim]"))
             return
         data = _dump(session)
+        state = data.get("state") or {}
         _output(data, lambda d: (
             console.print(f"Session: [cyan]{d.get('agentName', '')}[/cyan]"),
             console.print(f"  Session ID: {d.get('sessionId', '')}"),
+            console.print(f"  Client:     {state.get('client', '')}"),
+            console.print(f"  Source:     {state.get('source', '')} ({state.get('confidence', '')})"),
+            console.print(f"  CWD:        {state.get('cwd', '')}"),
             console.print(f"  Last task:  {d.get('lastTaskId', '')}"),
             console.print(f"  Saved at:   {format_timestamp(d.get('savedAt', ''))}"),
         ))
@@ -2622,12 +2686,17 @@ def session_show(
                 return
             table = Table(title=f"Sessions — {team}")
             table.add_column("Agent", style="cyan")
+            table.add_column("Client")
+            table.add_column("Confidence")
             table.add_column("Session ID")
             table.add_column("Last Task", style="dim")
             table.add_column("Saved At", style="dim")
             for s in items:
+                state = s.get("state") or {}
                 table.add_row(
                     s.get("agentName", ""),
+                    state.get("client", ""),
+                    state.get("confidence", ""),
                     s.get("sessionId", ""),
                     s.get("lastTaskId", ""),
                     format_timestamp(s.get("savedAt")),
@@ -3197,15 +3266,17 @@ def spawn_agent(
             repo_path=repo,
         )
 
-    # Session resume: inject --resume flag for claude commands
+    # Session resume: inject the native client resume flag.
     if resume:
+        from clawteam.spawn.session_capture import build_resume_command as build_cli_resume_command
         from clawteam.spawn.sessions import SessionStore
         session_store = SessionStore(_team)
         session = session_store.load(_name)
         if session and session.session_id:
-            # Add --resume to claude command
-            if command and Path(command[0]).name in ("claude", "claude-code"):
-                command = list(command) + ["--resume", session.session_id]
+            client = str((getattr(session, "state", None) or {}).get("client") or "")
+            resumed_command = build_cli_resume_command(command, session.session_id, client=client)
+            if resumed_command != list(command):
+                command = resumed_command
                 console.print(f"[dim]Resuming session: {session.session_id}[/dim]")
             if prompt:
                 prompt += "\nYou are resuming a previous session."
@@ -4495,7 +4566,7 @@ def run_command(
 
     from clawteam.harness.prompts import build_harness_system_prompt, build_wrapped_prompt
     from clawteam.spawn import get_backend
-    from clawteam.spawn.adapters import is_claude_command
+    from clawteam.spawn.session_capture import build_resume_command as build_cli_resume_command
     from clawteam.team.manager import TeamManager
 
     mgr = TeamManager
@@ -4566,8 +4637,11 @@ def run_command(
         from clawteam.spawn.sessions import SessionStore
 
         session = SessionStore(team).load(agent_name)
-        if session and session.session_id and is_claude_command(command_list):
-            command_list = [*command_list, "--resume", session.session_id]
+        if session and session.session_id:
+            client = str((getattr(session, "state", None) or {}).get("client") or "")
+            resumed_command = build_cli_resume_command(command_list, session.session_id, client=client)
+            if resumed_command != command_list:
+                command_list = resumed_command
             console.print(f"[dim]Resuming session: {session.session_id}[/dim]")
             if prompt:
                 prompt += "\nYou are resuming a previous session."

--- a/clawteam/spawn/session_capture.py
+++ b/clawteam/spawn/session_capture.py
@@ -1,0 +1,242 @@
+"""Facade for client-specific resumable session capture."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+from clawteam.spawn.command_validation import normalize_spawn_command
+from clawteam.spawn.session_locators import (
+    CapturedSession,
+    CurrentSessionHint,
+    PreparedSession,
+    SessionContext,
+    discover_codex_session,
+    locator_for_client,
+    locator_for_command,
+    locators,
+)
+from clawteam.spawn.session_locators.base import CONFIDENCE_RANK, now_iso
+from clawteam.spawn.sessions import SessionStore
+
+SessionCapture = PreparedSession
+__all__ = [
+    "SessionCapture",
+    "build_resume_command",
+    "discover_codex_session",
+    "persist_spawned_session",
+    "prepare_session_capture",
+    "save_current_agent_session",
+]
+
+
+def prepare_session_capture(
+    command: list[str],
+    *,
+    team_name: str,
+    agent_name: str,
+    cwd: str | None = None,
+    prompt: str | None = None,
+    task_id: str = "",
+) -> PreparedSession:
+    """Prepare a command so its native client session can be captured."""
+    context = _context(
+        team_name=team_name,
+        agent_name=agent_name,
+        cwd=cwd,
+        prompt=prompt,
+        task_id=task_id,
+    )
+    locator = locator_for_command(command)
+    if locator is None:
+        return PreparedSession(
+            command=list(command),
+            team_name=team_name,
+            agent_name=agent_name,
+            cwd=cwd or "",
+            hint=context.hint,
+        )
+    prepared = locator.prepare(command, context)
+    prepared.team_name = team_name
+    prepared.agent_name = agent_name
+    return prepared
+
+
+def persist_spawned_session(
+    capture: PreparedSession,
+    *,
+    team_name: str | None = None,
+    agent_name: str | None = None,
+    command: list[str] | None = None,
+    timeout_seconds: float = 8.0,
+) -> str:
+    """Persist a spawned session id under ~/.clawteam/sessions when possible."""
+    if not capture.client:
+        return ""
+
+    context = SessionContext(
+        team_name=team_name or capture.team_name,
+        agent_name=agent_name or capture.agent_name,
+        cwd=capture.cwd,
+        hint=capture.hint,
+        started_at=capture.started_at,
+        allow_environment=False,
+    )
+    if not context.team_name or not context.agent_name:
+        return ""
+
+    locator = locator_for_client(capture.client)
+    if locator is None:
+        return ""
+
+    if capture.async_capture and not capture.session_id:
+        thread = threading.Thread(
+            target=_capture_async,
+            kwargs={
+                "locator_client": capture.client,
+                "capture": capture,
+                "context": context,
+                "command": command or capture.command,
+                "timeout_seconds": timeout_seconds,
+            },
+            daemon=True,
+        )
+        thread.start()
+        return ""
+
+    captured = locator.capture(capture, context)
+    if captured is None:
+        return ""
+    _save_captured(context, captured, command or capture.command)
+    return captured.session_id
+
+
+def save_current_agent_session(
+    team_name: str,
+    agent_name: str,
+    *,
+    cwd: str | None = None,
+) -> str:
+    """Persist the current leader agent session id."""
+    context = SessionContext(team_name=team_name, agent_name=agent_name, cwd=cwd or os.getcwd())
+    preferred_clients = []
+    if os.environ.get("CODEX_THREAD_ID") or os.environ.get("CODEX_SESSION_ID"):
+        preferred_clients.append("codex")
+    if os.environ.get("CLAUDE_CODE_SESSION") or os.environ.get("CLAUDE_SESSION_ID"):
+        preferred_clients.append("claude")
+    for locator in [*(locator_for_client(c) for c in preferred_clients), *locators()]:
+        if locator is None:
+            continue
+        captured = locator.current_session(context)
+        if captured is None:
+            continue
+        _save_captured(context, captured, [])
+        return captured.session_id
+    return ""
+
+
+def build_resume_command(
+    command: list[str],
+    session_id: str,
+    client: str | None = None,
+) -> list[str]:
+    """Return a CLI-specific command that resumes a stored session id."""
+    if not session_id:
+        return list(command)
+    locator = locator_for_client(client or "") if client else locator_for_command(command)
+    if locator is None:
+        return list(command)
+    if client and not locator.matches(command):
+        command = [_default_command_for_client(locator.client)]
+    return locator.resume_command(command, session_id)
+
+
+def _capture_async(
+    *,
+    locator_client: str,
+    capture: PreparedSession,
+    context: SessionContext,
+    command: list[str],
+    timeout_seconds: float,
+) -> None:
+    locator = locator_for_client(locator_client)
+    if locator is None:
+        return
+    deadline = time.monotonic() + max(timeout_seconds, 0.0)
+    while True:
+        captured = locator.capture(capture, context)
+        if captured is not None:
+            _save_captured(context, captured, command)
+            return
+        if time.monotonic() >= deadline:
+            return
+        time.sleep(0.4)
+
+
+def _save_captured(
+    context: SessionContext,
+    captured: CapturedSession,
+    command: list[str],
+) -> None:
+    if not captured.session_id:
+        return
+    store = SessionStore(context.team_name)
+    existing = store.load(context.agent_name)
+    if existing and existing.session_id and not _should_overwrite(existing.state, captured.confidence):
+        return
+    store.save(
+        agent_name=context.agent_name,
+        session_id=captured.session_id,
+        state={
+            "client": captured.client,
+            "source": captured.source,
+            "cwd": captured.cwd or context.cwd,
+            "command": command,
+            "confidence": captured.confidence,
+            "capturedAt": now_iso(),
+        },
+    )
+
+
+def _should_overwrite(existing_state: dict, new_confidence: str) -> bool:
+    old = str(existing_state.get("confidence") or "")
+    return CONFIDENCE_RANK.get(new_confidence, 0) >= CONFIDENCE_RANK.get(old, 0)
+
+
+def _context(
+    *,
+    team_name: str,
+    agent_name: str,
+    cwd: str | None,
+    prompt: str | None,
+    task_id: str,
+) -> SessionContext:
+    return SessionContext(
+        team_name=team_name,
+        agent_name=agent_name,
+        cwd=cwd or "",
+        hint=CurrentSessionHint.from_prompt(
+            team_name=team_name,
+            agent_name=agent_name,
+            prompt=prompt,
+            task_id=task_id,
+        ),
+        allow_environment=False,
+    )
+
+
+def client_for_command(command: list[str]) -> str:
+    locator = locator_for_command(normalize_spawn_command(command))
+    return locator.client if locator else ""
+
+
+def _default_command_for_client(client: str) -> str:
+    return {
+        "claude": "claude",
+        "codex": "codex",
+        "gemini": "gemini",
+        "opencode": "opencode",
+        "openclaw": "openclaw",
+        "nanobot": "nanobot",
+    }.get(client, client)

--- a/clawteam/spawn/session_locators/__init__.py
+++ b/clawteam/spawn/session_locators/__init__.py
@@ -1,0 +1,67 @@
+"""Registry for client-specific session locators."""
+
+from __future__ import annotations
+
+from clawteam.spawn.command_validation import normalize_spawn_command
+
+from .base import (
+    CapturedSession,
+    CurrentSessionHint,
+    PreparedSession,
+    SessionContext,
+    SessionLocator,
+)
+from .claude import ClaudeSessionLocator
+from .codex import CodexSessionLocator, discover_codex_session
+from .gemini import GeminiSessionLocator
+from .nanobot import NanobotSessionLocator
+from .openclaw import OpenClawSessionLocator
+from .opencode import OpenCodeSessionLocator
+
+_LOCATORS: list[SessionLocator] = [
+    ClaudeSessionLocator(),
+    CodexSessionLocator(),
+    GeminiSessionLocator(),
+    OpenCodeSessionLocator(),
+    OpenClawSessionLocator(),
+    NanobotSessionLocator(),
+]
+
+
+def locators() -> list[SessionLocator]:
+    return list(_LOCATORS)
+
+
+def locator_for_command(command: list[str]) -> SessionLocator | None:
+    normalized = normalize_spawn_command(command)
+    for locator in _LOCATORS:
+        if locator.matches(normalized):
+            return locator
+    return None
+
+
+def locator_for_client(client: str) -> SessionLocator | None:
+    normalized = client.strip().lower()
+    aliases = {
+        "claude-code": "claude",
+        "codex-cli": "codex",
+        "gemini-cli": "gemini",
+    }
+    normalized = aliases.get(normalized, normalized)
+    for locator in _LOCATORS:
+        if locator.client == normalized:
+            return locator
+    return None
+
+
+__all__ = [
+    "CapturedSession",
+    "CurrentSessionHint",
+    "PreparedSession",
+    "SessionContext",
+    "SessionLocator",
+    "discover_codex_session",
+    "locator_for_client",
+    "locator_for_command",
+    "locators",
+]

--- a/clawteam/spawn/session_locators/base.py
+++ b/clawteam/spawn/session_locators/base.py
@@ -1,0 +1,191 @@
+"""Common types and helpers for client-specific session capture."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+CONFIDENCE_RANK = {
+    "latest": 10,
+    "hinted": 20,
+    "exact": 30,
+}
+
+
+@dataclass(frozen=True)
+class CurrentSessionHint:
+    """Metadata that helps match a spawned prompt to a native client session."""
+
+    team_name: str
+    agent_name: str
+    task_id: str = ""
+    prompt_text: str = ""
+    prompt_fingerprint: str = ""
+
+    @classmethod
+    def from_prompt(
+        cls,
+        *,
+        team_name: str,
+        agent_name: str,
+        prompt: str | None = None,
+        task_id: str = "",
+    ) -> "CurrentSessionHint":
+        text = normalize_message_text(prompt)
+        fingerprint = hashlib.sha256(text.encode("utf-8")).hexdigest() if text else ""
+        return cls(
+            team_name=team_name,
+            agent_name=agent_name,
+            task_id=task_id,
+            prompt_text=text,
+            prompt_fingerprint=fingerprint,
+        )
+
+    def tokens(self) -> list[str]:
+        return [value for value in (self.team_name, self.agent_name, self.task_id) if value]
+
+
+@dataclass
+class SessionContext:
+    team_name: str
+    agent_name: str
+    cwd: str = ""
+    hint: CurrentSessionHint | None = None
+    started_at: float = field(default_factory=time.time)
+    allow_environment: bool = True
+
+
+@dataclass
+class PreparedSession:
+    command: list[str]
+    team_name: str = ""
+    agent_name: str = ""
+    client: str = ""
+    session_id: str = ""
+    source: str = ""
+    confidence: str = ""
+    cwd: str = ""
+    started_at: float = field(default_factory=time.time)
+    async_capture: bool = False
+    hint: CurrentSessionHint | None = None
+
+
+@dataclass(frozen=True)
+class CapturedSession:
+    session_id: str
+    client: str
+    source: str
+    confidence: str
+    cwd: str = ""
+
+
+class SessionLocator(Protocol):
+    client: str
+
+    def matches(self, command: list[str]) -> bool:
+        ...
+
+    def prepare(self, command: list[str], context: SessionContext) -> PreparedSession:
+        ...
+
+    def capture(self, prepared: PreparedSession, context: SessionContext) -> CapturedSession | None:
+        ...
+
+    def current_session(self, context: SessionContext) -> CapturedSession | None:
+        ...
+
+    def resume_command(self, command: list[str], session_id: str) -> list[str]:
+        ...
+
+
+def option_value(command: list[str], option: str) -> str:
+    for i, item in enumerate(command):
+        if item == option and i + 1 < len(command):
+            return command[i + 1]
+        if item.startswith(option + "="):
+            return item.split("=", 1)[1]
+    return ""
+
+
+def has_any(command: list[str], options: set[str]) -> bool:
+    return any(item in options for item in command)
+
+
+def normalize_message_text(text: str | None) -> str:
+    if not text:
+        return ""
+    return re.sub(r"\s+", " ", text).strip().lower()[:4000]
+
+
+def same_path(left: str | Path, right: str | Path) -> bool:
+    try:
+        return Path(left).expanduser().resolve() == Path(right).expanduser().resolve()
+    except Exception:
+        return str(left) == str(right)
+
+
+def timestamp_to_epoch(value: Any) -> float:
+    if not value:
+        return 0.0
+    try:
+        text = str(value)
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        return datetime.fromisoformat(text).timestamp()
+    except Exception:
+        return 0.0
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def safe_json_load(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def first_json_line(path: Path) -> dict[str, Any]:
+    try:
+        first = path.read_text(encoding="utf-8").split("\n", 1)[0]
+        payload = json.loads(first)
+        return payload if isinstance(payload, dict) else {}
+    except Exception:
+        return {}
+
+
+def recent_files(root: Path, pattern: str, *, since: float = 0.0, limit: int = 80) -> list[Path]:
+    if not root.exists():
+        return []
+    threshold = since - 10 if since else 0
+    paths: list[Path] = []
+    for path in root.rglob(pattern):
+        try:
+            if path.is_file() and path.stat().st_mtime >= threshold:
+                paths.append(path)
+        except OSError:
+            continue
+    return sorted(paths, key=lambda p: p.stat().st_mtime, reverse=True)[:limit]
+
+
+def command_basename(command: list[str]) -> str:
+    if not command:
+        return ""
+    return Path(command[0]).name.lower()
+
+
+def env_session(*names: str) -> str:
+    for name in names:
+        value = os.environ.get(name)
+        if value and value.strip():
+            return value.strip()
+    return ""

--- a/clawteam/spawn/session_locators/claude.py
+++ b/clawteam/spawn/session_locators/claude.py
@@ -1,0 +1,148 @@
+"""Claude Code session locator."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from pathlib import Path
+
+from clawteam.spawn.adapters import is_claude_command
+from clawteam.spawn.command_validation import normalize_spawn_command
+
+from .base import (
+    CapturedSession,
+    PreparedSession,
+    SessionContext,
+    env_session,
+    has_any,
+    option_value,
+    timestamp_to_epoch,
+)
+
+
+class ClaudeSessionLocator:
+    client = "claude"
+
+    def matches(self, command: list[str]) -> bool:
+        return is_claude_command(normalize_spawn_command(command))
+
+    def prepare(self, command: list[str], context: SessionContext) -> PreparedSession:
+        normalized = normalize_spawn_command(command)
+        existing = option_value(normalized, "--session-id")
+        if existing:
+            return PreparedSession(
+                command=list(command),
+                client=self.client,
+                session_id=existing,
+                source="provided",
+                confidence="exact",
+                cwd=context.cwd,
+                started_at=context.started_at,
+                hint=context.hint,
+            )
+        resumed = option_value(normalized, "--resume") or option_value(normalized, "-r")
+        if resumed:
+            return PreparedSession(
+                command=list(command),
+                client=self.client,
+                session_id=resumed,
+                source="provided",
+                confidence="exact",
+                cwd=context.cwd,
+                started_at=context.started_at,
+                hint=context.hint,
+            )
+        if has_any(normalized, {"--continue", "-c", "--no-session-persistence"}):
+            return PreparedSession(
+                command=list(command),
+                client=self.client,
+                cwd=context.cwd,
+                started_at=context.started_at,
+                hint=context.hint,
+            )
+
+        session_id = str(uuid.uuid4())
+        return PreparedSession(
+            command=[*command, "--session-id", session_id],
+            client=self.client,
+            session_id=session_id,
+            source="generated",
+            confidence="exact",
+            cwd=context.cwd,
+            started_at=context.started_at,
+            hint=context.hint,
+        )
+
+    def capture(self, prepared: PreparedSession, context: SessionContext) -> CapturedSession | None:
+        if prepared.session_id:
+            return CapturedSession(
+                session_id=prepared.session_id,
+                client=self.client,
+                source=prepared.source or "prepared",
+                confidence=prepared.confidence or "exact",
+                cwd=context.cwd,
+            )
+        return self.current_session(context)
+
+    def current_session(self, context: SessionContext) -> CapturedSession | None:
+        if context.allow_environment:
+            session_id = env_session("CLAUDE_CODE_SESSION", "CLAUDE_SESSION_ID")
+            if session_id:
+                return CapturedSession(session_id, self.client, "environment", "exact", context.cwd)
+
+        project_dir = _claude_project_dir(context.cwd)
+        if not project_dir:
+            return None
+        sessions = sorted(project_dir.glob("*.jsonl"), key=_claude_session_sort_key, reverse=True)
+        if not sessions:
+            return None
+        session_path = sessions[0]
+        return CapturedSession(session_path.stem, self.client, "transcript", "latest", context.cwd)
+
+    def resume_command(self, command: list[str], session_id: str) -> list[str]:
+        normalized = normalize_spawn_command(command)
+        if option_value(normalized, "--resume") or option_value(normalized, "-r"):
+            return list(command)
+        return [*command, "--resume", session_id]
+
+
+def _encode_claude_project_dir(workspace: Path) -> str:
+    return re.sub(r"[^A-Za-z0-9-]", "-", str(workspace))
+
+
+def _claude_project_dir(cwd: str) -> Path | None:
+    if not cwd:
+        return None
+    projects = Path.home() / ".claude" / "projects"
+    if not projects.exists():
+        return None
+    encoded = _encode_claude_project_dir(Path(cwd).resolve())
+    direct = projects / encoded
+    if direct.exists():
+        return direct
+    for candidate in projects.iterdir():
+        if candidate.is_dir() and encoded in candidate.name:
+            return candidate
+    return None
+
+
+def _claude_session_sort_key(path: Path) -> tuple[float, float]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return (0.0, 0.0)
+    for line in reversed(lines):
+        if not line.strip():
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        ts = timestamp_to_epoch(payload.get("timestamp") or payload.get("createdAt"))
+        if ts:
+            return (ts, path.stat().st_mtime)
+    try:
+        return (0.0, path.stat().st_mtime)
+    except OSError:
+        return (0.0, 0.0)

--- a/clawteam/spawn/session_locators/codex.py
+++ b/clawteam/spawn/session_locators/codex.py
@@ -1,0 +1,159 @@
+"""Codex CLI session locator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clawteam.spawn.adapters import is_codex_command
+from clawteam.spawn.command_validation import normalize_spawn_command
+
+from .base import (
+    CapturedSession,
+    CurrentSessionHint,
+    PreparedSession,
+    SessionContext,
+    env_session,
+    first_json_line,
+    recent_files,
+    same_path,
+    timestamp_to_epoch,
+)
+
+
+class CodexSessionLocator:
+    client = "codex"
+
+    def matches(self, command: list[str]) -> bool:
+        return is_codex_command(normalize_spawn_command(command))
+
+    def prepare(self, command: list[str], context: SessionContext) -> PreparedSession:
+        session_id = _codex_resume_session_id(normalize_spawn_command(command))
+        return PreparedSession(
+            command=list(command),
+            client=self.client,
+            session_id=session_id,
+            source="provided" if session_id else "",
+            confidence="exact" if session_id else "",
+            cwd=context.cwd,
+            started_at=context.started_at,
+            async_capture=not bool(session_id),
+            hint=context.hint,
+        )
+
+    def capture(self, prepared: PreparedSession, context: SessionContext) -> CapturedSession | None:
+        if prepared.session_id:
+            return CapturedSession(prepared.session_id, self.client, "provided", "exact", context.cwd)
+        return self.current_session(context)
+
+    def current_session(self, context: SessionContext) -> CapturedSession | None:
+        current = env_session("CODEX_THREAD_ID", "CODEX_SESSION_ID") if context.allow_environment else ""
+        workspace = Path(context.cwd).resolve() if context.cwd else None
+        candidates = _codex_session_candidates(since=0.0 if context.allow_environment else context.started_at)
+        if current:
+            for path in candidates:
+                meta = _codex_meta(path)
+                if meta.get("id") == current and _meta_matches_workspace(meta, workspace):
+                    return CapturedSession(current, self.client, "environment", "exact", context.cwd)
+            return CapturedSession(current, self.client, "environment", "exact", context.cwd)
+
+        scored: list[tuple[int, float, str]] = []
+        for path in candidates:
+            meta = _codex_meta(path)
+            session_id = str(meta.get("id") or "")
+            if not session_id or not _meta_matches_workspace(meta, workspace):
+                continue
+            raw = _read_prefix(path)
+            score = 10
+            source = "transcript"
+            confidence = "latest"
+            if context.hint and all(token in raw for token in context.hint.tokens()):
+                score = 20
+                confidence = "hinted"
+            sort_ts = timestamp_to_epoch(meta.get("timestamp")) or path.stat().st_mtime
+            scored.append((score, sort_ts, f"{session_id}|{source}|{confidence}"))
+        if not scored:
+            return None
+        _, _, packed = max(scored, key=lambda item: (item[0], item[1]))
+        session_id, source, confidence = packed.split("|", 2)
+        return CapturedSession(session_id, self.client, source, confidence, context.cwd)
+
+    def resume_command(self, command: list[str], session_id: str) -> list[str]:
+        normalized = normalize_spawn_command(command)
+        if len(normalized) >= 2 and normalized[1] in {"resume", "fork"}:
+            return list(command)
+        return [*command, "resume", session_id]
+
+
+def discover_codex_session(
+    *,
+    team_name: str,
+    agent_name: str,
+    cwd: str,
+    since: float,
+    timeout_seconds: float = 8.0,
+) -> str:
+    import time
+
+    hint_context = SessionContext(
+        team_name=team_name,
+        agent_name=agent_name,
+        cwd=cwd,
+        hint=CurrentSessionHint.from_prompt(team_name=team_name, agent_name=agent_name),
+        started_at=since,
+        allow_environment=False,
+    )
+    deadline = time.monotonic() + max(timeout_seconds, 0.0)
+    locator = CodexSessionLocator()
+    while True:
+        found = locator.current_session(hint_context)
+        if found:
+            return found.session_id
+        if time.monotonic() >= deadline:
+            return ""
+        time.sleep(0.4)
+
+
+def _codex_session_id(path: Path) -> str:
+    return str(_codex_meta(path).get("id") or "")
+
+
+def _codex_meta(path: Path) -> dict:
+    first = first_json_line(path)
+    if first.get("type") != "session_meta":
+        return {}
+    payload = first.get("payload")
+    return payload if isinstance(payload, dict) else {}
+
+
+def _codex_session_candidates(*, since: float = 0.0) -> list[Path]:
+    return recent_files(Path.home() / ".codex" / "sessions", "*.jsonl", since=since, limit=100)
+
+
+def _meta_matches_workspace(meta: dict, workspace: Path | None) -> bool:
+    if workspace is None:
+        return True
+    cwd = meta.get("cwd")
+    return isinstance(cwd, str) and same_path(cwd, workspace)
+
+
+def _read_prefix(path: Path, max_lines: int = 120) -> str:
+    parts: list[str] = []
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for i, line in enumerate(fh):
+                parts.append(line)
+                if i >= max_lines:
+                    break
+    except OSError:
+        return ""
+    return "".join(parts)
+
+
+def _codex_resume_session_id(command: list[str]) -> str:
+    if len(command) < 2 or command[1] != "resume":
+        return ""
+    for item in command[2:]:
+        if item.startswith("-"):
+            continue
+        return item
+    return ""

--- a/clawteam/spawn/session_locators/gemini.py
+++ b/clawteam/spawn/session_locators/gemini.py
@@ -1,0 +1,106 @@
+"""Gemini CLI session locator."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from clawteam.spawn.adapters import is_gemini_command
+from clawteam.spawn.command_validation import normalize_spawn_command
+
+from .base import (
+    CapturedSession,
+    PreparedSession,
+    SessionContext,
+    option_value,
+    safe_json_load,
+    same_path,
+    timestamp_to_epoch,
+)
+
+
+class GeminiSessionLocator:
+    client = "gemini"
+
+    def matches(self, command: list[str]) -> bool:
+        return is_gemini_command(normalize_spawn_command(command))
+
+    def prepare(self, command: list[str], context: SessionContext) -> PreparedSession:
+        session_id = option_value(normalize_spawn_command(command), "--resume")
+        return PreparedSession(
+            command=list(command),
+            client=self.client,
+            session_id="" if session_id == "latest" else session_id,
+            source="provided" if session_id and session_id != "latest" else "",
+            confidence="exact" if session_id and session_id != "latest" else "",
+            cwd=context.cwd,
+            started_at=context.started_at,
+            async_capture=not bool(session_id),
+            hint=context.hint,
+        )
+
+    def capture(self, prepared: PreparedSession, context: SessionContext) -> CapturedSession | None:
+        if prepared.session_id:
+            return CapturedSession(prepared.session_id, self.client, "provided", "exact", context.cwd)
+        return self.current_session(context)
+
+    def current_session(self, context: SessionContext) -> CapturedSession | None:
+        cwd = Path(context.cwd).resolve() if context.cwd else None
+        sessions: list[Path] = []
+        tmp_root = _gemini_home() / "tmp"
+        if not tmp_root.exists() or cwd is None:
+            return None
+        for project_dir in tmp_root.iterdir():
+            marker = project_dir / ".project_root"
+            if not marker.is_file():
+                continue
+            try:
+                if not same_path(marker.read_text(encoding="utf-8").strip(), cwd):
+                    continue
+            except OSError:
+                continue
+            sessions.extend((project_dir / "chats").glob("*.json"))
+        sessions = sorted(sessions, key=_gemini_session_sort_key, reverse=True)
+        for path in sessions:
+            payload = safe_json_load(path)
+            if not isinstance(payload, dict):
+                continue
+            session_id = payload.get("sessionId")
+            if isinstance(session_id, str) and session_id:
+                return CapturedSession(session_id, self.client, "transcript", "latest", context.cwd)
+        return None
+
+    def resume_command(self, command: list[str], session_id: str) -> list[str]:
+        normalized = normalize_spawn_command(command)
+        if option_value(normalized, "--resume"):
+            return list(command)
+        return [*command, "--resume", session_id]
+
+
+def _gemini_home() -> Path:
+    cli_home = os.environ.get("GEMINI_CLI_HOME")
+    if cli_home:
+        return Path(cli_home).expanduser() / ".gemini"
+    legacy = os.environ.get("GEMINI_HOME")
+    if legacy:
+        return Path(legacy).expanduser()
+    return Path.home() / ".gemini"
+
+
+def _gemini_session_sort_key(path: Path) -> tuple[float, float]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        try:
+            return (0.0, path.stat().st_mtime)
+        except OSError:
+            return (0.0, 0.0)
+    for field in ("lastUpdated", "startTime"):
+        ts = timestamp_to_epoch(payload.get(field))
+        if ts:
+            return (ts, path.stat().st_mtime)
+    try:
+        return (0.0, path.stat().st_mtime)
+    except OSError:
+        return (0.0, 0.0)

--- a/clawteam/spawn/session_locators/nanobot.py
+++ b/clawteam/spawn/session_locators/nanobot.py
@@ -1,0 +1,53 @@
+"""Nanobot session locator."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from clawteam.spawn.adapters import is_nanobot_command
+from clawteam.spawn.command_validation import normalize_spawn_command
+
+from .base import CapturedSession, PreparedSession, SessionContext, option_value
+
+
+class NanobotSessionLocator:
+    client = "nanobot"
+
+    def matches(self, command: list[str]) -> bool:
+        return is_nanobot_command(normalize_spawn_command(command))
+
+    def prepare(self, command: list[str], context: SessionContext) -> PreparedSession:
+        session_id = option_value(normalize_spawn_command(command), "--session")
+        return PreparedSession(
+            command=list(command),
+            client=self.client,
+            session_id=session_id,
+            source="provided" if session_id else "",
+            confidence="exact" if session_id else "",
+            cwd=context.cwd,
+            started_at=context.started_at,
+            async_capture=not bool(session_id),
+            hint=context.hint,
+        )
+
+    def capture(self, prepared: PreparedSession, context: SessionContext) -> CapturedSession | None:
+        if prepared.session_id:
+            return CapturedSession(prepared.session_id, self.client, "provided", "exact", context.cwd)
+        return self.current_session(context)
+
+    def current_session(self, context: SessionContext) -> CapturedSession | None:
+        home = Path(os.environ.get("NANOBOT_HOME", Path.home() / ".nanobot")).expanduser()
+        sessions_dir = home / "workspace" / "sessions"
+        if not sessions_dir.exists():
+            return None
+        sessions = sorted(sessions_dir.glob("*.jsonl"), key=lambda path: path.stat().st_mtime, reverse=True)
+        if not sessions:
+            return None
+        return CapturedSession(sessions[0].stem, self.client, "transcript", "latest", context.cwd)
+
+    def resume_command(self, command: list[str], session_id: str) -> list[str]:
+        normalized = normalize_spawn_command(command)
+        if option_value(normalized, "--session"):
+            return list(command)
+        return [*command, "--session", session_id]

--- a/clawteam/spawn/session_locators/openclaw.py
+++ b/clawteam/spawn/session_locators/openclaw.py
@@ -1,0 +1,78 @@
+"""OpenClaw session locator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clawteam.spawn.adapters import is_openclaw_command
+from clawteam.spawn.command_validation import normalize_spawn_command
+
+from .base import (
+    CapturedSession,
+    PreparedSession,
+    SessionContext,
+    first_json_line,
+    option_value,
+    safe_json_load,
+    same_path,
+)
+
+
+class OpenClawSessionLocator:
+    client = "openclaw"
+
+    def matches(self, command: list[str]) -> bool:
+        return is_openclaw_command(normalize_spawn_command(command))
+
+    def prepare(self, command: list[str], context: SessionContext) -> PreparedSession:
+        normalized = normalize_spawn_command(command)
+        session_id = option_value(normalized, "--session-id") or option_value(normalized, "--session")
+        return PreparedSession(
+            command=list(command),
+            client=self.client,
+            session_id=session_id,
+            source="provided" if session_id else "",
+            confidence="exact" if session_id else "",
+            cwd=context.cwd,
+            started_at=context.started_at,
+            async_capture=not bool(session_id),
+            hint=context.hint,
+        )
+
+    def capture(self, prepared: PreparedSession, context: SessionContext) -> CapturedSession | None:
+        if prepared.session_id:
+            return CapturedSession(prepared.session_id, self.client, "provided", "exact", context.cwd)
+        return self.current_session(context)
+
+    def current_session(self, context: SessionContext) -> CapturedSession | None:
+        home = Path.home() / ".openclaw"
+        agents_dir = home / "agents"
+        if not agents_dir.exists():
+            return None
+        matches: list[tuple[float, str]] = []
+        for session_path in agents_dir.glob("*/sessions/*.jsonl"):
+            if context.cwd:
+                header = first_json_line(session_path)
+                cwd = header.get("cwd")
+                if isinstance(cwd, str) and not same_path(cwd, context.cwd):
+                    continue
+            session_id = session_path.stem
+            store = safe_json_load(session_path.parent / "sessions.json")
+            if isinstance(store, dict):
+                for item in store.values():
+                    if isinstance(item, dict) and item.get("sessionId") == session_path.stem:
+                        session_id = str(item.get("sessionId"))
+                        break
+            matches.append((session_path.stat().st_mtime, session_id))
+        if not matches:
+            return None
+        _, session_id = max(matches)
+        return CapturedSession(session_id, self.client, "transcript", "latest", context.cwd)
+
+    def resume_command(self, command: list[str], session_id: str) -> list[str]:
+        normalized = normalize_spawn_command(command)
+        if option_value(normalized, "--session-id") or option_value(normalized, "--session"):
+            return list(command)
+        if "tui" in normalized:
+            return [*command, "--session", f"agent:main:resume:{session_id}"]
+        return [*command, "--session-id", session_id]

--- a/clawteam/spawn/session_locators/opencode.py
+++ b/clawteam/spawn/session_locators/opencode.py
@@ -1,0 +1,74 @@
+"""OpenCode session locator."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+
+from clawteam.spawn.adapters import is_opencode_command
+from clawteam.spawn.command_validation import normalize_spawn_command
+
+from .base import CapturedSession, PreparedSession, SessionContext, option_value, same_path
+
+
+class OpenCodeSessionLocator:
+    client = "opencode"
+
+    def matches(self, command: list[str]) -> bool:
+        return is_opencode_command(normalize_spawn_command(command))
+
+    def prepare(self, command: list[str], context: SessionContext) -> PreparedSession:
+        session_id = option_value(normalize_spawn_command(command), "--session")
+        return PreparedSession(
+            command=list(command),
+            client=self.client,
+            session_id=session_id,
+            source="provided" if session_id else "",
+            confidence="exact" if session_id else "",
+            cwd=context.cwd,
+            started_at=context.started_at,
+            async_capture=not bool(session_id),
+            hint=context.hint,
+        )
+
+    def capture(self, prepared: PreparedSession, context: SessionContext) -> CapturedSession | None:
+        if prepared.session_id:
+            return CapturedSession(prepared.session_id, self.client, "provided", "exact", context.cwd)
+        return self.current_session(context)
+
+    def current_session(self, context: SessionContext) -> CapturedSession | None:
+        binary = shutil.which("opencode")
+        if not binary or not context.cwd or not os.path.isdir(context.cwd):
+            return None
+        result = subprocess.run(
+            [binary, "session", "list", "--format", "json"],
+            cwd=context.cwd,
+            text=True,
+            capture_output=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return None
+        matches = []
+        for item in payload if isinstance(payload, list) else []:
+            session_id = item.get("id")
+            directory = item.get("directory")
+            if isinstance(session_id, str) and isinstance(directory, str) and same_path(directory, context.cwd):
+                matches.append(item)
+        matches.sort(key=lambda item: item.get("updated", 0), reverse=True)
+        if not matches:
+            return None
+        return CapturedSession(matches[0]["id"], self.client, "client-list", "latest", context.cwd)
+
+    def resume_command(self, command: list[str], session_id: str) -> list[str]:
+        normalized = normalize_spawn_command(command)
+        if option_value(normalized, "--session"):
+            return list(command)
+        return [*command, "--session", session_id]

--- a/clawteam/spawn/subprocess_backend.py
+++ b/clawteam/spawn/subprocess_backend.py
@@ -15,6 +15,7 @@ from clawteam.spawn.keepalive import (
     build_resume_command,
 )
 from clawteam.spawn.runtime_notification import render_runtime_notification
+from clawteam.spawn.session_capture import persist_spawned_session, prepare_session_capture
 from clawteam.team.mailbox import MailboxManager
 from clawteam.team.models import MessageType, get_data_dir
 
@@ -69,8 +70,15 @@ class SubprocessBackend(SpawnBackend):
         if os.path.isabs(clawteam_bin):
             spawn_env.setdefault("CLAWTEAM_BIN", clawteam_bin)
 
-        prepared = self._adapter.prepare_command(
+        session_capture = prepare_session_capture(
             command,
+            team_name=team_name,
+            agent_name=agent_name,
+            cwd=cwd,
+            prompt=prompt,
+        )
+        prepared = self._adapter.prepare_command(
+            session_capture.command,
             prompt=prompt,
             cwd=cwd,
             skip_permissions=skip_permissions,
@@ -146,6 +154,12 @@ class SubprocessBackend(SpawnBackend):
             agent_name=agent_name,
             backend="subprocess",
             pid=process.pid,
+            command=list(final_command),
+        )
+        persist_spawned_session(
+            session_capture,
+            team_name=team_name,
+            agent_name=agent_name,
             command=list(final_command),
         )
 

--- a/clawteam/spawn/tmux_backend.py
+++ b/clawteam/spawn/tmux_backend.py
@@ -26,6 +26,7 @@ from clawteam.spawn.cli_env import build_spawn_path, resolve_clawteam_executable
 from clawteam.spawn.command_validation import validate_spawn_command
 from clawteam.spawn.keepalive import build_keepalive_shell_command, build_resume_command
 from clawteam.spawn.runtime_notification import render_runtime_notification
+from clawteam.spawn.session_capture import persist_spawned_session, prepare_session_capture
 from clawteam.team.models import get_data_dir
 
 _SHELL_ENV_KEY_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
@@ -86,8 +87,15 @@ class TmuxBackend(SpawnBackend):
         if os.path.isabs(clawteam_bin):
             env_vars.setdefault("CLAWTEAM_BIN", clawteam_bin)
 
-        prepared = self._adapter.prepare_command(
+        session_capture = prepare_session_capture(
             command,
+            team_name=team_name,
+            agent_name=agent_name,
+            cwd=cwd,
+            prompt=prompt,
+        )
+        prepared = self._adapter.prepare_command(
+            session_capture.command,
             prompt=prompt,
             cwd=cwd,
             skip_permissions=skip_permissions,
@@ -296,6 +304,12 @@ class TmuxBackend(SpawnBackend):
             backend="tmux",
             tmux_target=target,
             pid=pane_pid,
+            command=list(final_command),
+        )
+        persist_spawned_session(
+            session_capture,
+            team_name=team_name,
+            agent_name=agent_name,
             command=list(final_command),
         )
 

--- a/clawteam/spawn/wsh_backend.py
+++ b/clawteam/spawn/wsh_backend.py
@@ -22,6 +22,7 @@ from clawteam.spawn.cli_env import build_spawn_path, resolve_clawteam_executable
 from clawteam.spawn.command_validation import validate_spawn_command
 from clawteam.spawn.keepalive import build_keepalive_shell_command, build_resume_command
 from clawteam.spawn.runtime_notification import render_runtime_notification
+from clawteam.spawn.session_capture import persist_spawned_session, prepare_session_capture
 from clawteam.spawn.wsh_rpc import WshRpcClient
 from clawteam.team.models import get_data_dir
 
@@ -258,8 +259,15 @@ class WshBackend(SpawnBackend):
             env_vars.update(env)
         env_vars["PATH"] = build_spawn_path(env_vars.get("PATH", os.environ.get("PATH")))
 
-        prepared = self._adapter.prepare_command(
+        session_capture = prepare_session_capture(
             command,
+            team_name=team_name,
+            agent_name=agent_name,
+            cwd=cwd,
+            prompt=prompt,
+        )
+        prepared = self._adapter.prepare_command(
+            session_capture.command,
             prompt=None,
             cwd=cwd,
             skip_permissions=skip_permissions,
@@ -378,6 +386,12 @@ class WshBackend(SpawnBackend):
             backend="wsh",
             block_id=block_id,
             pid=pane_pid,
+            command=list(final_command),
+        )
+        persist_spawned_session(
+            session_capture,
+            team_name=team_name,
+            agent_name=agent_name,
             command=list(final_command),
         )
 

--- a/clawteam/store/file.py
+++ b/clawteam/store/file.py
@@ -99,6 +99,18 @@ class FileTaskStore(BaseTaskStore):
         with self._write_lock():
             self._save_unlocked(task)
         try:
+            from clawteam.team.redis_wakeup import publish_wakeup, team_channel
+            payload = {
+                "taskId": task.id,
+                "owner": task.owner,
+                "status": task.status.value,
+                "subject": task.subject,
+            }
+            publish_wakeup(self.team_name, team_channel(self.team_name, "tasks"), "task_created", payload)
+            publish_wakeup(self.team_name, team_channel(self.team_name, "events"), "task_created", payload)
+        except Exception:
+            pass
+        try:
             from clawteam.events.global_bus import get_event_bus
             from clawteam.events.types import BeforeTaskCreate
             get_event_bus().emit_async(BeforeTaskCreate(
@@ -209,6 +221,19 @@ class FileTaskStore(BaseTaskStore):
                     owner=task.owner,
                     duration_seconds=task.metadata.get("duration_seconds", 0.0),
                 ))
+        except Exception:
+            pass
+        try:
+            from clawteam.team.redis_wakeup import publish_wakeup, team_channel
+            payload = {
+                "taskId": task.id,
+                "owner": task.owner,
+                "oldStatus": _old_status,
+                "newStatus": task.status.value,
+                "subject": task.subject,
+            }
+            publish_wakeup(self.team_name, team_channel(self.team_name, "tasks"), "task_updated", payload)
+            publish_wakeup(self.team_name, team_channel(self.team_name, "events"), "task_updated", payload)
         except Exception:
             pass
         return task

--- a/clawteam/team/leader_watcher.py
+++ b/clawteam/team/leader_watcher.py
@@ -1,0 +1,327 @@
+"""Leader watcher that periodically injects coordination reminders."""
+
+from __future__ import annotations
+
+import json
+import signal
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from clawteam.fileutil import atomic_write_text
+from clawteam.paths import ensure_within_root, validate_identifier
+from clawteam.team.mailbox import MailboxManager
+from clawteam.team.models import MessageType, TaskStatus, get_data_dir
+from clawteam.team.redis_wakeup import (
+    RedisWakeup,
+    agent_channel,
+    resolve_wakeup,
+    subscribe_client,
+    team_channel,
+)
+from clawteam.team.routing_policy import RuntimeEnvelope
+from clawteam.team.tasks import TaskStore
+
+
+@dataclass
+class LeaderWatchResult:
+    injected: bool
+    reason: str
+    summary: str = ""
+    evidence: list[str] = field(default_factory=list)
+    redis_event: bool = False
+
+
+class LeaderWatcher:
+    """Poll team state and wake the leader agent when action is needed."""
+
+    def __init__(
+        self,
+        team_name: str,
+        leader_name: str,
+        *,
+        interval: float = 60.0,
+        heartbeat_interval: float = 300.0,
+        redis_mode: str = "auto",
+        json_output: bool = False,
+        verbose: bool = False,
+    ):
+        validate_identifier(team_name, "team name")
+        validate_identifier(leader_name, "leader name")
+        self.team_name = team_name
+        self.leader_name = leader_name
+        self.interval = max(interval, 1.0)
+        self.heartbeat_interval = max(heartbeat_interval, 1.0)
+        self.redis_mode = redis_mode
+        self.json_output = json_output
+        self.verbose = verbose
+        self.task_store = TaskStore(team_name)
+        self.mailbox = MailboxManager(team_name)
+        self.redis: RedisWakeup = RedisWakeup(False)
+        self._running = False
+
+    def run(self) -> None:
+        """Run the blocking watcher loop."""
+        self.redis = resolve_wakeup(self.team_name, self.redis_mode)
+        self._running = True
+
+        prev_int = signal.getsignal(signal.SIGINT)
+        prev_term = signal.getsignal(signal.SIGTERM)
+
+        def _handle_signal(signum, frame):
+            self._running = False
+
+        signal.signal(signal.SIGINT, _handle_signal)
+        signal.signal(signal.SIGTERM, _handle_signal)
+        try:
+            self.check_once(reason="startup")
+            if self.redis.enabled:
+                self._run_redis_loop()
+            else:
+                self._run_poll_loop()
+        finally:
+            signal.signal(signal.SIGINT, prev_int)
+            signal.signal(signal.SIGTERM, prev_term)
+
+    def check_once(self, *, reason: str = "poll", redis_event: bool = False) -> LeaderWatchResult:
+        """Check team state once and inject if state changed or heartbeat is due."""
+        snapshot = self._collect_snapshot()
+        state = self._read_state()
+        signature = self._signature(snapshot)
+        now = time.time()
+        last_signature = str(state.get("lastSignature") or "")
+        last_heartbeat = float(state.get("lastHeartbeatAt") or 0.0)
+
+        changed = signature != last_signature
+        heartbeat_due = now - last_heartbeat >= self.heartbeat_interval
+        if not changed and not heartbeat_due:
+            return LeaderWatchResult(False, "no_change", redis_event=redis_event)
+
+        summary, evidence = self._render(snapshot, changed=changed, heartbeat_due=heartbeat_due)
+        injected, status = self._inject(summary, evidence)
+        state.update(
+            {
+                "lastSignature": signature,
+                "lastCheckAt": now,
+                "lastInjectAt": now if injected else state.get("lastInjectAt", 0.0),
+                "lastInjectStatus": status,
+            }
+        )
+        if heartbeat_due:
+            state["lastHeartbeatAt"] = now
+        self._write_state(state)
+        result = LeaderWatchResult(
+            injected=injected,
+            reason=reason if changed else "heartbeat",
+            summary=summary,
+            evidence=evidence,
+            redis_event=redis_event,
+        )
+        self._emit_result(result)
+        return result
+
+    def _run_poll_loop(self) -> None:
+        while self._running:
+            time.sleep(self.interval)
+            self.check_once(reason="poll")
+
+    def _run_redis_loop(self) -> None:
+        client = subscribe_client(self.redis.url)
+        if client is None:
+            self.redis = RedisWakeup(False, reason="redis client unavailable")
+            self._run_poll_loop()
+            return
+        pubsub = client.pubsub(ignore_subscribe_messages=True)
+        try:
+            try:
+                from clawteam.team.manager import TeamManager
+                leader_inbox = TeamManager.resolve_inbox(self.team_name, self.leader_name)
+            except Exception:
+                leader_inbox = self.leader_name
+            channels = {
+                agent_channel(self.team_name, self.leader_name),
+                agent_channel(self.team_name, leader_inbox),
+                team_channel(self.team_name, "tasks"),
+                team_channel(self.team_name, "events"),
+            }
+            pubsub.subscribe(
+                *sorted(channels),
+            )
+            while self._running:
+                try:
+                    message = pubsub.get_message(timeout=self.interval)
+                except Exception:
+                    self.redis = RedisWakeup(False, reason="redis subscription failed")
+                    self._run_poll_loop()
+                    return
+                self.check_once(reason="redis" if message else "poll", redis_event=bool(message))
+        finally:
+            try:
+                pubsub.close()
+            except Exception:
+                pass
+
+    def _collect_snapshot(self) -> dict[str, Any]:
+        tasks = self.task_store.list_tasks()
+        try:
+            from clawteam.spawn.registry import list_dead_agents
+            dead_agents = list_dead_agents(self.team_name)
+        except Exception:
+            dead_agents = []
+        leader_messages = self.mailbox.peek(self.leader_name)
+        actionable_messages = [
+            m for m in leader_messages
+            if m.from_agent != "scheduler" and not (m.content or "").startswith("Scheduler check:")
+        ]
+        completed = [t for t in tasks if t.status == TaskStatus.completed]
+        blocked = [t for t in tasks if t.status == TaskStatus.blocked]
+        in_progress = [t for t in tasks if t.status == TaskStatus.in_progress]
+        pending = [t for t in tasks if t.status == TaskStatus.pending]
+        return {
+            "total": len(tasks),
+            "completed": [_task_ref(t) for t in completed],
+            "blocked": [_task_ref(t) for t in blocked],
+            "inProgress": [_task_ref(t) for t in in_progress],
+            "pending": [_task_ref(t) for t in pending],
+            "leaderInboxCount": len(actionable_messages),
+            "deadAgents": sorted(dead_agents),
+        }
+
+    def _signature(self, snapshot: dict[str, Any]) -> str:
+        data = {
+            "completed": snapshot["completed"],
+            "blocked": snapshot["blocked"],
+            "leaderInboxCount": snapshot["leaderInboxCount"],
+            "deadAgents": snapshot["deadAgents"],
+        }
+        return json.dumps(data, sort_keys=True, ensure_ascii=False)
+
+    def _render(
+        self,
+        snapshot: dict[str, Any],
+        *,
+        changed: bool,
+        heartbeat_due: bool,
+    ) -> tuple[str, list[str]]:
+        completed_by_owner: dict[str, int] = {}
+        for task in snapshot["completed"]:
+            owner = task.get("owner") or "unassigned"
+            completed_by_owner[owner] = completed_by_owner.get(owner, 0) + 1
+        completed_text = ", ".join(
+            f"{owner} finished {count} task(s)" for owner, count in sorted(completed_by_owner.items())
+        ) or "none"
+        dead_text = ", ".join(snapshot["deadAgents"]) or "none"
+        summary = (
+            "Scheduler check:\n"
+            f"- Completed: {completed_text}\n"
+            f"- Inbox: {self.leader_name} has {snapshot['leaderInboxCount']} unread message(s)\n"
+            f"- Blocked: {len(snapshot['blocked'])}\n"
+            f"- Dead agents: {dead_text}\n\n"
+            "Recommended next action:\n"
+            f"Run `clawteam task list {self.team_name}` and "
+            f"`clawteam inbox receive {self.team_name} --agent {self.leader_name}`, "
+            "then decide next steps."
+        )
+        evidence = [
+            f"trigger: {'state_changed' if changed else 'heartbeat'}",
+            f"heartbeatDue: {heartbeat_due}",
+            f"tasks: {len(snapshot['completed'])}/{snapshot['total']} completed",
+            f"inProgress: {len(snapshot['inProgress'])}",
+            f"pending: {len(snapshot['pending'])}",
+            f"blocked: {len(snapshot['blocked'])}",
+            f"leaderInboxCount: {snapshot['leaderInboxCount']}",
+            f"deadAgents: {dead_text}",
+        ]
+        return summary, evidence
+
+    def _inject(self, summary: str, evidence: list[str]) -> tuple[bool, str]:
+        envelope = RuntimeEnvelope(
+            source="scheduler",
+            target=self.leader_name,
+            channel="coordinator",
+            priority="medium",
+            message_type="scheduler_check",
+            summary=summary,
+            evidence=evidence,
+            recommended_next_action=(
+                f"Run `clawteam task list {self.team_name}` and "
+                f"`clawteam inbox receive {self.team_name} --agent {self.leader_name}`."
+            ),
+        )
+        try:
+            from clawteam.spawn import get_backend
+            from clawteam.spawn.registry import get_registry
+            registry = get_registry(self.team_name)
+            backend_name = (registry.get(self.leader_name) or {}).get("backend", "tmux") or "tmux"
+            backend = get_backend(backend_name)
+            if hasattr(backend, "inject_runtime_message"):
+                ok, status = backend.inject_runtime_message(self.team_name, self.leader_name, envelope)
+                if ok:
+                    return True, status
+        except Exception as exc:
+            status = str(exc)
+        else:
+            status = "runtime injection unsupported or failed"
+
+        try:
+            self.mailbox.send(
+                from_agent="scheduler",
+                to=self.leader_name,
+                content=summary,
+                msg_type=MessageType.message,
+                summary="Scheduler check",
+            )
+            return True, f"queued in leader inbox after injection failure: {status}"
+        except Exception as exc:
+            return False, f"runtime injection and inbox fallback failed: {exc}"
+
+    def _state_path(self) -> Path:
+        team_dir = ensure_within_root(
+            get_data_dir() / "teams",
+            validate_identifier(self.team_name, "team name"),
+        )
+        return team_dir / "leader_watch_state.json"
+
+    def _read_state(self) -> dict[str, Any]:
+        path = self._state_path()
+        if not path.exists():
+            return {}
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+
+    def _write_state(self, state: dict[str, Any]) -> None:
+        atomic_write_text(self._state_path(), json.dumps(state, indent=2, ensure_ascii=False))
+
+    def _emit_result(self, result: LeaderWatchResult) -> None:
+        if not (self.json_output or self.verbose):
+            return
+        if self.json_output:
+            print(
+                json.dumps(
+                    {
+                        "event": "leader_watch",
+                        "team": self.team_name,
+                        "leader": self.leader_name,
+                        "injected": result.injected,
+                        "reason": result.reason,
+                        "redisEvent": result.redis_event,
+                    },
+                    ensure_ascii=False,
+                ),
+                flush=True,
+            )
+            return
+        if result.injected:
+            print(f"[leader-watch] injected reminder ({result.reason})", flush=True)
+
+
+def _task_ref(task) -> dict[str, str]:
+    return {
+        "id": task.id,
+        "owner": task.owner,
+        "updatedAt": task.updated_at,
+        "status": task.status.value,
+    }

--- a/clawteam/team/mailbox.py
+++ b/clawteam/team/mailbox.py
@@ -117,6 +117,19 @@ class MailboxManager:
         self._transport.deliver(delivery_target, data)
         self._log_event(msg)
         try:
+            from clawteam.team.redis_wakeup import agent_channel, publish_wakeup, team_channel
+            payload = {
+                "from": from_agent,
+                "to": to,
+                "deliveryTarget": delivery_target,
+                "type": msg_type.value,
+                "requestId": msg.request_id,
+            }
+            publish_wakeup(self.team_name, agent_channel(self.team_name, delivery_target), "inbox", payload)
+            publish_wakeup(self.team_name, team_channel(self.team_name, "events"), "inbox", payload)
+        except Exception:
+            pass
+        try:
             from clawteam.events.global_bus import get_event_bus
             from clawteam.events.types import BeforeInboxSend
             get_event_bus().emit_async(BeforeInboxSend(
@@ -158,6 +171,23 @@ class MailboxManager:
                 ).encode("utf-8")
                 self._transport.deliver(recipient, data)
                 self._log_event(msg)
+                try:
+                    from clawteam.team.redis_wakeup import (
+                        agent_channel,
+                        publish_wakeup,
+                        team_channel,
+                    )
+                    payload = {
+                        "from": from_agent,
+                        "to": recipient,
+                        "deliveryTarget": recipient,
+                        "type": msg_type.value,
+                        "requestId": msg.request_id,
+                    }
+                    publish_wakeup(self.team_name, agent_channel(self.team_name, recipient), "inbox", payload)
+                    publish_wakeup(self.team_name, team_channel(self.team_name, "events"), "inbox", payload)
+                except Exception:
+                    pass
                 messages.append(msg)
         return messages
 

--- a/clawteam/team/redis_wakeup.py
+++ b/clawteam/team/redis_wakeup.py
@@ -1,0 +1,211 @@
+"""Optional Redis wakeup layer for team coordination."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from clawteam.fileutil import atomic_write_text
+from clawteam.paths import ensure_within_root, validate_identifier
+from clawteam.team.models import get_data_dir
+
+
+@dataclass
+class RedisWakeup:
+    """Resolved Redis wakeup state."""
+
+    enabled: bool
+    url: str = ""
+    reason: str = ""
+    started: bool = False
+    pid: int = 0
+
+
+def team_channel(team_name: str, suffix: str) -> str:
+    validate_identifier(team_name, "team name")
+    return f"clawteam:{team_name}:{suffix}"
+
+
+def agent_channel(team_name: str, agent_name: str) -> str:
+    validate_identifier(agent_name, "agent name")
+    return team_channel(team_name, f"agent:{agent_name}")
+
+
+def resolve_wakeup(team_name: str, mode: str = "auto") -> RedisWakeup:
+    """Resolve and optionally start Redis for a watcher.
+
+    Modes:
+    - off: disabled
+    - redis://...: use the explicit URL
+    - auto: use env/state URL, or start local redis-server if available
+    """
+    mode = (mode or "auto").strip()
+    if mode == "off":
+        return RedisWakeup(False, reason="disabled")
+    if _redis_module() is None:
+        return RedisWakeup(False, reason="python redis package not installed")
+
+    if mode.startswith("redis://") or mode.startswith("rediss://"):
+        return _ping(mode)
+
+    url = os.environ.get("CLAWTEAM_REDIS_URL") or _read_state_url(team_name)
+    if url:
+        resolved = _ping(url)
+        if resolved.enabled:
+            return resolved
+
+    if mode != "auto":
+        return RedisWakeup(False, reason=f"unsupported redis mode: {mode}")
+
+    redis_server = shutil.which("redis-server")
+    if not redis_server:
+        return RedisWakeup(False, reason="redis-server not found")
+
+    return _start_local_redis(team_name, redis_server)
+
+
+def publish_wakeup(
+    team_name: str,
+    channel: str,
+    event_type: str,
+    payload: dict[str, Any] | None = None,
+) -> bool:
+    """Best-effort Redis publish. Never raises to callers."""
+    redis_mod = _redis_module()
+    if redis_mod is None:
+        return False
+    url = os.environ.get("CLAWTEAM_REDIS_URL") or _read_state_url(team_name)
+    if not url:
+        return False
+    try:
+        client = redis_mod.from_url(url)
+        message = {
+            "team": team_name,
+            "type": event_type,
+            "payload": payload or {},
+            "timestamp": time.time(),
+        }
+        client.publish(channel, json.dumps(message, ensure_ascii=False))
+        return True
+    except Exception:
+        return False
+
+
+def subscribe_client(url: str):
+    redis_mod = _redis_module()
+    if redis_mod is None:
+        return None
+    try:
+        return redis_mod.from_url(url)
+    except Exception:
+        return None
+
+
+def _redis_module():
+    try:
+        import redis
+    except ImportError:
+        return None
+    return redis
+
+
+def _team_dir(team_name: str) -> Path:
+    return ensure_within_root(get_data_dir() / "teams", validate_identifier(team_name, "team name"))
+
+
+def _state_path(team_name: str) -> Path:
+    return _team_dir(team_name) / "redis.json"
+
+
+def _read_state_url(team_name: str) -> str:
+    path = _state_path(team_name)
+    if not path.exists():
+        return ""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return str(data.get("url") or "")
+    except Exception:
+        return ""
+
+
+def _write_state(team_name: str, data: dict[str, Any]) -> None:
+    atomic_write_text(_state_path(team_name), json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def _ping(url: str) -> RedisWakeup:
+    redis_mod = _redis_module()
+    if redis_mod is None:
+        return RedisWakeup(False, url=url, reason="python redis package not installed")
+    try:
+        client = redis_mod.from_url(url)
+        client.ping()
+        return RedisWakeup(True, url=url)
+    except Exception as exc:
+        return RedisWakeup(False, url=url, reason=str(exc))
+
+
+def _start_local_redis(team_name: str, redis_server: str) -> RedisWakeup:
+    port = _find_open_port()
+    url = f"redis://127.0.0.1:{port}/0"
+    redis_dir = _team_dir(team_name) / "redis"
+    redis_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        redis_server,
+        "--bind",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--save",
+        "",
+        "--appendonly",
+        "no",
+        "--dir",
+        str(redis_dir),
+    ]
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except Exception as exc:
+        return RedisWakeup(False, url=url, reason=str(exc))
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        resolved = _ping(url)
+        if resolved.enabled:
+            _write_state(
+                team_name,
+                {
+                    "url": url,
+                    "pid": proc.pid,
+                    "startedBy": "clawteam team watch",
+                    "startedAt": time.time(),
+                },
+            )
+            return RedisWakeup(True, url=url, started=True, pid=proc.pid)
+        if proc.poll() is not None:
+            return RedisWakeup(False, url=url, reason="redis-server exited during startup")
+        time.sleep(0.1)
+    return RedisWakeup(False, url=url, reason="redis-server startup timed out")
+
+
+def _find_open_port(start: int = 6380, attempts: int = 100) -> int:
+    for port in range(start, start + attempts):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError("no open Redis port found")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dev = [
 p2p = [
     "pyzmq>=25.0.0,<27.0.0",
 ]
+redis = [
+    "redis>=5.0.0,<6.0.0",
+]
 
 [project.scripts]
 clawteam = "clawteam.cli.commands:app"

--- a/tests/test_leader_watcher.py
+++ b/tests/test_leader_watcher.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from clawteam.team.leader_watcher import LeaderWatcher
+from clawteam.team.manager import TeamManager
+from clawteam.team.models import TaskStatus
+from clawteam.team.tasks import TaskStore
+
+
+class FakeBackend:
+    def __init__(self):
+        self.injected = []
+
+    def inject_runtime_message(self, team, agent_name, envelope):
+        self.injected.append((team, agent_name, envelope))
+        return True, "injected"
+
+
+def _create_team(tmp_path: Path, monkeypatch, team_name: str = "demo") -> None:
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path))
+    TeamManager.create_team(team_name, leader_name="leader", leader_id="leader-id")
+    TeamManager.add_member(team_name, "worker1", agent_id="worker-id")
+
+
+def test_leader_watcher_injects_startup_and_dedupes(monkeypatch, tmp_path):
+    _create_team(tmp_path, monkeypatch)
+    backend = FakeBackend()
+    monkeypatch.setattr("clawteam.spawn.get_backend", lambda _: backend)
+
+    watcher = LeaderWatcher(
+        "demo",
+        "leader",
+        redis_mode="off",
+        heartbeat_interval=3600,
+    )
+
+    first = watcher.check_once(reason="startup")
+    second = watcher.check_once(reason="poll")
+
+    assert first.injected is True
+    assert second.injected is False
+    assert len(backend.injected) == 1
+    assert "Scheduler check:" in backend.injected[0][2].summary
+
+
+def test_leader_watcher_reinjects_on_task_completion(monkeypatch, tmp_path):
+    _create_team(tmp_path, monkeypatch)
+    backend = FakeBackend()
+    monkeypatch.setattr("clawteam.spawn.get_backend", lambda _: backend)
+    store = TaskStore("demo")
+    task = store.create("Implement feature", owner="worker1")
+
+    watcher = LeaderWatcher(
+        "demo",
+        "leader",
+        redis_mode="off",
+        heartbeat_interval=3600,
+    )
+    watcher.check_once(reason="startup")
+
+    store.update(task.id, status=TaskStatus.completed, caller="worker1", force=True)
+    result = watcher.check_once(reason="poll")
+
+    assert result.injected is True
+    assert len(backend.injected) == 2
+    assert "worker1 finished 1 task(s)" in backend.injected[-1][2].summary
+
+
+def test_leader_watcher_heartbeat_injects_without_state_change(monkeypatch, tmp_path):
+    _create_team(tmp_path, monkeypatch)
+    backend = FakeBackend()
+    monkeypatch.setattr("clawteam.spawn.get_backend", lambda _: backend)
+
+    watcher = LeaderWatcher(
+        "demo",
+        "leader",
+        redis_mode="off",
+        heartbeat_interval=1,
+    )
+    watcher.check_once(reason="startup")
+    time.sleep(1.1)
+    result = watcher.check_once(reason="poll")
+
+    assert result.injected is True
+    assert result.reason == "heartbeat"
+    assert len(backend.injected) == 2
+
+
+def test_redis_wakeup_off_mode(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path))
+    from clawteam.team.redis_wakeup import resolve_wakeup
+
+    resolved = resolve_wakeup("demo", "off")
+
+    assert resolved.enabled is False
+    assert resolved.reason == "disabled"

--- a/tests/test_session_capture.py
+++ b/tests/test_session_capture.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from clawteam.spawn.session_capture import (
+    build_resume_command,
+    discover_codex_session,
+    persist_spawned_session,
+    prepare_session_capture,
+    save_current_agent_session,
+)
+from clawteam.spawn.session_locators import SessionContext, locator_for_client
+from clawteam.spawn.sessions import SessionStore
+
+
+def test_prepare_session_capture_generates_claude_session_id(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path / ".clawteam"))
+
+    capture = prepare_session_capture(
+        ["claude"],
+        team_name="demo",
+        agent_name="leader",
+        cwd=str(tmp_path),
+    )
+
+    assert capture.client == "claude"
+    assert capture.session_id
+    assert capture.command == ["claude", "--session-id", capture.session_id]
+
+    saved = persist_spawned_session(capture, command=capture.command)
+    session = SessionStore("demo").load("leader")
+
+    assert saved == capture.session_id
+    assert session is not None
+    assert session.session_id == capture.session_id
+    assert session.state["client"] == "claude"
+    assert session.state["confidence"] == "exact"
+
+
+def test_prepare_session_capture_keeps_existing_claude_session_id():
+    capture = prepare_session_capture(
+        ["claude", "--session-id", "11111111-1111-4111-8111-111111111111"],
+        team_name="demo",
+        agent_name="worker",
+    )
+
+    assert capture.session_id == "11111111-1111-4111-8111-111111111111"
+    assert capture.source == "provided"
+    assert capture.command == ["claude", "--session-id", "11111111-1111-4111-8111-111111111111"]
+
+
+def test_build_resume_command_supports_codex_and_claude():
+    assert build_resume_command(["claude"], "sess-1") == ["claude", "--resume", "sess-1"]
+    assert build_resume_command(["codex"], "sess-2") == ["codex", "resume", "sess-2"]
+    assert build_resume_command(["run"], "sess-3", client="codex") == ["codex", "resume", "sess-3"]
+
+
+def test_save_current_agent_session_uses_codex_thread_id(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path / ".clawteam"))
+    monkeypatch.setenv("CODEX_THREAD_ID", "019dd264-7ba2-7be2-8493-329b1c5ef1f3")
+
+    saved = save_current_agent_session("demo", "leader", cwd=str(tmp_path))
+    session = SessionStore("demo").load("leader")
+
+    assert saved == "019dd264-7ba2-7be2-8493-329b1c5ef1f3"
+    assert session is not None
+    assert session.session_id == saved
+    assert session.state["client"] == "codex"
+
+
+def test_discover_codex_session_matches_recent_agent_prompt(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cwd = tmp_path / "repo"
+    cwd.mkdir()
+    session_id = "019dd264-7ba2-7be2-8493-329b1c5ef1f3"
+    session_dir = tmp_path / ".codex" / "sessions" / "2026" / "04" / "28"
+    session_dir.mkdir(parents=True)
+    session_file = session_dir / f"rollout-2026-04-28T12-41-33-{session_id}.jsonl"
+    now = time.time()
+    session_file.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "session_meta",
+                        "payload": {
+                            "id": session_id,
+                            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                            "cwd": str(cwd),
+                        },
+                    }
+                ),
+                json.dumps({"type": "user_message", "text": "team demo agent worker1"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    Path(session_file).touch()
+
+    found = discover_codex_session(
+        team_name="demo",
+        agent_name="worker1",
+        cwd=str(cwd),
+        since=now - 30,
+        timeout_seconds=0,
+    )
+
+    assert found == session_id
+
+
+def test_spawned_codex_capture_ignores_parent_thread_id(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("CLAWTEAM_DATA_DIR", str(tmp_path / ".clawteam"))
+    monkeypatch.setenv("CODEX_THREAD_ID", "parent-session")
+    cwd = tmp_path / "repo"
+    cwd.mkdir()
+    child_session_id = "019dd264-7ba2-7be2-8493-329b1c5ef1f3"
+    session_dir = tmp_path / ".codex" / "sessions" / "2026" / "04" / "28"
+    session_dir.mkdir(parents=True)
+    session_file = session_dir / f"rollout-2026-04-28T12-41-33-{child_session_id}.jsonl"
+    now = time.time()
+    session_file.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "session_meta",
+                        "payload": {
+                            "id": child_session_id,
+                            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                            "cwd": str(cwd),
+                        },
+                    }
+                ),
+                json.dumps({"type": "user_message", "text": "demo worker1"}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    capture = prepare_session_capture(
+        ["codex"],
+        team_name="demo",
+        agent_name="worker1",
+        cwd=str(cwd),
+        prompt="work for demo worker1",
+    )
+    capture.async_capture = False
+    capture.started_at = now - 30
+    saved = persist_spawned_session(capture, team_name="demo", agent_name="worker1")
+    session = SessionStore("demo").load("worker1")
+
+    assert saved == child_session_id
+    assert session is not None
+    assert session.session_id == child_session_id
+
+
+def test_gemini_locator_reads_workspace_chat_session(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cwd = tmp_path / "repo"
+    cwd.mkdir()
+    project_dir = tmp_path / ".gemini" / "tmp" / "project-a"
+    chats_dir = project_dir / "chats"
+    chats_dir.mkdir(parents=True)
+    (project_dir / ".project_root").write_text(str(cwd), encoding="utf-8")
+    (chats_dir / "session.json").write_text(
+        json.dumps(
+            {
+                "sessionId": "gemini-session-1",
+                "lastUpdated": datetime.now(timezone.utc).isoformat(),
+                "messages": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    captured = locator_for_client("gemini").current_session(  # type: ignore[union-attr]
+        SessionContext(
+            team_name="demo",
+            agent_name="gem",
+            cwd=str(cwd),
+            allow_environment=False,
+        )
+    )
+
+    assert captured is not None
+    assert captured.session_id == "gemini-session-1"
+
+
+def test_opencode_locator_uses_session_list(monkeypatch, tmp_path):
+    cwd = tmp_path / "repo"
+    cwd.mkdir()
+
+    monkeypatch.setattr("clawteam.spawn.session_locators.opencode.shutil.which", lambda name: "/usr/bin/opencode")
+
+    class Result:
+        returncode = 0
+        stdout = json.dumps(
+            [
+                {"id": "other", "directory": str(tmp_path / "other"), "updated": 3},
+                {"id": "opencode-session-1", "directory": str(cwd), "updated": 5},
+            ]
+        )
+
+    monkeypatch.setattr(
+        "clawteam.spawn.session_locators.opencode.subprocess.run",
+        lambda *_, **__: Result(),
+    )
+
+    captured = locator_for_client("opencode").current_session(  # type: ignore[union-attr]
+        SessionContext(
+            team_name="demo",
+            agent_name="open",
+            cwd=str(cwd),
+            allow_environment=False,
+        )
+    )
+
+    assert captured is not None
+    assert captured.session_id == "opencode-session-1"


### PR DESCRIPTION
## Summary
- add client-specific session capture and resume support for spawned agents
- add leader watcher with optional Redis wakeups to nudge leaders on team state changes
- wire session persistence into subprocess, tmux, and wsh spawn backends

## Validation
- python -m pytest -q
- python -m ruff check .