### PR TITLE
fix(snapshot): prevent path traversal in snapshot restore

### DIFF
--- a/clawteam/team/snapshot.py
+++ b/clawteam/team/snapshot.py
@@ -106,6 +106,26 @@ def _safe_snapshot_tag(tag: str) -> str:
     return safe or "snapshot"
 
 
+def _safe_filename_part(value: Any, kind: str) -> str:
+    return validate_identifier(str(value or "unknown"), kind)
+
+
+def _validate_restore_bundle(bundle: dict[str, Any]) -> None:
+    for task in bundle.get("tasks", []):
+        _safe_filename_part(task.get("id"), "task id")
+    for sess in bundle.get("sessions", []):
+        _safe_filename_part(
+            sess.get("agentName", sess.get("agent_name")),
+            "session agent name",
+        )
+    for cost in bundle.get("costs", []):
+        _safe_filename_part(cost.get("id"), "cost id")
+        _safe_filename_part(
+            str(cost.get("reportedAt") or "x").replace(":", "-").replace("+", "p"),
+            "cost timestamp",
+        )
+
+
 class SnapshotManager:
     """Create and restore full team state snapshots.
 
@@ -196,6 +216,7 @@ class SnapshotManager:
 
     def load_bundle(self, snapshot_id: str) -> dict[str, Any]:
         """Load a snapshot bundle from disk."""
+        validate_identifier(snapshot_id, "snapshot id")
         path = _snapshots_root(self.team_name) / f"snap-{snapshot_id}.json"
         if not path.exists():
             raise ValueError(f"Snapshot '{snapshot_id}' not found")
@@ -207,6 +228,7 @@ class SnapshotManager:
         Returns a summary dict. With dry_run=True nothing is written.
         """
         bundle = self.load_bundle(snapshot_id)
+        _validate_restore_bundle(bundle)
 
         summary: dict[str, Any] = {
             "snapshot_id": snapshot_id,
@@ -245,7 +267,7 @@ class SnapshotManager:
         tasks_dir = ensure_within_root(data_dir / "tasks", self.team_name)
         tasks_dir.mkdir(parents=True, exist_ok=True)
         for task in bundle.get("tasks", []):
-            tid = task.get("id", "unknown")
+            tid = _safe_filename_part(task.get("id"), "task id")
             _atomic_write(tasks_dir / f"task-{tid}.json", task)
 
         # events -- restored with sequential names to avoid collisions
@@ -258,15 +280,21 @@ class SnapshotManager:
         sessions_dir = ensure_within_root(data_dir / "sessions", self.team_name)
         sessions_dir.mkdir(parents=True, exist_ok=True)
         for sess in bundle.get("sessions", []):
-            name = sess.get("agentName", sess.get("agent_name", "unknown"))
+            name = _safe_filename_part(
+                sess.get("agentName", sess.get("agent_name")),
+                "session agent name",
+            )
             _atomic_write(sessions_dir / f"{name}.json", sess)
 
         # costs
         costs_dir = ensure_within_root(data_dir / "costs", self.team_name)
         costs_dir.mkdir(parents=True, exist_ok=True)
         for cost in bundle.get("costs", []):
-            cid = cost.get("id", "unknown")
-            ts = cost.get("reportedAt", "x").replace(":", "-").replace("+", "p")
+            cid = _safe_filename_part(cost.get("id"), "cost id")
+            ts = _safe_filename_part(
+                str(cost.get("reportedAt") or "x").replace(":", "-").replace("+", "p"),
+                "cost timestamp",
+            )
             _atomic_write(costs_dir / f"cost-{ts}-{cid}.json", cost)
 
         # inbox messages
@@ -285,6 +313,7 @@ class SnapshotManager:
         return summary
 
     def delete(self, snapshot_id: str) -> bool:
+        validate_identifier(snapshot_id, "snapshot id")
         path = _snapshots_root(self.team_name) / f"snap-{snapshot_id}.json"
         if path.exists():
             path.unlink()


### PR DESCRIPTION
Prevent path traversal in snapshot restore by validating bundle-controlled filename fields before they are used to build restored file paths or replace existing restore state.

## What Problem This Solves

This fixes a local path traversal / restore-integrity vulnerability in snapshot restore.

`SnapshotManager.restore()` treats a snapshot JSON bundle as restore input and rebuilds several file-backed state domains from fields inside that bundle:

- task `id` -> `task-{id}.json`
- session `agentName` / `agent_name` -> `{agent}.json`
- cost `reportedAt` and `id` -> `cost-{reportedAt}-{id}.json`

The restore entry point is `clawteam team restore TEAM SNAPSHOT_ID`. At that point, the snapshot bundle should be treated as untrusted input: snapshot JSON can be copied between machines, edited manually, restored from backups, or otherwise replaced before the restore command is run.

Before this patch, restore used bundle-controlled fields directly as filename components. A malicious snapshot can include a path-like session agent name such as `../escape`; that value is not a valid local agent identifier, but it was still used to derive the restored session filename. This is the same class of issue as externally controlled filenames or paths in filesystem operations: path components controlled by input data need to be validated before they are joined into output paths and written.

## Change

- Validate `snapshot_id` before loading or deleting `snap-{snapshot_id}.json`.
- Pre-validate task IDs, session agent names, cost IDs, and timestamp-derived cost filename parts immediately after loading the bundle.
- Keep per-write validation at each restore site as a local guard.

## Evidence

Attack-oriented call chain:

1. A team snapshot is created with `clawteam team snapshot TEAM --tag checkpoint`.
2. The saved `snap-SNAPSHOT_ID.json` file is edited, copied from another machine, restored from backup, or otherwise replaced before restore.
3. The attacker-controlled snapshot bundle contains a path-like session agent name:

```json
{
  "sessions": [
    {
      "agentName": "../escape",
      "sessionId": "attacker-controlled"
    }
  ]
}
```

4. The user runs `clawteam team restore TEAM SNAPSHOT_ID`.
5. `SnapshotManager.restore()` loads the bundle, replaces the current restore domains, and writes restored tasks, sessions, and costs.

I reproduced this against the unpatched upstream `main` commit `0119833`. Restoring the tampered bundle completed and wrote the session record outside the intended team-scoped session directory:

```text
PAYLOAD_SESSION_AGENT= ../escape
RESTORE_RESULT=completed
ESCAPE_PATH= ...\sessions\escape.json
ESCAPE_EXISTS= True
INSIDE_EXPECTED_PATH_EXISTS= False
ESCAPE_CONTENT= {
  "agentName": "../escape",
  "sessionId": "attacker-controlled"
}
```

After this patch, the same tampered bundle is rejected before any restore replacement work begins:

```text
RESTORE_RESULT=raised ValueError Invalid session agent name: only letters, digits, '.', '_' and '-' are allowed
ESCAPE_EXISTS= False
TASKS_AFTER= ['keep me']
```

There is also a restore-integrity concern: snapshot restore clears the current task/session/cost domains before writing restored records. If unsafe filename components are rejected only after replacement begins, malformed restore input can still affect existing team state before failing. This patch validates the complete restore bundle immediately after loading it, before any deletion or write step begins.

## Possible call chain / impact

This is not a remote code execution issue and does not affect normal snapshot creation. The vulnerable condition is restore of a snapshot bundle whose JSON content can be influenced before restore.

The practical impact is local filesystem boundary bypass within the current user's permissions. A crafted snapshot can derive restored filenames outside the domain that restore is supposed to manage. It can also cause loss of existing team state if malformed restore input is rejected only after replacement has already started.

## Testing

- `python -m ruff check clawteam tests`

Also attempted full `python -m pytest -q` on Windows. It reaches unrelated existing Windows/platform failures outside this change, including `os.getuid()` in adapter tests, `touch` in the shell hook test, timezone output expecting `CST`, and a Windows concurrent `os.replace` permission error in `test_fileutil.py`. No new tests are included in this PR.