### PR TITLE
Add user-level install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,16 +364,22 @@ Templates are TOML files — **create your own team archetypes** for any domain.
 ```bash
 pip install clawteam
 
+# Or install into an isolated user venv at ~/.clawteam/.venv
+scripts/install_clawteam.sh
+
 # Or from source
 git clone https://github.com/HKUDS/ClawTeam.git
 cd ClawTeam
 pip install -e .
 
+# Or install this checkout into ~/.clawteam/.venv
+scripts/clawteam_local_install
+
 # Optional: P2P transport (ZeroMQ)
 pip install -e ".[p2p]"
 ```
 
-Requires **Python 3.10+**, **tmux**, and a CLI coding agent (e.g. `claude`, `codex`). Python dependencies: `typer`, `pydantic`, `rich`.
+Requires **Python 3.10+**, **tmux**, and a CLI coding agent (e.g. `claude`, `codex`). The install scripts create/reuse `~/.clawteam/.venv` and link `~/.local/bin/clawteam`.
 
 All `spawn` examples assume the agent CLI you name is already installed and available on `PATH`.
 

--- a/scripts/clawteam_local_install
+++ b/scripts/clawteam_local_install
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# ClawTeam local source installer.
+#
+# Installs this checkout with `pip install -e .` into ~/.clawteam/.venv and
+# links ~/.local/bin/clawteam to that virtual environment.
+
+set -euo pipefail
+
+CLAWTEAM_HOME="${CLAWTEAM_HOME:-$HOME/.clawteam}"
+VENV_PATH="${CLAWTEAM_HOME}/.venv"
+BIN_DIR="${HOME}/.local/bin"
+PYTHON_BIN="${PYTHON_BIN:-}"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+log() { printf '%s\n' "$*"; }
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+python_version_ok() {
+  local bin="$1"
+  "$bin" - <<'PY' >/dev/null 2>&1
+import sys
+raise SystemExit(0 if sys.version_info >= (3, 10) else 1)
+PY
+}
+
+try_python_bin() {
+  local bin="$1"
+  [ -n "$bin" ] || return 1
+  command -v "$bin" >/dev/null 2>&1 || return 1
+  python_version_ok "$bin" || return 1
+  command -v "$bin"
+}
+
+detect_python_bin() {
+  if [ -n "$PYTHON_BIN" ]; then
+    try_python_bin "$PYTHON_BIN" && return 0
+    log "Requested PYTHON_BIN=$PYTHON_BIN is not Python 3.10+"
+  fi
+  for candidate in python3.12 python3.11 python3.10 python3; do
+    try_python_bin "$candidate" && return 0
+  done
+  return 1
+}
+
+[ -f "${REPO_ROOT}/pyproject.toml" ] || fail "Could not find pyproject.toml at ${REPO_ROOT}"
+
+if ! PYTHON_BIN="$(detect_python_bin)"; then
+  fail "Python 3.10+ is required to install ClawTeam"
+fi
+
+log "Using Python: $("$PYTHON_BIN" --version 2>&1)"
+mkdir -p "$CLAWTEAM_HOME" "$BIN_DIR"
+
+if [ ! -x "${VENV_PATH}/bin/python" ]; then
+  log "Creating virtual environment at ${VENV_PATH}"
+  "$PYTHON_BIN" -m venv "$VENV_PATH"
+fi
+
+if ! python_version_ok "${VENV_PATH}/bin/python"; then
+  fail "Existing virtual environment at ${VENV_PATH} is not Python 3.10+. Remove it and run again."
+fi
+
+log "Installing local ClawTeam checkout from ${REPO_ROOT}"
+"${VENV_PATH}/bin/pip" install --upgrade pip >/dev/null
+"${VENV_PATH}/bin/pip" install -e "${REPO_ROOT}"
+
+ln -sf "${VENV_PATH}/bin/clawteam" "${BIN_DIR}/clawteam"
+log "Linked clawteam -> ${BIN_DIR}/clawteam"
+
+case ":${PATH}:" in
+  *":${BIN_DIR}:"*) ;;
+  *) log "Add ${BIN_DIR} to PATH to use clawteam in every shell." ;;
+esac
+
+log "ClawTeam local install is ready."

--- a/scripts/install_clawteam.sh
+++ b/scripts/install_clawteam.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# ClawTeam user-level installer.
+#
+# Installs the PyPI package into ~/.clawteam/.venv and links ~/.local/bin/clawteam.
+
+set -euo pipefail
+
+CLAWTEAM_HOME="${CLAWTEAM_HOME:-$HOME/.clawteam}"
+VENV_PATH="${CLAWTEAM_HOME}/.venv"
+BIN_DIR="${HOME}/.local/bin"
+PYTHON_BIN="${PYTHON_BIN:-}"
+
+log() { printf '%s\n' "$*"; }
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+python_version_ok() {
+  local bin="$1"
+  "$bin" - <<'PY' >/dev/null 2>&1
+import sys
+raise SystemExit(0 if sys.version_info >= (3, 10) else 1)
+PY
+}
+
+try_python_bin() {
+  local bin="$1"
+  [ -n "$bin" ] || return 1
+  command -v "$bin" >/dev/null 2>&1 || return 1
+  python_version_ok "$bin" || return 1
+  command -v "$bin"
+}
+
+detect_python_bin() {
+  if [ -n "$PYTHON_BIN" ]; then
+    try_python_bin "$PYTHON_BIN" && return 0
+    log "Requested PYTHON_BIN=$PYTHON_BIN is not Python 3.10+"
+  fi
+  for candidate in python3.12 python3.11 python3.10 python3; do
+    try_python_bin "$candidate" && return 0
+  done
+  return 1
+}
+
+if ! PYTHON_BIN="$(detect_python_bin)"; then
+  fail "Python 3.10+ is required to install ClawTeam"
+fi
+
+log "Using Python: $("$PYTHON_BIN" --version 2>&1)"
+mkdir -p "$CLAWTEAM_HOME" "$BIN_DIR"
+
+if [ ! -x "${VENV_PATH}/bin/python" ]; then
+  log "Creating virtual environment at ${VENV_PATH}"
+  "$PYTHON_BIN" -m venv "$VENV_PATH"
+fi
+
+log "Installing latest clawteam from PyPI"
+"${VENV_PATH}/bin/pip" install --upgrade pip >/dev/null
+"${VENV_PATH}/bin/pip" install --upgrade clawteam
+
+ln -sf "${VENV_PATH}/bin/clawteam" "${BIN_DIR}/clawteam"
+log "Linked clawteam -> ${BIN_DIR}/clawteam"
+
+case ":${PATH}:" in
+  *":${BIN_DIR}:"*) ;;
+  *) log "Add ${BIN_DIR} to PATH to use clawteam in every shell." ;;
+esac
+
+log "ClawTeam is ready."


### PR DESCRIPTION
## Summary
- add a PyPI installer that creates ~/.clawteam/.venv and links ~/.local/bin/clawteam
- add a local source installer for editable installs from a checkout
- document the script-based install path in README

## Validation
- bash -n scripts/install_clawteam.sh scripts/clawteam_local_install
- python -m ruff check .
- python -m pytest -q