### PR TITLE
fix(spawn): handle Windows volume mount paths with colons and slashes

### DIFF
--- a/clawteam/spawn/command_validation.py
+++ b/clawteam/spawn/command_validation.py
@@ -132,7 +132,8 @@ def ensure_docker_workspace(command: list[str], cwd: str) -> list[str]:
 
     image_index, image, remainder = spec
     prefix = list(command[:image_index])
-    volume_spec = f"{cwd}:{cwd}"
+    cwd_norm = cwd.replace("\\", "/")
+    volume_spec = f"{cwd_norm}:{cwd_norm}"
 
     if not _docker_has_workdir(prefix, cwd):
         prefix.extend(["-w", cwd])
@@ -151,7 +152,9 @@ def ensure_docker_mount(command: list[str], host_path: str, container_path: str 
     image_index, image, remainder = spec
     prefix = list(command[:image_index])
     target_path = container_path or host_path
-    volume_spec = f"{host_path}:{target_path}"
+    host_path_norm = host_path.replace("\\", "/")
+    target_path_norm = target_path.replace("\\", "/")
+    volume_spec = f"{host_path_norm}:{target_path_norm}"
 
     if not _docker_has_mount(prefix, host_path, target_path):
         prefix.extend(["-v", volume_spec])
@@ -219,11 +222,46 @@ def _docker_has_mount(prefix: list[str], host_path: str, container_path: str) ->
     return False
 
 
+def _normalize_path(p: str) -> str:
+    """Normalize path slashes, drive letter casing, and translate Windows drive paths to /c/... format."""
+    p_norm = p.replace("\\", "/").rstrip("/")
+    if len(p_norm) >= 2 and p_norm[1] == ":" and p_norm[0].isalpha():
+        drive = p_norm[0].lower()
+        p_norm = f"/{drive}{p_norm[2:]}"
+    elif len(p_norm) >= 3 and p_norm[0] == "/" and p_norm[1].isalpha() and p_norm[2] == "/":
+        drive = p_norm[1].lower()
+        p_norm = f"/{drive}{p_norm[2:]}"
+    return p_norm.lower()
+
+
+def _split_volume_spec(spec: str) -> tuple[str, str]:
+    """Parse host_path and container_path from volume spec, handling Windows drive letter colons."""
+    seps = []
+    colons = [i for i, char in enumerate(spec) if char == ':']
+    for c in colons:
+        is_drive = False
+        if c > 0 and spec[c-1].isalpha():
+            if c == 1:
+                is_drive = True
+            elif c > 1 and spec[c-2] in (':', '/', '\\', ' '):
+                is_drive = True
+        if not is_drive:
+            seps.append(c)
+
+    if seps:
+        host = spec[:seps[0]]
+        container = spec[seps[0]+1:]
+        if len(seps) > 1:
+            container = spec[seps[0]+1:seps[1]]
+        return host, container
+    return spec, ""
+
+
 def _volume_targets(spec: str, host_path: str, container_path: str) -> bool:
-    parts = spec.split(":")
-    if len(parts) < 2:
+    parsed_host, parsed_container = _split_volume_spec(spec)
+    if not parsed_host or not parsed_container:
         return False
-    return parts[0] == host_path and parts[1] == container_path
+    return _normalize_path(parsed_host) == _normalize_path(host_path) and _normalize_path(parsed_container) == _normalize_path(container_path)
 
 
 def _mount_targets(spec: str, host_path: str, container_path: str) -> bool:

--- a/tests/test_docker_volumes_windows.py
+++ b/tests/test_docker_volumes_windows.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from clawteam.spawn.command_validation import (
+    _split_volume_spec,
+    _normalize_path,
+    _volume_targets,
+    ensure_docker_workspace,
+    ensure_docker_mount,
+)
+
+def test_split_volume_spec():
+    # Unix style
+    assert _split_volume_spec("/tmp/demo:/tmp/demo") == ("/tmp/demo", "/tmp/demo")
+    assert _split_volume_spec("/tmp/demo:/tmp/demo:ro") == ("/tmp/demo", "/tmp/demo")
+    
+    # Windows style
+    assert _split_volume_spec("C:\\Users\\alice\\proj:C:\\Users\\alice\\proj") == ("C:\\Users\\alice\\proj", "C:\\Users\\alice\\proj")
+    assert _split_volume_spec("C:\\Users\\alice\\proj:/workspace:ro") == ("C:\\Users\\alice\\proj", "/workspace")
+    assert _split_volume_spec("c:/users/alice/proj:/workspace") == ("c:/users/alice/proj", "/workspace")
+
+
+def test_normalize_path():
+    assert _normalize_path("C:\\Users\\Alice\\Proj") == "/c/users/alice/proj"
+    assert _normalize_path("c:/users/alice/proj/") == "/c/users/alice/proj"
+    assert _normalize_path("/c/users/alice/proj") == "/c/users/alice/proj"
+    assert _normalize_path("/tmp/demo") == "/tmp/demo"
+
+
+def test_volume_targets():
+    # Windows host and container paths
+    spec1 = "C:\\Users\\alice\\proj:C:\\Users\\alice\\proj"
+    assert _volume_targets(spec1, "C:\\Users\\alice\\proj", "C:\\Users\\alice\\proj") is True
+    assert _volume_targets(spec1, "C:/Users/alice/proj", "C:/Users/alice/proj") is True
+    assert _volume_targets(spec1, "/c/users/alice/proj", "/c/users/alice/proj") is True
+    
+    # Mixed Windows host, Unix container paths
+    spec2 = "C:\\Users\\alice\\proj:/workspace:ro"
+    assert _volume_targets(spec2, "C:\\Users\\alice\\proj", "/workspace") is True
+    assert _volume_targets(spec2, "C:/Users/alice/proj", "/workspace") is True
+
+
+def test_ensure_docker_workspace_idempotence():
+    # Calling it twice with the same path should not duplicate the volume mounting
+    cwd = "C:\\Users\\alice\\proj"
+    cmd = ["docker", "run", "--rm", "hkuds/nanobot"]
+    
+    cmd_with_mounts = ensure_docker_workspace(cmd, cwd)
+    # Check that volume mount is present with forward slashes
+    assert "-v" in cmd_with_mounts
+    assert "C:/Users/alice/proj:C:/Users/alice/proj" in cmd_with_mounts
+    
+    # Run ensure_docker_workspace again
+    cmd_double_mount = ensure_docker_workspace(cmd_with_mounts, cwd)
+    
+    # Ensure there's only one "-v C:/Users/alice/proj:C:/Users/alice/proj"
+    v_indices = [i for i, x in enumerate(cmd_double_mount) if x == "-v"]
+    assert len(v_indices) == 1


### PR DESCRIPTION
Fixes #163. Translates and normalizes Windows paths in volume mounting specifications (including colons after drive letters), avoiding command duplication and Docker Workspace mount validation errors.