### PR TITLE
fix(launch): surface per-agent spawn failures

### DIFF
--- a/clawteam/cli/commands.py
+++ b/clawteam/cli/commands.py
@@ -4124,7 +4124,7 @@ def launch_team(
 
     # 8. Spawn all agents (leader first, then workers)
     all_agents = [tmpl.leader] + list(tmpl.agents)
-    spawned: list[dict[str, str]] = []
+    spawned: list[dict[str, object]] = []
     resolved_profile = None
     if profile:
         try:
@@ -4186,33 +4186,70 @@ def launch_team(
             is_leader=(agent.name == tmpl.leader.name),
             keepalive=True,
         )
-        spawned.append({"name": agent.name, "id": a_id, "type": agent.type, "result": result})
+        spawned.append(
+            {
+                "name": agent.name,
+                "id": a_id,
+                "type": agent.type,
+                "result": result,
+                "success": not result.startswith("Error"),
+            }
+        )
 
     # 9. Output summary
+    successful_count = sum(bool(s["success"]) for s in spawned)
+    if successful_count == len(spawned):
+        launch_status = "launched"
+    elif successful_count:
+        launch_status = "partial"
+    else:
+        launch_status = "failed"
+
     out = {
-        "status": "launched",
+        "status": launch_status,
         "team": t_name,
         "template": tmpl.name,
         "backend": be_name,
-        "agents": [{"name": s["name"], "id": s["id"], "type": s["type"]} for s in spawned],
+        "agents": spawned,
     }
 
     def _human(_data):
-        console.print(f"\n[green bold]Team '{t_name}' launched from template '{tmpl.name}'[/green bold]\n")
+        if launch_status == "launched":
+            console.print(
+                f"\n[green bold]Team '{t_name}' launched from template "
+                f"'{tmpl.name}'[/green bold]\n"
+            )
+        elif launch_status == "partial":
+            console.print(
+                f"\n[yellow bold]Team '{t_name}' launched with failures from template "
+                f"'{tmpl.name}'[/yellow bold]\n"
+            )
+        else:
+            console.print(
+                f"\n[red bold]Team '{t_name}' failed to launch from template "
+                f"'{tmpl.name}'[/red bold]\n"
+            )
         table = Table(title="Agents")
         table.add_column("Name", style="cyan")
         table.add_column("Type")
         table.add_column("ID", style="dim")
+        table.add_column("Status")
         for s in spawned:
-            table.add_row(s["name"], s["type"], s["id"])
+            status = "[green]launched[/green]" if s["success"] else "[red]failed[/red]"
+            table.add_row(str(s["name"]), str(s["type"]), str(s["id"]), status)
         console.print(table)
+        for s in spawned:
+            if not s["success"]:
+                console.print(f"[red]FAILED {s['name']}:[/red] {s['result']}")
         console.print()
-        if be_name == "tmux":
+        if be_name == "tmux" and successful_count:
             console.print(f"[bold]Attach:[/bold] tmux attach -t clawteam-{t_name}")
         console.print(f"[bold]Board:[/bold]  clawteam board show {t_name}")
         console.print(f"[bold]Inbox:[/bold]  clawteam inbox peek {t_name} --agent <name>")
 
     _output(out, _human)
+    if launch_status == "failed":
+        raise typer.Exit(1)
 
 
 # ── Hook management ────────────────────────────────────────────────────

--- a/tests/test_launch_cli.py
+++ b/tests/test_launch_cli.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from clawteam.cli.commands import app
+from clawteam.templates import AgentDef, TemplateDef
+
+
+class _FailingBackend:
+    def spawn(self, **_kwargs) -> str:
+        return "Error: executable 'codex' not found or not executable"
+
+
+class _MixedBackend:
+    def __init__(self) -> None:
+        self._results = iter(["Spawned leader in tmux session", "Error: worker command not found"])
+
+    def spawn(self, **_kwargs) -> str:
+        return next(self._results)
+
+
+def _template() -> TemplateDef:
+    return TemplateDef(
+        name="codex-demo",
+        command=["codex"],
+        backend="tmux",
+        leader=AgentDef(name="leader", type="leader", task="do {goal}"),
+    )
+
+
+def _two_agent_template() -> TemplateDef:
+    return TemplateDef(
+        name="codex-demo",
+        command=["codex"],
+        backend="tmux",
+        leader=AgentDef(name="leader", type="leader", task="do {goal}"),
+        agents=[AgentDef(name="worker", type="worker", task="help {goal}")],
+    )
+
+
+def _patch_launch_dependencies(monkeypatch) -> None:
+    monkeypatch.setattr("clawteam.templates.load_template", lambda _name: _template())
+    monkeypatch.setattr("clawteam.spawn.get_backend", lambda _name: _FailingBackend())
+
+
+def test_launch_json_reports_total_spawn_failure(monkeypatch, tmp_path) -> None:
+    _patch_launch_dependencies(monkeypatch)
+    result = CliRunner().invoke(
+        app,
+        ["--json", "launch", "codex-demo", "--team-name", "json-failure"],
+        env={"HOME": str(tmp_path), "CLAWTEAM_DATA_DIR": str(tmp_path / ".clawteam")},
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "failed"
+    assert payload["agents"][0]["success"] is False
+    assert "not found" in payload["agents"][0]["result"]
+
+
+def test_launch_human_output_omits_tmux_attach_when_all_spawns_fail(monkeypatch, tmp_path) -> None:
+    _patch_launch_dependencies(monkeypatch)
+    result = CliRunner().invoke(
+        app,
+        ["launch", "codex-demo", "--team-name", "human-failure"],
+        env={"HOME": str(tmp_path), "CLAWTEAM_DATA_DIR": str(tmp_path / ".clawteam")},
+    )
+
+    assert result.exit_code == 1
+    assert "failed to launch" in result.stdout
+    assert "not found" in result.stdout
+    assert "tmux attach" not in result.stdout
+
+
+def test_launch_json_reports_partial_spawn_failure(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("clawteam.templates.load_template", lambda _name: _two_agent_template())
+    monkeypatch.setattr("clawteam.spawn.get_backend", lambda _name: _MixedBackend())
+
+    result = CliRunner().invoke(
+        app,
+        ["--json", "launch", "codex-demo", "--team-name", "partial-failure"],
+        env={"HOME": str(tmp_path), "CLAWTEAM_DATA_DIR": str(tmp_path / ".clawteam")},
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "partial"
+    assert [agent["success"] for agent in payload["agents"]] == [True, False]


### PR DESCRIPTION
## Summary

- preserve each backend spawn result in JSON output
- report `launched`, `partial`, or `failed` at team level
- show per-agent status and raw failure details in human output
- suppress invalid tmux attach instructions and return non-zero when every spawn fails

## Root cause

`launch_team()` captured backend results but discarded them when building both output formats, so failed agents looked identical to successful ones.

## Validation

- `python3 -m pytest tests/test_cli_commands.py tests/test_launch_cli.py -q` — 25 passed
- `ruff check clawteam/cli/commands.py tests/test_launch_cli.py`
- `git diff --check`

Fixes #166

