### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ clawteam preset show moonshot-cn
 # Generate a reusable runtime profile from a preset
 clawteam preset generate-profile moonshot-cn claude --name claude-kimi
 
-# MiniMax (M2.7) — global or China endpoint
+# MiniMax (M3) — global or China endpoint
 clawteam preset generate-profile minimax-global claude --name claude-minimax
 clawteam preset generate-profile minimax-cn claude --name claude-minimax-cn
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -407,7 +407,7 @@ clawteam preset show moonshot-cn
 # 从 preset 生成可复用的 runtime profile
 clawteam preset generate-profile moonshot-cn claude --name claude-kimi
 
-# MiniMax（M2.7）— 国际或国内端点
+# MiniMax（M3）— 国际或国内端点
 clawteam preset generate-profile minimax-global claude --name claude-minimax
 clawteam preset generate-profile minimax-cn claude --name claude-minimax-cn
 

--- a/clawteam/spawn/presets.py
+++ b/clawteam/spawn/presets.py
@@ -137,7 +137,7 @@ def builtin_presets() -> dict[str, AgentPreset]:
             "MiniMax China Anthropic-compatible Claude Code endpoint.",
             "MINIMAX_API_KEY",
             "https://api.minimaxi.com/anthropic",
-            "MiniMax-M2.7",
+            "MiniMax-M3",
             extra_env={
                 "API_TIMEOUT_MS": "3000000",
                 "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
@@ -147,7 +147,7 @@ def builtin_presets() -> dict[str, AgentPreset]:
             "MiniMax global Anthropic-compatible Claude Code endpoint.",
             "MINIMAX_API_KEY",
             "https://api.minimax.io/anthropic",
-            "MiniMax-M2.7",
+            "MiniMax-M3",
             extra_env={
                 "API_TIMEOUT_MS": "3000000",
                 "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -36,11 +36,11 @@ def test_generate_profile_from_minimax_global_preset():
 
     assert name == "claude-minimax-global"
     assert profile.agent == "claude"
-    assert profile.model == "MiniMax-M2.7"
+    assert profile.model == "MiniMax-M3"
     assert profile.base_url == "https://api.minimax.io/anthropic"
     assert profile.api_key_env == "MINIMAX_API_KEY"
-    assert profile.env["ANTHROPIC_MODEL"] == "MiniMax-M2.7"
-    assert profile.env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "MiniMax-M2.7"
+    assert profile.env["ANTHROPIC_MODEL"] == "MiniMax-M3"
+    assert profile.env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "MiniMax-M3"
     assert profile.env["API_TIMEOUT_MS"] == "3000000"
     assert profile.env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
 
@@ -50,11 +50,11 @@ def test_generate_profile_from_minimax_cn_preset():
 
     assert name == "claude-minimax-cn"
     assert profile.agent == "claude"
-    assert profile.model == "MiniMax-M2.7"
+    assert profile.model == "MiniMax-M3"
     assert profile.base_url == "https://api.minimaxi.com/anthropic"
     assert profile.api_key_env == "MINIMAX_API_KEY"
-    assert profile.env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "MiniMax-M2.7"
-    assert profile.env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "MiniMax-M2.7"
+    assert profile.env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "MiniMax-M3"
+    assert profile.env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "MiniMax-M3"
 
 
 def test_minimax_presets_in_builtin_list():


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration in the built-in presets to use the latest M3 model as the default.

## Changes
- Bump `minimax-cn` and `minimax-global` preset defaults from `MiniMax-M2.7` to `MiniMax-M3`
- Update the corresponding `tests/test_presets.py` assertions to expect `MiniMax-M3`
- Refresh the MiniMax quick-start example block in `README.md` and `README_CN.md`

## Why
MiniMax-M3 is the new flagship model with 512K context window, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces. Existing users who pick the `minimax-cn` / `minimax-global` preset will now get the latest model out of the box; users who want to pin to M2.7 can still override the model on the generated profile.

## Testing
- `python -m pytest tests/ -v` — 586 passed
- `ruff check clawteam/ tests/` — clean