### PR TITLE
Install ClawTeam skills from setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,9 @@ scripts/clawteam_local_install
 pip install -e ".[p2p]"
 ```
 
-Requires **Python 3.10+**, **tmux**, and a CLI coding agent (e.g. `claude`, `codex`). The install scripts create/reuse `~/.clawteam/.venv` and link `~/.local/bin/clawteam`.
+Requires **Python 3.10+**, **tmux**, and a CLI coding agent (e.g. `claude`, `codex`). The install scripts create/reuse `~/.clawteam/.venv`, link `~/.local/bin/clawteam`, and install/update the bundled `clawteam` skill for detected clients.
+
+Skill install targets are detected from existing config directories, including Claude Code, Codex, Gemini CLI, OpenClaw, OpenCode, Nanobot, Cursor, OpenHarness (`~/.openharness/skills`), and Ohmo (`~/.ohmo/skills`).
 
 All `spawn` examples assume the agent CLI you name is already installed and available on `PATH`.
 

--- a/scripts/clawteam_local_install
+++ b/scripts/clawteam_local_install
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # ClawTeam local source installer.
 #
-# Installs this checkout with `pip install -e .` into ~/.clawteam/.venv and
-# links ~/.local/bin/clawteam to that virtual environment.
+# Installs this checkout with `pip install -e .` into ~/.clawteam/.venv,
+# links ~/.local/bin/clawteam, and installs the local ClawTeam skill into
+# detected agent clients.
 
 set -euo pipefail
 
@@ -10,9 +11,18 @@ CLAWTEAM_HOME="${CLAWTEAM_HOME:-$HOME/.clawteam}"
 VENV_PATH="${CLAWTEAM_HOME}/.venv"
 BIN_DIR="${HOME}/.local/bin"
 PYTHON_BIN="${PYTHON_BIN:-}"
+SKILLS_BASE="${CLAWTEAM_SKILLS_BASE:-https://raw.githubusercontent.com/HKUDS/ClawTeam/main/skills/clawteam}"
+SKILL_SLUG="clawteam"
+SKILL_FILES=(
+  "SKILL.md:SKILL.md"
+  "agents/openai.yaml:agents/openai.yaml"
+  "references/cli-reference.md:references/cli-reference.md"
+  "references/workflows.md:references/workflows.md"
+)
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+LOCAL_SKILL_DIR="${REPO_ROOT}/skills/${SKILL_SLUG}"
 
 log() { printf '%s\n' "$*"; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
@@ -44,7 +54,73 @@ detect_python_bin() {
   return 1
 }
 
+install_clawteam_skills() {
+  local skill_source_dir="${1:-}"
+  local clients=(
+    "Claude Code|${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills|${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+    "Codex CLI|${CODEX_HOME:-$HOME/.codex}/skills|${CODEX_HOME:-$HOME/.codex}"
+    "Gemini CLI|$HOME/.gemini/skills|$HOME/.gemini"
+    "OpenClaw|$HOME/.openclaw/skills|$HOME/.openclaw"
+    "OpenCode|$HOME/.config/opencode/skills|$HOME/.config/opencode"
+    "Nanobot|$HOME/.nanobot/skills|$HOME/.nanobot"
+    "Cursor|$HOME/.cursor/skills|$HOME/.cursor"
+    "OpenHarness|${OPENHARNESS_CONFIG_DIR:-$HOME/.openharness}/skills|${OPENHARNESS_CONFIG_DIR:-$HOME/.openharness}"
+    "Ohmo|${OHMO_WORKSPACE:-$HOME/.ohmo}/skills|${OHMO_WORKSPACE:-$HOME/.ohmo}"
+  )
+
+  local detected=()
+  local entry client_name skills_dir probe_path
+  for entry in "${clients[@]}"; do
+    IFS='|' read -r client_name skills_dir probe_path <<<"$entry"
+    if [ -d "$probe_path" ]; then
+      detected+=("${client_name}|${skills_dir}")
+    fi
+  done
+
+  if [ ${#detected[@]} -eq 0 ]; then
+    log "No supported agent client config directories detected; skipping ClawTeam skill install."
+    return 0
+  fi
+
+  log "Installing ClawTeam skill into detected clients:"
+  for entry in "${detected[@]}"; do
+    IFS='|' read -r client_name skills_dir <<<"$entry"
+    install_clawteam_skill_into "$client_name" "$skills_dir" "$skill_source_dir"
+  done
+}
+
+install_clawteam_skill_into() {
+  local client_name="$1"
+  local skill_root="$2"
+  local skill_source_dir="$3"
+  local target="${skill_root}/${SKILL_SLUG}"
+  local failed=0
+
+  mkdir -p "$target"
+
+  local pair dest_rel remote_rel dest_path
+  for pair in "${SKILL_FILES[@]}"; do
+    IFS=':' read -r dest_rel remote_rel <<<"$pair"
+    dest_path="${target}/${dest_rel}"
+    mkdir -p "$(dirname "$dest_path")"
+
+    if [ -n "$skill_source_dir" ] && [ -f "${skill_source_dir}/${remote_rel}" ]; then
+      cp "${skill_source_dir}/${remote_rel}" "$dest_path" || failed=1
+    elif ! curl -fsSL "${SKILLS_BASE}/${remote_rel}" -o "$dest_path"; then
+      log "Failed to fetch ${SKILLS_BASE}/${remote_rel}; skipping ${client_name} skill file ${dest_rel}."
+      failed=1
+    fi
+  done
+
+  if [ "$failed" -eq 0 ]; then
+    log "  Installed ${client_name}: ${target}"
+  else
+    log "  Partially installed ${client_name}: ${target}"
+  fi
+}
+
 [ -f "${REPO_ROOT}/pyproject.toml" ] || fail "Could not find pyproject.toml at ${REPO_ROOT}"
+[ -d "$LOCAL_SKILL_DIR" ] || fail "Could not find ClawTeam skill at ${LOCAL_SKILL_DIR}"
 
 if ! PYTHON_BIN="$(detect_python_bin)"; then
   fail "Python 3.10+ is required to install ClawTeam"
@@ -68,6 +144,8 @@ log "Installing local ClawTeam checkout from ${REPO_ROOT}"
 
 ln -sf "${VENV_PATH}/bin/clawteam" "${BIN_DIR}/clawteam"
 log "Linked clawteam -> ${BIN_DIR}/clawteam"
+
+install_clawteam_skills "$LOCAL_SKILL_DIR"
 
 case ":${PATH}:" in
   *":${BIN_DIR}:"*) ;;

--- a/scripts/install_clawteam.sh
+++ b/scripts/install_clawteam.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # ClawTeam user-level installer.
 #
-# Installs the PyPI package into ~/.clawteam/.venv and links ~/.local/bin/clawteam.
+# Installs the PyPI package into ~/.clawteam/.venv, links ~/.local/bin/clawteam,
+# and installs the ClawTeam skill into detected agent clients.
 
 set -euo pipefail
 
@@ -9,6 +10,14 @@ CLAWTEAM_HOME="${CLAWTEAM_HOME:-$HOME/.clawteam}"
 VENV_PATH="${CLAWTEAM_HOME}/.venv"
 BIN_DIR="${HOME}/.local/bin"
 PYTHON_BIN="${PYTHON_BIN:-}"
+SKILLS_BASE="${CLAWTEAM_SKILLS_BASE:-https://raw.githubusercontent.com/HKUDS/ClawTeam/main/skills/clawteam}"
+SKILL_SLUG="clawteam"
+SKILL_FILES=(
+  "SKILL.md:SKILL.md"
+  "agents/openai.yaml:agents/openai.yaml"
+  "references/cli-reference.md:references/cli-reference.md"
+  "references/workflows.md:references/workflows.md"
+)
 
 log() { printf '%s\n' "$*"; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
@@ -40,6 +49,71 @@ detect_python_bin() {
   return 1
 }
 
+install_clawteam_skills() {
+  local skill_source_dir="${1:-}"
+  local clients=(
+    "Claude Code|${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills|${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+    "Codex CLI|${CODEX_HOME:-$HOME/.codex}/skills|${CODEX_HOME:-$HOME/.codex}"
+    "Gemini CLI|$HOME/.gemini/skills|$HOME/.gemini"
+    "OpenClaw|$HOME/.openclaw/skills|$HOME/.openclaw"
+    "OpenCode|$HOME/.config/opencode/skills|$HOME/.config/opencode"
+    "Nanobot|$HOME/.nanobot/skills|$HOME/.nanobot"
+    "Cursor|$HOME/.cursor/skills|$HOME/.cursor"
+    "OpenHarness|${OPENHARNESS_CONFIG_DIR:-$HOME/.openharness}/skills|${OPENHARNESS_CONFIG_DIR:-$HOME/.openharness}"
+    "Ohmo|${OHMO_WORKSPACE:-$HOME/.ohmo}/skills|${OHMO_WORKSPACE:-$HOME/.ohmo}"
+  )
+
+  local detected=()
+  local entry client_name skills_dir probe_path
+  for entry in "${clients[@]}"; do
+    IFS='|' read -r client_name skills_dir probe_path <<<"$entry"
+    if [ -d "$probe_path" ]; then
+      detected+=("${client_name}|${skills_dir}")
+    fi
+  done
+
+  if [ ${#detected[@]} -eq 0 ]; then
+    log "No supported agent client config directories detected; skipping ClawTeam skill install."
+    return 0
+  fi
+
+  log "Installing ClawTeam skill into detected clients:"
+  for entry in "${detected[@]}"; do
+    IFS='|' read -r client_name skills_dir <<<"$entry"
+    install_clawteam_skill_into "$client_name" "$skills_dir" "$skill_source_dir"
+  done
+}
+
+install_clawteam_skill_into() {
+  local client_name="$1"
+  local skill_root="$2"
+  local skill_source_dir="$3"
+  local target="${skill_root}/${SKILL_SLUG}"
+  local failed=0
+
+  mkdir -p "$target"
+
+  local pair dest_rel remote_rel dest_path
+  for pair in "${SKILL_FILES[@]}"; do
+    IFS=':' read -r dest_rel remote_rel <<<"$pair"
+    dest_path="${target}/${dest_rel}"
+    mkdir -p "$(dirname "$dest_path")"
+
+    if [ -n "$skill_source_dir" ] && [ -f "${skill_source_dir}/${remote_rel}" ]; then
+      cp "${skill_source_dir}/${remote_rel}" "$dest_path" || failed=1
+    elif ! curl -fsSL "${SKILLS_BASE}/${remote_rel}" -o "$dest_path"; then
+      log "Failed to fetch ${SKILLS_BASE}/${remote_rel}; skipping ${client_name} skill file ${dest_rel}."
+      failed=1
+    fi
+  done
+
+  if [ "$failed" -eq 0 ]; then
+    log "  Installed ${client_name}: ${target}"
+  else
+    log "  Partially installed ${client_name}: ${target}"
+  fi
+}
+
 if ! PYTHON_BIN="$(detect_python_bin)"; then
   fail "Python 3.10+ is required to install ClawTeam"
 fi
@@ -58,6 +132,8 @@ log "Installing latest clawteam from PyPI"
 
 ln -sf "${VENV_PATH}/bin/clawteam" "${BIN_DIR}/clawteam"
 log "Linked clawteam -> ${BIN_DIR}/clawteam"
+
+install_clawteam_skills ""
 
 case ":${PATH}:" in
   *":${BIN_DIR}:"*) ;;


### PR DESCRIPTION
## Summary
- install/update the bundled clawteam skill from both setup scripts
- detect Claude Code, Codex, Gemini, OpenClaw, OpenCode, Nanobot, Cursor, OpenHarness, and Ohmo skill directories
- document skill installation behavior in README

## Validation
- bash -n scripts/install_clawteam.sh scripts/clawteam_local_install
- HOME=<tmp> OPENHARNESS_CONFIG_DIR=<tmp> OHMO_WORKSPACE=<tmp> scripts/clawteam_local_install
- python -m ruff check .
- python -m pytest -q